### PR TITLE
Make search results stand out

### DIFF
--- a/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
@@ -61,7 +61,11 @@ namespace StructuredLogViewer.Controls
                 return results;
             };
             searchLogControl.ResultsTreeBuilder = BuildResultTree;
-            searchLogControl.WatermarkDisplayed += () => UpdateWatermark();
+            searchLogControl.WatermarkDisplayed += () =>
+            {
+                Search.ClearSearchResults(Build);
+                UpdateWatermark();
+            };
 
             VirtualizingPanel.SetIsVirtualizing(treeView, SettingsService.EnableTreeViewVirtualization);
 

--- a/src/StructuredLogViewer/themes/Generic.xaml
+++ b/src/StructuredLogViewer/themes/Generic.xaml
@@ -20,6 +20,8 @@
   <SolidColorBrush x:Key="NoImportStroke" Color="Red" />
   <SolidColorBrush x:Key="ErrorStroke" Color="Red" />
   <SolidColorBrush x:Key="WarningStroke" Color="Gold" />
+  <SolidColorBrush x:Key="SearchResultStroke" Color="OrangeRed" />
+  <SolidColorBrush x:Key="ContainsSearchResultStroke" Color="LightCoral" />
 
   <LinearGradientBrush x:Key="ClosedFolderBrush" StartPoint="0,0" EndPoint="1,1">
     <GradientStop Color="FloralWhite" Offset="0" />
@@ -75,6 +77,9 @@
     <GradientStop Color="LightYellow" Offset="0" />
     <GradientStop Color="Yellow" Offset="1" />
   </LinearGradientBrush>
+
+  <SolidColorBrush x:Key="SearchResultBrush" Color="DarkOrange" />
+  <SolidColorBrush x:Key="ContainsSearchResultBrush" Color="Bisque" />
 
   <DrawingBrush x:Key="SlnIcon">
     <DrawingBrush.Drawing>
@@ -873,6 +878,11 @@
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
             </Border>
             <ItemsPresenter x:Name="ItemsHost" Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2"/>
+            <Ellipse x:Name="SearchResult"
+                     Grid.Column="1"
+                     Width="6" Height="6" Margin="1,1,0,0" StrokeThickness="1"
+                     HorizontalAlignment="Left" VerticalAlignment="Top"
+                     Visibility="Collapsed" />
           </Grid>
           <ControlTemplate.Triggers>
             <Trigger Property="IsExpanded" Value="false">
@@ -885,6 +895,16 @@
               <Setter TargetName="Bd" Property="Background" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
               <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"/>
             </Trigger>
+            <DataTrigger Binding="{Binding ContainsSearchResult}" Value="True">
+              <Setter TargetName="SearchResult" Property="Visibility" Value="Visible" />
+              <Setter TargetName="SearchResult" Property="Fill" Value="{StaticResource ContainsSearchResultBrush}" />
+              <Setter TargetName="SearchResult" Property="Stroke" Value="{StaticResource ContainsSearchResultStroke}" />
+            </DataTrigger>
+            <DataTrigger Binding="{Binding IsSearchResult}" Value="True">
+              <Setter TargetName="SearchResult" Property="Visibility" Value="Visible" />
+              <Setter TargetName="SearchResult" Property="Fill" Value="{StaticResource SearchResultBrush}" />
+              <Setter TargetName="SearchResult" Property="Stroke" Value="{StaticResource SearchResultStroke}" />
+            </DataTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
                 <Condition Property="IsSelected" Value="true"/>

--- a/src/StructuredLogger/ObjectModel/BaseNode.cs
+++ b/src/StructuredLogger/ObjectModel/BaseNode.cs
@@ -2,6 +2,8 @@
 {
     public abstract class BaseNode : ObservableObject
     {
+        private protected NodeFlags Flags { get; private set; }
+
         /// <summary>
         /// Since there can only be 1 selected node at a time, don't waste an instance field
         /// just to store a bit. Store the currently selected node here and this way we save
@@ -29,6 +31,20 @@
 
                 RaisePropertyChanged();
                 RaisePropertyChanged("IsLowRelevance");
+            }
+        }
+
+        private protected bool HasFlag(NodeFlags flag) => (Flags & flag) == flag;
+
+        private protected void SetFlag(NodeFlags flag, bool value)
+        {
+            if (value)
+            {
+                Flags = Flags | flag;
+            }
+            else
+            {
+                Flags = Flags & ~flag;
             }
         }
     }

