### PR TITLE
Fixed NullRefs in MessageProcessor

### DIFF
--- a/src/StructuredLogger/Construction/MessageProcessor.cs
+++ b/src/StructuredLogger/Construction/MessageProcessor.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 Timestamp = args.Timestamp
             };
 
-            if (args.BuildEventContext.TaskId > 0)
+            if (args.BuildEventContext?.TaskId > 0)
             {
                 node = construction.GetOrAddProject(args.BuildEventContext.ProjectContextId)
                     .GetTargetById(args.BuildEventContext.TargetId)
@@ -189,7 +189,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
                     }
                 }
             }
-            else if (args.BuildEventContext.TargetId > 0)
+            else if (args.BuildEventContext?.TargetId > 0)
             {
                 node = construction.GetOrAddProject(args.BuildEventContext.ProjectContextId)
                     .GetTargetById(args.BuildEventContext.TargetId);
@@ -199,7 +199,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
                     messageNode.IsLowRelevance = true;
                 }
             }
-            else if (args.BuildEventContext.ProjectContextId > 0)
+            else if (args.BuildEventContext?.ProjectContextId > 0)
             {
                 var project = construction.GetOrAddProject(args.BuildEventContext.ProjectContextId);
                 node = project;
@@ -219,25 +219,21 @@ namespace Microsoft.Build.Logging.StructuredLogger
             {
                 node = construction.Build;
 
-                if (message.StartsWith("Overriding target"))
-                {
+                if(message.StartsWith("Overriding target")) {
                     var folder = construction.Build.GetOrCreateNodeWithName<Folder>("TargetOverrides");
                     folder.IsLowRelevance = true;
                     node = folder;
                     messageNode.IsLowRelevance = true;
-                }
-                else if (message.StartsWith("The target") && message.Contains("does not exist in the project, and will be ignored"))
-                {
+                } else if(message.StartsWith("The target") && message.Contains("does not exist in the project, and will be ignored")) {
                     var folder = construction.Build.GetOrCreateNodeWithName<Folder>("MissingTargets");
                     folder.IsLowRelevance = true;
                     node = folder;
                     messageNode.IsLowRelevance = true;
-                }
-                else if (args.BuildEventContext.NodeId == 0 &&
+                } else if(args.BuildEventContext != null && (args.BuildEventContext.NodeId == 0 &&
                          args.BuildEventContext.ProjectContextId == 0 &&
                          args.BuildEventContext.ProjectInstanceId == 0 &&
                          args.BuildEventContext.TargetId == 0 &&
-                         args.BuildEventContext.TaskId == 0)
+                         args.BuildEventContext.TaskId == 0))
                 {
                     // must be Detailed Build Summary
                     // https://github.com/Microsoft/msbuild/blob/master/src/XMakeBuildEngine/BackEnd/Components/Scheduler/Scheduler.cs#L509


### PR DESCRIPTION
When running this against a build on VSTS I got a few NullRefs.

After correcting these few things the build does not fail and I'm able to view the XML.

```
2016-05-13T20:33:55.5102901Z MSBUILD : error MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
2016-05-13T20:33:55.5112900Z Microsoft.Build.Exceptions.InternalLoggerException: The build stopped unexpectedly because of an unexpected logger failure. ---> System.NullReferenceException: Object reference not set to an instance of an object.
2016-05-13T20:33:55.5112900Z    at Microsoft.Build.Logging.StructuredLogger.MessageProcessor.AddMessage(LazyFormattedBuildEventArgs args, String message) in C:\MSBuildStructuredLog\src\StructuredLogger\Construction\MessageProcessor.cs:line 236
```

```
2016-05-13T20:29:20.3315026Z MSBUILD : error MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
2016-05-13T20:29:20.3325021Z Microsoft.Build.Exceptions.InternalLoggerException: The build stopped unexpectedly because of an unexpected logger failure. ---> System.NullReferenceException: Object reference not set to an instance of an object.
2016-05-13T20:29:20.3325021Z    at Microsoft.Build.Logging.StructuredLogger.MessageProcessor.AddMessage(LazyFormattedBuildEventArgs args, String message) in C:\MSBuildStructuredLog\src\StructuredLogger\Construction\MessageProcessor.cs:line 159
```


