### PR TITLE
Adds PrivateAssets="all" to Nerdbank.GitVersioning

### DIFF
--- a/src/StructuredLogger/StructuredLogger.csproj
+++ b/src/StructuredLogger/StructuredLogger.csproj
@@ -20,7 +20,7 @@
     <PackageTags>MSBuild Log Logger Structure Structured</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.0.41" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.0.41" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.IO.Compression" />


### PR DESCRIPTION
 Nerdbank.GitVersioning is currently listed as a dependency in the Microsoft.Build.Logging.StructuredLogger package. It's a development dependency so it shouldn't flow through to consumers (see https://github.com/AArnott/Nerdbank.GitVersioning/issues/122).