--- a/src/StructuredLogger/ObjectModel/BaseNode.cs
+++ b/src/StructuredLogger/ObjectModel/BaseNode.cs
@@ -34,6 +34,38 @@
             }
         }
 
+        public bool IsSearchResult
+        {
+            get => HasFlag(NodeFlags.SearchResult);
+
+            set
+            {
+                if (IsSearchResult == value)
+                {
+                    return;
+                }
+
+                SetFlag(NodeFlags.SearchResult, value);
+                RaisePropertyChanged();
+            }
+        }
+
+        public bool ContainsSearchResult
+        {
+            get => HasFlag(NodeFlags.ContainsSearchResult);
+
+            set
+            {
+                if (ContainsSearchResult == value)
+                {
+                    return;
+                }
+
+                SetFlag(NodeFlags.ContainsSearchResult, value);
+                RaisePropertyChanged();
+            }
+        }
+
         private protected bool HasFlag(NodeFlags flag) => (Flags & flag) == flag;
 
         private protected void SetFlag(NodeFlags flag, bool value)

--- a/src/StructuredLogger/ObjectModel/NodeFlags.cs
+++ b/src/StructuredLogger/ObjectModel/NodeFlags.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Microsoft.Build.Logging.StructuredLogger
+{
+    [Flags]
+    internal enum NodeFlags : byte
+    {
+        None = 0,
+        Hidden = 1 << 0,
+        Expanded = 1 << 1
+    }
+}

--- a/src/StructuredLogger/ObjectModel/NodeFlags.cs
+++ b/src/StructuredLogger/ObjectModel/NodeFlags.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Build.Logging.StructuredLogger
     {
         None = 0,
         Hidden = 1 << 0,
-        Expanded = 1 << 1
+        Expanded = 1 << 1,
+        SearchResult = 1 << 2,
+        ContainsSearchResult = 1 << 3
     }
 }

--- a/src/StructuredLogger/ObjectModel/TreeNode.cs
+++ b/src/StructuredLogger/ObjectModel/TreeNode.cs
@@ -7,42 +7,34 @@ namespace Microsoft.Build.Logging.StructuredLogger
 {
     public abstract class TreeNode : ParentedNode
     {
-        private bool isVisible = true;
         public bool IsVisible
         {
-            get
-            {
-                return isVisible;
-            }
+            get => !HasFlag(NodeFlags.Hidden);
 
             set
             {
-                if (isVisible == value)
+                if (IsVisible == value)
                 {
                     return;
                 }
 
-                isVisible = value;
+                SetFlag(NodeFlags.Hidden, !value);
                 RaisePropertyChanged();
             }
         }
 
-        private bool isExpanded = false;
         public bool IsExpanded
         {
-            get
-            {
-                return isExpanded;
-            }
+            get => HasFlag(NodeFlags.Expanded);
 
             set
             {
-                if (isExpanded == value)
+                if (IsExpanded == value)
                 {
                     return;
                 }
 
-                isExpanded = value;
+                SetFlag(NodeFlags.Expanded, value);
                 RaisePropertyChanged();
             }
         }


### PR DESCRIPTION
I wanted the search results to be easier to navigate by making them stand out in the main tree.

Here's what this PR does (in this example, I searched for *"compile"*):

![image](https://user-images.githubusercontent.com/7913492/52016761-c56ee280-24e5-11e9-8162-1384c9a9b91b.png)

As you can see, there are two kinds of markers:

- ![image](https://user-images.githubusercontent.com/7913492/52016958-44641b00-24e6-11e9-91c0-78c141d03187.png) means the node is a search result
- ![image](https://user-images.githubusercontent.com/7913492/52016991-56de5480-24e6-11e9-9b4e-ce11c8466693.png) means the node *contains* a search result

Feel free to change the colors if you can find something better :)

As for the implementation, I noticed [a comment in `BaseNode`](https://github.com/KirillOsenkov/MSBuildStructuredLog/blob/fc260682c4a43123faa516c9c8b38c20a69bfca4/src/StructuredLogger/ObjectModel/BaseNode.cs#L5-L10) which says that the node size should be kept at a minimum, so I grouped the necessary data under a flags enum (1 byte). I also removed the underlying fields from `IsVisible`/`IsExpanded` so this change should make the tree use *less* memory than before while adding a new feature. If you accept this PR, I'll also add `IsLowRelevance` to the flags later to save another bool.
