### PR TITLE
Update to version 8

### DIFF
--- a/src/StructuredLogger/BinaryLogger/BinaryLogRecordKind.cs
+++ b/src/StructuredLogger/BinaryLogger/BinaryLogRecordKind.cs
@@ -20,6 +20,10 @@
         ProjectEvaluationFinished,
         ProjectImported,
         ProjectImportArchive,
-        TargetSkipped
+        TargetSkipped,
+        PropertyReassignment,
+        UninitializedPropertyRead,
+        EnvironmentVariableRead,
+        PropertyInitialValueSet
     }
 }

--- a/src/StructuredLogger/BinaryLogger/BinaryLogger.cs
+++ b/src/StructuredLogger/BinaryLogger/BinaryLogger.cs
@@ -30,7 +30,13 @@ namespace Microsoft.Build.Logging.StructuredLogger
         //   -  Ids and parent ids for the evaluation locations
         // version 7:
         //   -  Include ProjectStartedEventArgs.GlobalProperties
-        internal const int FileFormatVersion = 7;
+        // version 8
+        // - New record kinds: 
+        // - EnvironmentVariableRead
+        // - PropertyInitialValueSet
+        // - PropertyReassignment
+        // - UninitializedPropertyRead
+        internal const int FileFormatVersion = 8;
 
         private Stream stream;
         private BinaryWriter binaryWriter;

--- a/src/StructuredLogger/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/StructuredLogger/BinaryLogger/BuildEventArgsReader.cs
@@ -111,6 +111,18 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 case BinaryLogRecordKind.TargetSkipped:
                     result = ReadTargetSkippedEventArgs();
                     break;
+                case BinaryLogRecordKind.PropertyReassignment:
+                    result = ReadPropertyReassignmentEventArgs();
+                    break;
+                case BinaryLogRecordKind.UninitializedPropertyRead:
+                    result = ReadUninitializedPropertyReadEventArgs();
+                    break;
+                case BinaryLogRecordKind.EnvironmentVariableRead:
+                    result = ReadEnvironmentVariableReadEventArgs();
+                    break;
+                case BinaryLogRecordKind.PropertyInitialValueSet:
+                    result = ReadPropertyInitialValueSetEventArgs();
+                    break;
                 default:
                     break;
             }
@@ -185,6 +197,84 @@ namespace Microsoft.Build.Logging.StructuredLogger
             e.TargetName = targetName;
             e.ParentTarget = parentTarget;
             e.BuildReason = buildReason;
+
+            return e;
+        }
+
+        private BuildEventArgs ReadPropertyReassignmentEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields();
+            var importance = (MessageImportance)ReadInt32();
+            string propertyName = ReadString();
+            string previousValue = ReadString();
+            string newValue = ReadString();
+            string location = ReadString();
+
+            var e = new PropertyReassignmentEventArgs(
+               propertyName,
+               previousValue,
+               newValue,
+               location,
+               fields.Message,
+               fields.HelpKeyword,
+               fields.SenderName,
+               importance);
+            SetCommonFields(e, fields);
+
+            return e;
+        }
+        private BuildEventArgs ReadUninitializedPropertyReadEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields();
+            var importance = (MessageImportance)ReadInt32();
+            string propertyName = ReadString();
+
+            var e = new UninitializedPropertyReadEventArgs(
+               propertyName,
+               fields.Message,
+               fields.HelpKeyword,
+               fields.SenderName,
+               importance);
+            SetCommonFields(e, fields);
+
+            return e;
+        }
+
+        private BuildEventArgs ReadPropertyInitialValueSetEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields();
+            var importance = (MessageImportance)ReadInt32();
+            string propertyName = ReadString();
+            string propertyValue = ReadString();
+            string propertySource = ReadString();
+
+            var e = new PropertyInitialValueSetEventArgs(
+               propertyName,
+               propertyValue,
+               propertySource,
+               fields.Message,
+               fields.HelpKeyword,
+               fields.SenderName,
+               importance);
+            SetCommonFields(e, fields);
+
+            return e;
+        }
+
+        private BuildEventArgs ReadEnvironmentVariableReadEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields();
+            var importance = (MessageImportance)ReadInt32();
+
+            var environmentVariableName = ReadString();
+
+            var e = new EnvironmentVariableReadEventArgs(
+               environmentVariableName,
+               fields.Message,
+               fields.HelpKeyword,
+               fields.SenderName,
+               importance);
+            SetCommonFields(e, fields);
 
             return e;
         }

