### PR TITLE
Let Windows prompt the user for an application to Open a file with

### DIFF
--- a/src/StructuredLogViewer/Controls/TextViewerControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/TextViewerControl.xaml.cs
@@ -147,7 +147,11 @@ namespace StructuredLogViewer.Controls
                 filePath = SettingsService.WriteContentToTempFileAndGetPath(Text, extension);
             }
 
-            Process.Start(filePath, null);
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = filePath,
+                Verb = "open"
+            });
         }
 
         private void copyFullPath_Click(object sender, System.Windows.RoutedEventArgs e)


### PR DESCRIPTION
Currently when the Open button is used on a `.targets` or `.props` file, when there is no application mapped to open those files, an exception is thrown. This PR tells Windows to show the standard dialog for unmapped files, like so:

![image](https://user-images.githubusercontent.com/754264/61604031-4f248f00-ac83-11e9-9537-cac6469aacfb.png)
