### PR TITLE
Node flags cleanup

### DIFF
--- a/src/StructuredLogger/ObjectModel/BaseNode.cs
+++ b/src/StructuredLogger/ObjectModel/BaseNode.cs
@@ -1,8 +1,10 @@
-﻿namespace Microsoft.Build.Logging.StructuredLogger
+﻿using System.Runtime.CompilerServices;
+
+namespace Microsoft.Build.Logging.StructuredLogger
 {
     public abstract class BaseNode : ObservableObject
     {
-        private protected NodeFlags Flags { get; private set; }
+        private NodeFlags flags;
 
         /// <summary>
         /// Since there can only be 1 selected node at a time, don't waste an instance field
@@ -37,47 +39,30 @@
         public bool IsSearchResult
         {
             get => HasFlag(NodeFlags.SearchResult);
-
-            set
-            {
-                if (IsSearchResult == value)
-                {
-                    return;
-                }
-
-                SetFlag(NodeFlags.SearchResult, value);
-                RaisePropertyChanged();
-            }
+            set => SetFlag(NodeFlags.SearchResult, value);
         }
 
         public bool ContainsSearchResult
         {
             get => HasFlag(NodeFlags.ContainsSearchResult);
-
-            set
-            {
-                if (ContainsSearchResult == value)
-                {
-                    return;
-                }
-
-                SetFlag(NodeFlags.ContainsSearchResult, value);
-                RaisePropertyChanged();
-            }
+            set => SetFlag(NodeFlags.ContainsSearchResult, value);
         }
 
-        private protected bool HasFlag(NodeFlags flag) => (Flags & flag) == flag;
+        private protected bool HasFlag(NodeFlags flag) => (flags & flag) == flag;
 
-        private protected void SetFlag(NodeFlags flag, bool value)
+        private protected void SetFlag(NodeFlags flag, bool isSet, [CallerMemberName] string propertyName = null)
         {
-            if (value)
+            var newFlags = isSet
+                ? flags | flag
+                : flags & ~flag;
+
+            if (flags == newFlags)
             {
-                Flags = Flags | flag;
+                return;
             }
-            else
-            {
-                Flags = Flags & ~flag;
-            }
+
+            flags = newFlags;
+            RaisePropertyChanged(propertyName);
         }
     }
 }

--- a/src/StructuredLogger/ObjectModel/Folder.cs
+++ b/src/StructuredLogger/ObjectModel/Folder.cs
@@ -2,24 +2,10 @@
 {
     public class Folder : NamedNode, IHasRelevance
     {
-        private bool isLowRelevance = false;
         public bool IsLowRelevance
         {
-            get
-            {
-                return isLowRelevance && !IsSelected;
-            }
-
-            set
-            {
-                if (isLowRelevance == value)
-                {
-                    return;
-                }
-
-                isLowRelevance = value;
-                RaisePropertyChanged();
-            }
+            get => HasFlag(NodeFlags.LowRelevance) && !IsSelected;
+            set => SetFlag(NodeFlags.LowRelevance, value);
         }
     }
 }

--- a/src/StructuredLogger/ObjectModel/Import.cs
+++ b/src/StructuredLogger/ObjectModel/Import.cs
@@ -27,11 +27,10 @@
 
         public string Location => $" at ({Line};{Column})";
 
-        private bool isLowRelevance = false;
         public bool IsLowRelevance
         {
-            get => isLowRelevance && !IsSelected;
-            set => SetField(ref isLowRelevance, value);
+            get => HasFlag(NodeFlags.LowRelevance) && !IsSelected;
+            set => SetFlag(NodeFlags.LowRelevance, value);
         }
 
         string IPreprocessable.RootFilePath => ImportedProjectFilePath;

--- a/src/StructuredLogger/ObjectModel/Message.cs
+++ b/src/StructuredLogger/ObjectModel/Message.cs
@@ -12,11 +12,10 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
         public override string LookupKey => Text;
 
-        private bool isLowRelevance = false;
         public bool IsLowRelevance
         {
-            get => isLowRelevance && !IsSelected;
-            set => SetField(ref isLowRelevance, value);
+            get => HasFlag(NodeFlags.LowRelevance) && !IsSelected;
+            set => SetFlag(NodeFlags.LowRelevance, value);
         }
 
         public string SourceFilePath