--- a/src/StructuredLogger/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/StructuredLogger/BinaryLogger/BuildEventArgsWriter.cs
@@ -328,6 +328,29 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 Write((TargetSkippedEventArgs)e);
                 return;
             }
+            if (e is PropertyReassignmentEventArgs)
+            {
+                Write((PropertyReassignmentEventArgs)e);
+                return;
+            }
+
+            if (e is UninitializedPropertyReadEventArgs)
+            {
+                Write((UninitializedPropertyReadEventArgs)e);
+                return;
+            }
+
+            if (e is EnvironmentVariableReadEventArgs)
+            {
+                Write((EnvironmentVariableReadEventArgs)e);
+                return;
+            }
+
+            if (e is PropertyInitialValueSetEventArgs)
+            {
+                Write((PropertyInitialValueSetEventArgs)e);
+                return;
+            }
 
             Write(BinaryLogRecordKind.Message);
             WriteMessageFields(e);
@@ -350,6 +373,38 @@ namespace Microsoft.Build.Logging.StructuredLogger
             WriteOptionalString(e.TargetName);
             WriteOptionalString(e.ParentTarget);
             Write((int)e.BuildReason);
+        }
+
+        private void Write(PropertyReassignmentEventArgs e)
+        {
+            Write(BinaryLogRecordKind.PropertyReassignment);
+            WriteMessageFields(e);
+            Write(e.PropertyName);
+            Write(e.PreviousValue);
+            Write(e.NewValue);
+            Write(e.Location);
+        }
+        private void Write(UninitializedPropertyReadEventArgs e)
+        {
+            Write(BinaryLogRecordKind.UninitializedPropertyRead);
+            WriteMessageFields(e);
+            Write(e.PropertyName);
+        }
+
+        private void Write(PropertyInitialValueSetEventArgs e)
+        {
+            Write(BinaryLogRecordKind.PropertyInitialValueSet);
+            WriteMessageFields(e);
+            Write(e.PropertyName);
+            Write(e.PropertyValue);
+            Write(e.PropertySource);
+        }
+
+        private void Write(EnvironmentVariableReadEventArgs e)
+        {
+            Write(BinaryLogRecordKind.EnvironmentVariableRead);
+            WriteMessageFields(e);
+            Write(e.EnvironmentVariableName);
         }
 
         private void Write(CriticalBuildMessageEventArgs e)

--- a/src/StructuredLogger/BinaryLogger/EnvironmentVariableReadEventArgs.cs
+++ b/src/StructuredLogger/BinaryLogger/EnvironmentVariableReadEventArgs.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+namespace Microsoft.Build.Framework
+{
+    public class EnvironmentVariableReadEventArgs : BuildMessageEventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the EnvironmentVariableReadEventArgs class.
+        /// </summary>
+#if FEATURE_BINARY_SERIALIZATION
+        [Serializable]
+#endif
+        public EnvironmentVariableReadEventArgs()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the EnvironmentVariableReadEventArgs class.
+        /// </summary>
+        public EnvironmentVariableReadEventArgs
+        (
+            string environmentVariableName,
+            string message,
+            string helpKeyword=null,
+            string senderName=null,
+            MessageImportance importance = MessageImportance.Low,
+            params object[] messageArgs
+        )
+            : base(null, null, null, 0, 0, 0, 0, message, helpKeyword, senderName, importance, DateTime.UtcNow, messageArgs)
+        {
+            EnvironmentVariableName = environmentVariableName;
+        }
+        
+
+        public string EnvironmentVariableName { get; set; }
+    }
+}

