### PR TITLE
Show minimal console logging in the hosted build window

### DIFF
--- a/src/StructuredLogViewer.Core/HostedBuild.cs
+++ b/src/StructuredLogViewer.Core/HostedBuild.cs
@@ -22,7 +22,7 @@ namespace StructuredLogViewer
         public static string GetPostfixArguments()
         {
             var loggerDll = typeof(StructuredLogger).Assembly.Location;
-            return $@"/v:diag /nologo /noconlog /logger:{nameof(StructuredLogger)},""{loggerDll}"";""{logFilePath}""";
+            return $@"/v:diag /nologo /clp:NoSummary;Verbosity=minimal /logger:{nameof(StructuredLogger)},""{loggerDll}"";""{logFilePath}""";
         }
 
         public Task<Build> BuildAndGetResult(BuildProgress progress)


### PR DESCRIPTION
This is useful when builds take a long time, since at least you have
*some* indication of progress, which is otherwise fully opaque until
the build finishes and the main window loads the entire output.