--- a/src/StructuredLogger/ObjectModel/NoImport.cs
+++ b/src/StructuredLogger/ObjectModel/NoImport.cs
@@ -9,6 +9,7 @@
 
         public NoImport()
         {
+            IsLowRelevance = true;
         }
 
         public NoImport(
@@ -17,6 +18,7 @@
             int line,
             int column,
             string reason)
+            : this()
         {
             ProjectFilePath = projectFilePath;
             Name = importedFileSpec;
@@ -27,11 +29,10 @@
 
         public string Location => $" at ({Line};{Column})";
 
-        private bool isLowRelevance = true;
         public bool IsLowRelevance
         {
-            get => isLowRelevance && !IsSelected;
-            set => SetField(ref isLowRelevance, value);
+            get => HasFlag(NodeFlags.LowRelevance) && !IsSelected;
+            set => SetFlag(NodeFlags.LowRelevance, value);
         }
 
         string IHasSourceFile.SourceFilePath => ProjectFilePath;

--- a/src/StructuredLogger/ObjectModel/NodeFlags.cs
+++ b/src/StructuredLogger/ObjectModel/NodeFlags.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
         Hidden = 1 << 0,
         Expanded = 1 << 1,
         SearchResult = 1 << 2,
-        ContainsSearchResult = 1 << 3
+        ContainsSearchResult = 1 << 3,
+        LowRelevance = 1 << 4
     }
 }

--- a/src/StructuredLogger/ObjectModel/Project.cs
+++ b/src/StructuredLogger/ObjectModel/Project.cs
@@ -154,11 +154,10 @@ namespace Microsoft.Build.Logging.StructuredLogger
             return result;
         }
 
-        private bool isLowRelevance = false;
         public bool IsLowRelevance
         {
-            get => isLowRelevance && !IsSelected;
-            set => SetField(ref isLowRelevance, value);
+            get => HasFlag(NodeFlags.LowRelevance) && !IsSelected;
+            set => SetFlag(NodeFlags.LowRelevance, value);
         }
 
         public override string ToString() => $"Project Name={Name} File={ProjectFile}";

--- a/src/StructuredLogger/ObjectModel/Target.cs
+++ b/src/StructuredLogger/ObjectModel/Target.cs
@@ -33,24 +33,10 @@ namespace Microsoft.Build.Logging.StructuredLogger
             return $"Target Name={Name} Project={Path.GetFileName(Project?.ProjectFile)}";
         }
 
-        private bool isLowRelevance = false;
         public bool IsLowRelevance
         {
-            get
-            {
-                return isLowRelevance && !IsSelected;
-            }
-
-            set
-            {
-                if (isLowRelevance == value)
-                {
-                    return;
-                }
-
-                isLowRelevance = value;
-                RaisePropertyChanged();
-            }
+            get => HasFlag(NodeFlags.LowRelevance) && !IsSelected;
+            set => SetFlag(NodeFlags.LowRelevance, value);
         }
     }
 }

--- a/src/StructuredLogger/ObjectModel/TreeNode.cs
+++ b/src/StructuredLogger/ObjectModel/TreeNode.cs
@@ -10,33 +10,13 @@ namespace Microsoft.Build.Logging.StructuredLogger
         public bool IsVisible
         {
             get => !HasFlag(NodeFlags.Hidden);
-
-            set
-            {
-                if (IsVisible == value)
-                {
-                    return;
-                }
-
-                SetFlag(NodeFlags.Hidden, !value);
-                RaisePropertyChanged();
-            }
+            set => SetFlag(NodeFlags.Hidden, !value);
         }
 
         public bool IsExpanded
         {
             get => HasFlag(NodeFlags.Expanded);
-
-            set
-            {
-                if (IsExpanded == value)
-                {
-                    return;
-                }
-
-                SetFlag(NodeFlags.Expanded, value);
-                RaisePropertyChanged();
-            }
+            set => SetFlag(NodeFlags.Expanded, value);
         }
 
         private IList<object> children;


### PR DESCRIPTION
Here's some cleanup after #236:

- Simplified setters in properties that use flags
- `LowRelevance` flag
- I also noticed that the search results markers flickered between similar searches, so I fixed that