--- a/src/StructuredLogger/BinaryLogger/PropertyInitialValueSetEventArgs.cs
+++ b/src/StructuredLogger/BinaryLogger/PropertyInitialValueSetEventArgs.cs
@@ -1,0 +1,42 @@
+﻿using System;
+
+namespace Microsoft.Build.Framework
+{
+    public class PropertyInitialValueSetEventArgs : BuildMessageEventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the UninitializedPropertyRead class.
+        /// </summary>
+#if FEATURE_BINARY_SERIALIZATION
+    [Serializable]
+#endif
+        public PropertyInitialValueSetEventArgs()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the UninitializedPropertyRead class.
+        /// </summary>
+        public PropertyInitialValueSetEventArgs
+        (
+            string propertyName,
+            string propertyValue,
+            string propertySource,
+            string message,
+            string helpKeyword = null,
+            string senderName = null,
+            MessageImportance importance = MessageImportance.Low
+        ) : base(message, helpKeyword, senderName, importance)
+        {
+            this.PropertyName = propertyName;
+            this.PropertySource = propertySource;
+            this.PropertyValue = propertyValue;
+        }
+
+        public string PropertyName { get; set; }
+
+        public string PropertySource { get; set; }
+
+        public string PropertyValue { get; set; }
+    }
+}

--- a/src/StructuredLogger/BinaryLogger/PropertyReassignmentEventArgs.cs
+++ b/src/StructuredLogger/BinaryLogger/PropertyReassignmentEventArgs.cs
@@ -1,0 +1,62 @@
+﻿using System;
+
+namespace Microsoft.Build.Framework
+{
+    public class PropertyReassignmentEventArgs : BuildMessageEventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the PropertyReassignment class.
+        /// </summary>
+#if FEATURE_BINARY_SERIALIZATION
+    [Serializable]
+#endif
+        public PropertyReassignmentEventArgs()
+        {
+        }
+
+        /// <summary>
+        /// Creates an instance of the PropertyReassignmentEventArgs class.
+        /// </summary>
+        /// <param name="propertyName">The name of the property whose value was reassigned.</param>
+        /// <param name="previousValue">The previous value of the reassigned property.</param>
+        /// <param name="newValue">The new value of the reassigned property.</param>
+        /// <param name="location">The location of the reassignment.</param>
+        public PropertyReassignmentEventArgs
+        (
+            string propertyName,
+            string previousValue,
+            string newValue,
+            string location,
+            string message,
+            string helpKeyword = null,
+            string senderName = null,
+            MessageImportance importance = MessageImportance.Low
+        ) : base(message, helpKeyword, senderName, importance)
+        {
+            this.PropertyName = propertyName;
+            this.PreviousValue = previousValue;
+            this.NewValue = newValue;
+            this.Location = location;
+        }
+
+        /// <summary>
+        /// The name of the property whose value was reassigned.
+        /// </summary>
+        public string PropertyName { get; set; }
+
+        /// <summary>
+        /// The previous value of the reassigned property.
+        /// </summary>
+        public string PreviousValue { get; set; }
+
+        /// <summary>
+        /// The new value of the reassigned property.
+        /// </summary>
+        public string NewValue { get; set; }
+
+        /// <summary>
+        /// The location of the reassignment.
+        /// </summary>
+        public string Location { get; set; }
+    }
+}

--- a/src/StructuredLogger/BinaryLogger/UninitializedPropertyReadEventArgs.cs
+++ b/src/StructuredLogger/BinaryLogger/UninitializedPropertyReadEventArgs.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.Build.Logging.StructuredLogger;
+using System;
+
+namespace Microsoft.Build.Framework
+{
+    public class UninitializedPropertyReadEventArgs : BuildMessageEventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the UninitializedPropertyRead class.
+        /// </summary>
+#if FEATURE_BINARY_SERIALIZATION
+        [Serializable]
+#endif
+        public UninitializedPropertyReadEventArgs()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the UninitializedPropertyRead class.
+        /// </summary>
+        public UninitializedPropertyReadEventArgs
+        (
+            string propertyName,
+            string message,
+            string helpKeyword=null,
+            string senderName=null,
+            MessageImportance importance = MessageImportance.Low,
+            params object[] messageArgs
+        ) : base(message, helpKeyword, senderName, importance)
+        {
+            this.PropertyName = propertyName;
+        }
+
+        public string PropertyName { get; set; }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/KirillOsenkov/MSBuildStructuredLog/issues/253

Related PR: https://github.com/microsoft/msbuild/pull/4461

Added support for viewing version 8 binlogs that include the following events:
- PropertyReassignment
- UninitializedPropertyRead
- EnvironmentVariableRead
- PropertyInitialValueSet