### PR TITLE
Trigger BuildCommand when pressing enter in Build Arguments

### DIFF
--- a/src/StructuredLogViewer/themes/Generic.xaml
+++ b/src/StructuredLogViewer/themes/Generic.xaml
@@ -493,8 +493,14 @@
           <TextBlock Text="{Binding PrefixArguments}" />
           <TextBox x:Name="argumentsText"
                    Margin="4,0,4,0"
-                   Text="{Binding MSBuildArguments}" 
-                   MinWidth="300" />
+                   Text="{Binding MSBuildArguments, UpdateSourceTrigger=PropertyChanged}" 
+                   MinWidth="300">
+            <TextBox.InputBindings>
+              <KeyBinding  Key="Enter" 
+                           Command="{Binding BuildCommand}" />
+            </TextBox.InputBindings>
+           </TextBox>
+            
           <TextBlock Text="{Binding PostfixArguments}" />
         </WrapPanel>
       </StackPanel>


### PR DESCRIPTION
This fixes #33. 

- Added a KeyBinding to the textbox to trigger the BuildCommand when pressing enter key in the arguments textbox. 
- Set the UpdateSourceTrigger to PropertyChanged so that the binding is updated immediately as earlier it was getting triggered automatically on loosing focus , which will no longer happen if pressing Enter key.