### PR TITLE
Detect double writes from compilation

### DIFF
--- a/src/StructuredLogViewer.Core/BuildAnalyzer.cs
+++ b/src/StructuredLogViewer.Core/BuildAnalyzer.cs
@@ -230,14 +230,12 @@ namespace Microsoft.Build.Logging.StructuredLogger
             {
                 resolveAssemblyReferenceAnalyzer.AnalyzeResolveAssemblyReference(task);
             }
-            else if (task is CopyTask copyTask)
-            {
-                doubleWritesAnalyzer.AnalyzeFileCopies(copyTask);
-            }
             else if (task.Name == "Message")
             {
                 MessageTaskAnalyzer.Analyze(task);
             }
+
+            doubleWritesAnalyzer.AnalyzeTask(task);
         }
 
         private void AnalyzeTarget(Target target)

--- a/src/StructuredLogger/Analyzers/DoubleWritesAnalyzer.cs
+++ b/src/StructuredLogger/Analyzers/DoubleWritesAnalyzer.cs
@@ -42,9 +42,13 @@ namespace Microsoft.Build.Logging.StructuredLogger
             {
                 AnalyzeCopyTask(copyTask);
             }
-            else if (task is CscTask cscTask)
+            else if (task is CscTask cscTask && cscTask.CompilationWrites.HasValue)
             {
-                AnalyzeCscTask(cscTask);
+                AnalyzeCompilationWrites(cscTask.CompilationWrites.Value);
+            }
+            else if (task is VbcTask vbcTask && vbcTask.CompilationWrites.HasValue)
+            {
+                AnalyzeCompilationWrites(vbcTask.CompilationWrites.Value);
             }
         }
 
@@ -59,24 +63,20 @@ namespace Microsoft.Build.Logging.StructuredLogger
             }
         }
 
-        private void AnalyzeCscTask(CscTask cscTask)
+        private void AnalyzeCompilationWrites(CompilationWrites writes)
         {
-            if (cscTask.CompilationWrites.HasValue)
-            {
-                var writes = cscTask.CompilationWrites.Value;
-                var source = writes.AssemblyOrRefAssembly;
-                process(writes.Assembly);
-                process(writes.RefAssembly);
-                process(writes.Pdb);
-                process(writes.XmlDocumentation);
-                process(writes.SourceLink);
+            var source = writes.AssemblyOrRefAssembly;
+            process(writes.Assembly);
+            process(writes.RefAssembly);
+            process(writes.Pdb);
+            process(writes.XmlDocumentation);
+            process(writes.SourceLink);
 
-                void process(string destination)
+            void process(string destination)
+            {
+                if (!string.IsNullOrEmpty(destination))
                 {
-                    if (!string.IsNullOrEmpty(destination))
-                    {
-                        ProcessCopy(source, destination);
-                    }
+                    ProcessCopy(source, destination);
                 }
             }
         }

--- a/src/StructuredLogger/Analyzers/DoubleWritesAnalyzer.cs
+++ b/src/StructuredLogger/Analyzers/DoubleWritesAnalyzer.cs
@@ -50,6 +50,10 @@ namespace Microsoft.Build.Logging.StructuredLogger
             {
                 AnalyzeCompilationWrites(vbcTask.CompilationWrites.Value);
             }
+            else if (task is FscTask fscTask && fscTask.CompilationWrites.HasValue)
+            {
+                AnalyzeCompilationWrites(fscTask.CompilationWrites.Value);
+            }
         }
 
         private void AnalyzeCopyTask(CopyTask copyTask)

--- a/src/StructuredLogger/Construction/Construction.cs
+++ b/src/StructuredLogger/Construction/Construction.cs
@@ -792,13 +792,17 @@ namespace Microsoft.Build.Logging.StructuredLogger
             var startTime = taskStartedEventArgs.Timestamp;
 
             Task result;
-            if (taskName == "Copy")
+            switch (taskName)
             {
-                result = new CopyTask();
-            }
-            else
-            {
-                result = new Task();
+                case "Copy":
+                    result = new CopyTask();
+                    break;
+                case "Csc":
+                    result = new CscTask();
+                    break;
+                default:
+                    result = new Task();
+                    break;
             }
 
             result.Name = taskName;

--- a/src/StructuredLogger/Construction/Construction.cs
+++ b/src/StructuredLogger/Construction/Construction.cs
@@ -800,6 +800,9 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 case "Csc":
                     result = new CscTask();
                     break;
+                case "Vbc":
+                    result = new VbcTask();
+                    break;
                 default:
                     result = new Task();
                     break;

--- a/src/StructuredLogger/Construction/Construction.cs
+++ b/src/StructuredLogger/Construction/Construction.cs
@@ -803,6 +803,9 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 case "Vbc":
                     result = new VbcTask();
                     break;
+                case "Fsc":
+                    result = new FscTask();
+                    break;
                 default:
                     result = new Task();
                     break;

