### PR TITLE
Massive API breaking change to remove conflicts with MSBuild.

### DIFF
--- a/src/StructuredLogger.Tests/Roundtrip.cs
+++ b/src/StructuredLogger.Tests/Roundtrip.cs
@@ -61,7 +61,7 @@ namespace StructuredLogger.Tests
         //[Fact]
         public void ReadBinaryLogRecords()
         {
-            var reader = new BinaryLogReplayEventSource();
+            var reader = new BinLogReader();
             var records = reader.ReadRecords(@"C:\temp\msbuild.binlog");
             foreach (var record in records)
             {

--- a/src/StructuredLogger/BinaryLog.cs
+++ b/src/StructuredLogger/BinaryLog.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
         public static Build ReadBuild(Stream stream, byte[] projectImportsArchive = null)
         {
-            var eventSource = new BinaryLogReplayEventSource();
+            var eventSource = new BinLogReader();
 
             Build build = null;
 

--- a/src/StructuredLogger/BinaryLogger/BinLogReader.cs
+++ b/src/StructuredLogger/BinaryLogger/BinLogReader.cs
@@ -6,14 +6,14 @@ using System.IO;
 using System.IO.Compression;
 using Microsoft.Build.Framework;
 
-namespace Microsoft.Build.Logging
+namespace Microsoft.Build.Logging.StructuredLogger
 {
     /// <summary>
     /// Provides a method to read a binary log file (*.binlog) and replay all stored BuildEventArgs
     /// by implementing IEventSource and raising corresponding events.
     /// </summary>
     /// <remarks>The class is public so that we can call it from MSBuild.exe when replaying a log file.</remarks>
-    public sealed class BinaryLogReplayEventSource : EventArgsDispatcher
+    public sealed class BinLogReader : EventArgsDispatcher
     {
         /// <summary>
         /// Raised when the log reader encounters a binary blob embedded in the stream.

--- a/src/StructuredLogger/BinaryLogger/BinaryLogRecordKind.cs
+++ b/src/StructuredLogger/BinaryLogger/BinaryLogRecordKind.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.Build.Logging
+﻿namespace Microsoft.Build.Logging.StructuredLogger
 {
     public enum BinaryLogRecordKind
     {

--- a/src/StructuredLogger/BinaryLogger/BinaryLogger.cs
+++ b/src/StructuredLogger/BinaryLogger/BinaryLogger.cs
@@ -4,7 +4,7 @@ using System.IO.Compression;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 
-namespace Microsoft.Build.Logging
+namespace Microsoft.Build.Logging.StructuredLogger
 {
     /// <summary>
     /// A logger that serializes all incoming BuildEventArgs in a compressed binary file (*.binlog). The file

--- a/src/StructuredLogger/BinaryLogger/BuildEventArgsDispatcher.cs
+++ b/src/StructuredLogger/BinaryLogger/BuildEventArgsDispatcher.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Build.Framework;
 
-namespace Microsoft.Build.Logging
+namespace Microsoft.Build.Logging.StructuredLogger
 {
     /// <summary>
     /// An implementation of IEventSource that raises appropriate events for a provided BuildEventArgs object.

--- a/src/StructuredLogger/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/StructuredLogger/BinaryLogger/BuildEventArgsReader.cs
@@ -4,9 +4,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using Microsoft.Build.Framework;
-using Microsoft.Build.Framework.Profiler;
 
-namespace Microsoft.Build.Logging
+namespace Microsoft.Build.Logging.StructuredLogger
 {
     /// <summary>
     /// Deserializes and returns BuildEventArgs-derived objects from a BinaryReader

--- a/src/StructuredLogger/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/StructuredLogger/BinaryLogger/BuildEventArgsWriter.cs
@@ -4,9 +4,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.Build.Framework;
-using Microsoft.Build.Framework.Profiler;
 
-namespace Microsoft.Build.Logging
+namespace Microsoft.Build.Logging.StructuredLogger
 {
     /// <summary>
     /// Serializes BuildEventArgs-derived objects into a provided BinaryWriter

--- a/src/StructuredLogger/BinaryLogger/EvaluationIdProvider.cs
+++ b/src/StructuredLogger/BinaryLogger/EvaluationIdProvider.cs
@@ -8,7 +8,7 @@ using System;
 using System.Diagnostics;
 using System.Threading;
 
-namespace Microsoft.Build.Framework.Profiler
+namespace Microsoft.Build.Logging.StructuredLogger
 {
     /// <summary>
     /// Assigns unique evaluation ids. Thread safe.

--- a/src/StructuredLogger/BinaryLogger/EvaluationLocation.cs
+++ b/src/StructuredLogger/BinaryLogger/EvaluationLocation.cs
@@ -8,7 +8,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Microsoft.Build.Framework.Profiler
+namespace Microsoft.Build.Logging.StructuredLogger
 {
     /// <summary>
     /// Evaluation main phases used by the profiler

--- a/src/StructuredLogger/BinaryLogger/ProfilerResult.cs
+++ b/src/StructuredLogger/BinaryLogger/ProfilerResult.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 
-namespace Microsoft.Build.Framework.Profiler
+namespace Microsoft.Build.Logging.StructuredLogger
 {
     /// <summary>
     /// Result of profiling an evaluation

--- a/src/StructuredLogger/BinaryLogger/ProjectEvaluationFinishedEventArgs.cs
+++ b/src/StructuredLogger/BinaryLogger/ProjectEvaluationFinishedEventArgs.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using Microsoft.Build.Framework.Profiler;
+using Microsoft.Build.Framework;
 
-namespace Microsoft.Build.Framework
+namespace Microsoft.Build.Logging.StructuredLogger
 {
     /// <summary>
     /// Arguments for the project evaluation finished event.

--- a/src/StructuredLogger/BinaryLogger/ProjectEvaluationStartedEventArgs.cs
+++ b/src/StructuredLogger/BinaryLogger/ProjectEvaluationStartedEventArgs.cs
@@ -2,8 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using Microsoft.Build.Framework;
 
-namespace Microsoft.Build.Framework
+namespace Microsoft.Build.Logging.StructuredLogger
 {
     /// <summary>
     /// Arguments for the project evaluation started event.

--- a/src/StructuredLogger/BinaryLogger/ProjectImportedEventArgs.cs
+++ b/src/StructuredLogger/BinaryLogger/ProjectImportedEventArgs.cs
@@ -2,8 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using Microsoft.Build.Framework;
 
-namespace Microsoft.Build.Framework
+namespace Microsoft.Build.Logging.StructuredLogger
 {
     /// <summary>
     /// Arguments for the project imported event.

--- a/src/StructuredLogger/Construction/Construction.cs
+++ b/src/StructuredLogger/Construction/Construction.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
-using Microsoft.Build.Framework.Profiler;
 
 namespace Microsoft.Build.Logging.StructuredLogger
 {

--- a/src/StructuredLogger/ObjectModel/EvaluationProfileEntry.cs
+++ b/src/StructuredLogger/ObjectModel/EvaluationProfileEntry.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO;
-using Microsoft.Build.Framework.Profiler;
 
 namespace Microsoft.Build.Logging.StructuredLogger
 {

--- a/src/StructuredLogger/Serialization/Binary/BuildLogReader.cs
+++ b/src/StructuredLogger/Serialization/Binary/BuildLogReader.cs
@@ -4,7 +4,7 @@ using System.IO;
 
 namespace Microsoft.Build.Logging.StructuredLogger
 {
-    public class BinaryLogReader : IDisposable
+    public class BuildLogReader : IDisposable
     {
         private TreeBinaryReader reader;
         private readonly Queue<string> attributes = new Queue<string>(10);
@@ -33,7 +33,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
         public static Build Read(Stream stream, byte[] projectImportsArchive = null)
         {
-            using (var binaryLogReader = new BinaryLogReader(stream))
+            using (var binaryLogReader = new BuildLogReader(stream))
             {
                 if (!binaryLogReader.formatIsValid)
                 {
@@ -57,7 +57,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
             }
         }
 
-        private BinaryLogReader(string filePath)
+        private BuildLogReader(string filePath)
         {
             this.reader = new TreeBinaryReader(filePath);
             this.formatSupportsSourceFiles = reader.Version > new Version(1, 0, 130);
@@ -66,7 +66,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
             this.formatIsValid = reader.IsValid();
         }
 
-        private BinaryLogReader(Stream stream)
+        private BuildLogReader(Stream stream)
         {
             this.reader = new TreeBinaryReader(stream);
             this.formatSupportsSourceFiles = reader.Version > new Version(1, 0, 130);

--- a/src/StructuredLogger/Serialization/Binary/BuildLogWriter.cs
+++ b/src/StructuredLogger/Serialization/Binary/BuildLogWriter.cs
@@ -2,20 +2,20 @@
 
 namespace Microsoft.Build.Logging.StructuredLogger
 {
-    public class BinaryLogWriter : IDisposable
+    public class BuildLogWriter : IDisposable
     {
         private readonly string filePath;
         private TreeBinaryWriter writer;
 
         public static void Write(Build build, string filePath)
         {
-            using (var binaryLogWriter = new BinaryLogWriter(filePath))
+            using (var binaryLogWriter = new BuildLogWriter(filePath))
             {
                 binaryLogWriter.WriteNode(build);
             }
         }
 
-        private BinaryLogWriter(string filePath)
+        private BuildLogWriter(string filePath)
         {
             this.filePath = filePath;
             this.writer = new TreeBinaryWriter(filePath);

--- a/src/StructuredLogger/Serialization/Serialization.cs
+++ b/src/StructuredLogger/Serialization/Serialization.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
         }
 
         public static Build ReadXmlLog(Stream stream) => XmlLogReader.ReadFromXml(stream);
-        public static Build ReadBuildLog(Stream stream, byte[] projectImportsArchive = null) => BinaryLogReader.Read(stream, projectImportsArchive);
+        public static Build ReadBuildLog(Stream stream, byte[] projectImportsArchive = null) => BuildLogReader.Read(stream, projectImportsArchive);
         public static Build ReadBinLog(Stream stream, byte[] projectImportsArchive = null) => BinaryLog.ReadBuild(stream, projectImportsArchive);
 
         public static Build Read(string filePath)
@@ -59,7 +59,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 {
                     if (DetectLogFormat(filePath) == ".buildlog")
                     {
-                        return BinaryLogReader.Read(filePath);
+                        return BuildLogReader.Read(filePath);
                     }
                     else
                     {
@@ -71,7 +71,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
             {
                 try
                 {
-                    return BinaryLogReader.Read(filePath);
+                    return BuildLogReader.Read(filePath);
                 }
                 catch (Exception)
                 {
@@ -122,7 +122,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
             }
             else
             {
-                BinaryLogWriter.Write(build, filePath);
+                BuildLogWriter.Write(build, filePath);
             }
         }
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.2",
+  "version": "2.0",
   "assemblyVersion": {
       "precision": "build"
   },


### PR DESCRIPTION
Previously we used to keep a fork of the same public types and namespaces present in MSBuild (such as BinaryLogger, BinaryLogReplayEventSource, etc). It was easier to sync with the MSBuild codebase.

However this presents a problem - if someone is referencing both MSBuild and StructuredLogger.dll then they have a conflict - types with the same namespace and name are present in both places, so it fails the build.

I've decided to move public types which are mirrored from MSBuild into a different namespace, and additionally rename BinaryLogReplayEventSource -> BinLogReader.

Also switching the version from 1.2 to 2.0 as this is a major breaking change.