### PR TITLE
Add syntax highlighting for .sln files

### DIFF
--- a/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj
+++ b/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj
@@ -23,4 +23,12 @@
     <ProjectReference Include="..\StructuredLogViewer.Core\StructuredLogViewer.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Resources\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="..\StructuredLogViewer\Resources\SolutionFile.xshd" Link="Resources\SolutionFile.xshd" />
+  </ItemGroup>
+
 </Project>

--- a/src/StructuredLogViewer/Resources/SolutionFile.xshd
+++ b/src/StructuredLogViewer/Resources/SolutionFile.xshd
@@ -1,0 +1,34 @@
+﻿<SyntaxDefinition name="Solution File" xmlns="http://icsharpcode.net/sharpdevelop/syntaxdefinition/2008">
+  
+  <RuleSet>
+    <!-- Comments -->
+    <Span foreground="#008000" begin="^\s*#" />
+
+    <Keywords fontWeight="bold" foreground="#a31544">
+      <Word>VisualStudioVersion</Word>
+      <Word>MinimumVisualStudioVersion</Word>
+      <Word>Project</Word>
+      <Word>EndProject</Word>
+      <Word>ProjectSection</Word>
+      <Word>EndProjectSection</Word>
+      <Word>Global</Word>
+      <Word>EndGlobal</Word>
+      <Word>GlobalSection</Word>
+      <Word>EndGlobalSection</Word>
+      <Word>HideSolutionNode</Word>
+      <Word>SolutionGuid</Word>
+    </Keywords>
+
+    <!-- GUIDs -->
+    <Rule foreground="#0000ff">
+      \{[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\}
+    </Rule>
+
+    <!-- Punctuation -->
+    <Rule foreground="#888888">
+      [=()"]+
+    </Rule>
+
+  </RuleSet>
+
+</SyntaxDefinition>

--- a/src/StructuredLogViewer/StructuredLogViewer.csproj
+++ b/src/StructuredLogViewer/StructuredLogViewer.csproj
@@ -107,6 +107,7 @@
     <None Include="App.config" />
     <None Include="MSBuildStructuredLogViewer.nuspec" />
     <None Include="project.json" />
+    <EmbeddedResource Include="Resources\SolutionFile.xshd" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SrcRoot)\Common.targets" />


### PR DESCRIPTION
Fixes half of #87 (highlighting, but no folding).

I was curious to see how syntax highlighting worked in the Avalonia editor. Turns out to be pretty simple. I chose colours to match project files. Could probably do something fancier with the highlighting file, but this seems to work well enough.

![image](https://user-images.githubusercontent.com/350947/59030922-b211c080-88a5-11e9-9a2c-779a49bea21d.png)