--- a/src/StructuredLogger/ObjectModel/Tasks/CompilationWrites.cs
+++ b/src/StructuredLogger/ObjectModel/Tasks/CompilationWrites.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Build.Logging.StructuredLogger
+{
+    public readonly struct CompilationWrites
+    {
+        public string Assembly { get; }
+        public string RefAssembly { get; }
+        public string Pdb { get; }
+        public string XmlDocumentation { get; }
+        public string SourceLink { get; }
+
+        public string AssemblyOrRefAssembly => Assembly ?? RefAssembly;
+
+        public CompilationWrites(
+            string assembly,
+            string refAssembly,
+            string pdb,
+            string xmlDocumentation,
+            string sourceLink)
+        {
+            Assembly = assembly;
+            RefAssembly = refAssembly;
+            Pdb = pdb;
+            XmlDocumentation = xmlDocumentation;
+            SourceLink = sourceLink;
+        }
+
+        internal static CompilationWrites? TryParse(Task task)
+        {
+            var parameters = task.FindChild<Folder>(c => c.Name == "Parameters");
+            string assembly = null;
+            string refAssembly = null;
+            string xmlDocumentation = null;
+            string sourceLink = null;
+            var hasPdb = false;
+
+            foreach (var property in parameters.Children.OfType<Property>())
+            {
+                switch (property.Name)
+                {
+                    case "OutputAssembly":
+                        assembly = property.Value;
+                        break;
+                    case "OutputRefAssembly":
+                        refAssembly = property.Value;
+                        break;
+                    case "DocumentationFile":
+                        xmlDocumentation = property.Value;
+                        break;
+                    case "SourceLink":
+                        sourceLink = property.Value;
+                        break;
+                    case "DebugType":
+                        switch (property.Value.ToLower())
+                        {
+                            case "full":
+                            case "portable":
+                            case "pdbonly":
+                                hasPdb = true;
+                                break;
+                        }
+                        break;
+                }
+            }
+
+            if (string.IsNullOrEmpty(assembly) && string.IsNullOrEmpty(refAssembly))
+            {
+                return null;
+            }
+
+            var pdb = hasPdb && !string.IsNullOrEmpty(assembly)
+                ? Path.ChangeExtension(assembly, ".pdb")
+                : null;
+            return new CompilationWrites(
+                assembly,
+                refAssembly,
+                pdb,
+                xmlDocumentation,
+                sourceLink);
+        }
+
+        public override string ToString() => $"{Path.GetFileName(AssemblyOrRefAssembly)}";
+    }
+}

--- a/src/StructuredLogger/ObjectModel/Tasks/CscTask.cs
+++ b/src/StructuredLogger/ObjectModel/Tasks/CscTask.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Build.Logging.StructuredLogger
+{
+    public class CscTask : Task
+    {
+        private CompilationWrites? compilationWrites;
+
+        public CompilationWrites? CompilationWrites
+        {
+            get
+            {
+                if (!HasChildren)
+                {
+                    return null;
+                }
+
+                if (!compilationWrites.HasValue)
+                {
+                    compilationWrites = Logging.StructuredLogger.CompilationWrites.TryParse(this);
+                }
+
+                return compilationWrites.Value;
+            }
+        }
+    }
+}

--- a/src/StructuredLogger/ObjectModel/Tasks/FscTask.cs
+++ b/src/StructuredLogger/ObjectModel/Tasks/FscTask.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Build.Logging.StructuredLogger
+{
+    public class FscTask : Task
+    {
+        private CompilationWrites? compilationWrites;
+
+        public CompilationWrites? CompilationWrites
+        {
+            get
+            {
+                if (!HasChildren)
+                {
+                    return null;
+                }
+
+                if (!compilationWrites.HasValue)
+                {
+                    compilationWrites = Logging.StructuredLogger.CompilationWrites.TryParse(this);
+                }
+
+                return compilationWrites.Value;
+            }
+        }
+    }
+}

--- a/src/StructuredLogger/ObjectModel/Tasks/VbcTask.cs
+++ b/src/StructuredLogger/ObjectModel/Tasks/VbcTask.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Build.Logging.StructuredLogger
+{
+    public class VbcTask : Task
+    {
+        private CompilationWrites? compilationWrites;
+
+        public CompilationWrites? CompilationWrites
+        {
+            get
+            {
+                if (!HasChildren)
+                {
+                    return null;
+                }
+
+                if (!compilationWrites.HasValue)
+                {
+                    compilationWrites = Logging.StructuredLogger.CompilationWrites.TryParse(this);
+                }
+
+                return compilationWrites.Value;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds support for detecting double writes that occur during a compilation from the C#, VB and F# compilers. 

For single targeted projects this isn't much of a problem. After all if you have two different projects compiling the same assembly to the same directory then you will likely notice this real fast. 

For multi targeted projects though this is a real problem. It's very easy to leave off a `$(TargetFramework)` sub-directory in a path and say write the same XML documentation file for every target framework. This change helps detect mistakes like that which otherwise tend to go unnoticed.

Fixes #217  