### PR TITLE
Better AppVeyor builds

### DIFF
--- a/MSBuildStructuredLog.sln
+++ b/MSBuildStructuredLog.sln
@@ -12,6 +12,7 @@ Project("{FF286327-C783-4F7A-AB73-9BCBAD0D4460}") = "MSBuildStructuredLogViewer"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1DA9000E-FE5B-467F-B6CB-2CFA7584ABF7}"
 	ProjectSection(SolutionItems) = preProject
+		appveyor.yml = appveyor.yml
 		Common.props = Common.props
 		Common.targets = Common.targets
 		nuget.config = nuget.config

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ configuration: Release
 environment:
   VisualStudioVersion: 14.0
 cache:
-- '%USERPROFILE%\.nuget\packages'
+- '%USERPROFILE%\.nuget\packages -> **\project.json'
 install:
 - ps: >-
     iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/install-nuget-3-3-0.ps1'))

--- a/src/MSBuildStructuredLogViewer/project.json
+++ b/src/MSBuildStructuredLogViewer/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Nerdbank.GitVersioning": "1.4.19",
+    "Nerdbank.GitVersioning": "1.4.41",
     "NuProj": "0.10.48-beta-gea4a31bbc5",
     "squirrel.windows": "1.4.0"
   },

--- a/src/Microsoft.Build.Logging.StructuredLogger/project.json
+++ b/src/Microsoft.Build.Logging.StructuredLogger/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Nerdbank.GitVersioning": "1.4.19",
+    "Nerdbank.GitVersioning": "1.4.41",
     "NuProj": "0.10.48-beta-gea4a31bbc5"
   },
   "frameworks": {

--- a/src/StructuredLogger/project.json
+++ b/src/StructuredLogger/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "Nerdbank.GitVersioning": {
-      "version": "1.4.19",
+      "version": "1.4.41",
       "suppressParent": "none"
     },
     "NuProj.Common": {

--- a/version.json
+++ b/version.json
@@ -9,4 +9,9 @@
     "^refs/heads/master$", // we release out of master
     "^refs/heads/v\\d+(?:.\\d+)?$" // we also release out of vNN branches
   ],
+  "cloudBuild": {
+    "buildNumber": {
+      "enabled": true
+    }
+  }
 }


### PR DESCRIPTION
Sets the cloud build number in AppVeyor (so you get meaningful build numbers that align with the version you're building instead of some ever-increasing number).
More accurate build caching in AppVeyor.
Make AppVeyor.yml conveniently accessible from the loaded solution.

![image](https://cloud.githubusercontent.com/assets/3548/15812349/7ea83ad2-2b68-11e6-9900-4e7fe6716255.png)
