### PR TITLE
Fix NRE when opening an Evaluation build log

### DIFF
--- a/src/StructuredLogger/Construction/Construction.cs
+++ b/src/StructuredLogger/Construction/Construction.cs
@@ -378,6 +378,8 @@ namespace Microsoft.Build.Logging.StructuredLogger
                     // This happens when we consume args created by us (deserialized)
                     if (e is ProjectEvaluationStartedEventArgs projectEvaluationStarted)
                     {
+                        EvaluationFolder = Build.GetOrCreateNodeWithName<Folder>("Evaluation");
+
                         var projectName = projectEvaluationStarted.ProjectFile;
                         var project = EvaluationFolder.GetOrCreateNodeWithName<Project>(projectName);
                         project.Id = e.BuildEventContext.ProjectContextId;


### PR DESCRIPTION
The issue is the EvaluationFolder was not initialized.

This happens when opening an Evaluation build log generated by the Project System Tools extension.

First, there's an exception when trying to add the project node:
System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.Build.Logging.StructuredLogger.Construction.StatusEventRaised(Object sender, BuildStatusEventArgs e) in C:\MSBuildStructuredLog\src\StructuredLogger\Construction\Construction.cs:line 379

And then, there's an exception for each message in the log:
System.NullReferenceException: Object reference not set to an instance of an object.

   at Microsoft.Build.Logging.StructuredLogger.MessageProcessor.AddMessage(LazyFormattedBuildEventArgs args, String message) in C:\MSBuildStructuredLog\src\StructuredLogger\Construction\MessageProcessor.cs:line 348

   at Microsoft.Build.Logging.StructuredLogger.Construction.MessageRaised(Object sender, BuildMessageEventArgs args) in C:\MSBuildStructuredLog\src\StructuredLogger\Construction\Construction.cs:line 344