### PR TITLE
Improve search in the Avalonia viewer

### DIFF
--- a/src/StructuredLogViewer.Avalonia/App.xaml
+++ b/src/StructuredLogViewer.Avalonia/App.xaml
@@ -41,6 +41,21 @@
                 </ControlTemplate>
             </Setter>
         </Style>
+        
+        <Style Selector="Rectangle.nodeIcon">
+            <Setter Property="Width" Value="14" />
+            <Setter Property="Height" Value="11" />
+            <Setter Property="Margin" Value="3,5,6,3" />
+            <Setter Property="StrokeThickness" Value="1" />
+            <Setter Property="VerticalAlignment" Value="Top" />
+        </Style>
+        
+        <Style Selector="DrawingPresenter.projectNodeIcon">
+            <Setter Property="Width" Value="16" />
+            <Setter Property="Height" Value="16" />
+            <Setter Property="Margin" Value="2,4,6,2" />
+            <Setter Property="VerticalAlignment" Value="Top" />
+        </Style>
 
     </Application.Styles>
     <Application.DataTemplates>
@@ -49,13 +64,9 @@
                           ItemsSource="{Binding Children}">
             <StackPanel Orientation="Horizontal">
                 <Rectangle Name="icon"
-                           Width="14"
-                           Height="11"
+                           Classes="nodeIcon"
                            Stroke="{DynamicResource FolderStroke}"
-                           StrokeThickness="1"
-                           Margin="3,5,6,3"
-                           Fill="{DynamicResource ClosedFolderBrush}"
-                           VerticalAlignment="Top" />
+                           Fill="{DynamicResource ClosedFolderBrush}" />
                 <TextBlock Name="nameText"
                            Text="{Binding Name}" />
             </StackPanel>
@@ -82,10 +93,7 @@
                           ItemsSource="{Binding Children}">
             <StackPanel Orientation="Horizontal"
                         Name="projectRoot">
-                <DrawingPresenter Width="16"
-                                  Height="16"
-                                  Margin="2,4,6,2"
-                                  VerticalAlignment="Top"
+                <DrawingPresenter Classes="projectNodeIcon"
                                   Drawing="{Binding ProjectFileExtension, Converter={StaticResource ProjectIconConverter}}" />
                 <TextBlock Text="{Binding Name}"
                            Margin="0,1,0,0" />
@@ -97,13 +105,9 @@
             <StackPanel Orientation="Horizontal"
                         Name="targetRoot">
                 <Rectangle Name="icon"
-                           Width="14"
-                           Height="11"
+                           Classes="nodeIcon"
                            Stroke="{DynamicResource TargetStroke}"
-                           StrokeThickness="1"
-                           Margin="3,5,6,3"
-                           Fill="{DynamicResource TargetBrush}"
-                           VerticalAlignment="Top" />
+                           Fill="{DynamicResource TargetBrush}" />
                 <TextBlock Name="label"
                            Text="Target " />
                 <TextBlock Text="{Binding Name}" />
@@ -128,13 +132,9 @@
                           ItemsSource="{Binding Children}">
             <StackPanel Orientation="Horizontal">
                 <Rectangle Name="icon"
-                           Width="14"
-                           Height="11"
+                           Classes="nodeIcon"
                            Stroke="{DynamicResource TaskStroke}"
-                           StrokeThickness="1"
-                           Margin="3,5,6,3"
-                           Fill="{DynamicResource TaskBrush}"
-                           VerticalAlignment="Top" />
+                           Fill="{DynamicResource TaskBrush}" />
                 <TextBlock Name="label"
                            Text="Task " />
                 <TextBlock Text="{Binding Name}" />
@@ -158,13 +158,9 @@
                           ItemsSource="{Binding Children}">
             <StackPanel Orientation="Horizontal">
                 <Rectangle Name="icon"
-                           Width="14"
-                           Height="11"
+                           Classes="nodeIcon"
                            Stroke="{DynamicResource ItemStroke}"
-                           StrokeThickness="1"
-                           Margin="3,5,6,3"
-                           Fill="{DynamicResource ItemBrush}"
-                           VerticalAlignment="Top" />
+                           Fill="{DynamicResource ItemBrush}" />
                 <TextBlock Name="label"
                            Text="Add Item " />
                 <TextBlock Text="{Binding Name}" />
@@ -183,13 +179,9 @@
                           ItemsSource="{Binding Children}">
             <StackPanel Orientation="Horizontal">
                 <Rectangle Name="icon"
-                           Width="14"
-                           Height="11"
+                           Classes="nodeIcon"
                            Stroke="{DynamicResource ItemStroke}"
-                           StrokeThickness="1"
-                           Margin="3,5,6,3"
-                           Fill="{DynamicResource ItemBrush}"
-                           VerticalAlignment="Top" />
+                           Fill="{DynamicResource ItemBrush}" />
                 <TextBlock Name="label"
                            Text="Remove Item " />
                 <TextBlock Text="{Binding Name}" />
@@ -208,13 +200,9 @@
                           ItemsSource="{Binding Children}">
             <StackPanel Orientation="Horizontal">
                 <Rectangle Name="icon"
-                           Width="14"
-                           Height="11"
+                           Classes="nodeIcon"
                            Stroke="{DynamicResource ItemStroke}"
-                           StrokeThickness="1"
-                           Margin="3,5,6,3"
-                           Fill="{DynamicResource ItemBrush}"
-                           VerticalAlignment="Top" />
+                           Fill="{DynamicResource ItemBrush}" />
                 <TextBlock Name="nameAndEquals"
                            Text="{Binding NameAndEquals}" />
                 <TextBlock Text="{Binding ShortenedText}" />
@@ -232,13 +220,9 @@
         <DataTemplate DataType="{x:Type l:Metadata}">
             <StackPanel Orientation="Horizontal">
                 <Rectangle Name="icon"
-                           Width="14"
-                           Height="11"
+                           Classes="nodeIcon"
                            Stroke="{DynamicResource MetadataStroke}"
-                           StrokeThickness="1"
-                           Margin="3,5,6,3"
-                           Fill="{DynamicResource ItemBrush}"
-                           VerticalAlignment="Top" />
+                           Fill="{DynamicResource ItemBrush}" />
                 <TextBlock Name="label"
                            Text="{Binding NameAndEquals, Mode=OneTime}" />
                 <TextBlock Text="{Binding ShortenedValue}" />
@@ -256,13 +240,9 @@
         <DataTemplate DataType="{x:Type l:Property}">
             <StackPanel Orientation="Horizontal">
                 <Rectangle Name="icon"
-                           Width="14"
-                           Height="11"
+                           Classes="nodeIcon"
                            Stroke="{DynamicResource PropertyStroke}"
-                           StrokeThickness="1"
-                           Margin="3,5,6,3"
-                           Fill="{DynamicResource PropertyBrush}"
-                           VerticalAlignment="Top" />
+                           Fill="{DynamicResource PropertyBrush}" />
                 <TextBlock Name="label"
                            Text="{Binding NameAndEquals, Mode=OneTime}" />
                 <TextBlock Text="{Binding ShortenedValue}" />
@@ -281,13 +261,9 @@
                           ItemsSource="{Binding Children}">
             <StackPanel Orientation="Horizontal">
                 <Rectangle Name="icon"
-                           Width="14"
-                           Height="11"
+                           Classes="nodeIcon"
                            Stroke="{DynamicResource ParameterStroke}"
-                           StrokeThickness="1"
-                           Margin="3,5,6,3"
-                           Fill="{DynamicResource ParameterBrush}"
-                           VerticalAlignment="Top" />
+                           Fill="{DynamicResource ParameterBrush}" />
                 <TextBlock Name="name"
                            Text="{Binding Name}" />
             </StackPanel>
@@ -304,13 +280,9 @@
         <DataTemplate DataType="{x:Type l:Message}">
             <StackPanel Orientation="Horizontal">
                 <Rectangle Name="icon"
-                           Width="14"
-                           Height="11"
+                           Classes="nodeIcon"
                            Stroke="{DynamicResource MessageStroke}"
-                           StrokeThickness="1"
-                           Margin="3,5,6,3"
-                           Fill="{DynamicResource MessageBrush}"
-                           VerticalAlignment="Top" />
+                           Fill="{DynamicResource MessageBrush}" />
                 <TextBlock Name="messageText"
                            Text="{Binding ShortenedText}" />
             </StackPanel>
@@ -328,13 +300,9 @@
                           ItemsSource="{Binding Children}">
             <StackPanel Orientation="Horizontal">
                 <Rectangle Name="icon"
-                           Width="14"
-                           Height="11"
+                           Classes="nodeIcon"
                            Stroke="{DynamicResource ImportStroke}"
-                           StrokeThickness="1"
-                           Margin="3,5,6,3"
-                           Fill="{DynamicResource ImportBrush}"
-                           VerticalAlignment="Top" />
+                           Fill="{DynamicResource ImportBrush}" />
                 <TextBlock x:Name="label"
                            Text="Import"
                            Margin="0,0,6,0" />
@@ -349,13 +317,9 @@
                           ItemsSource="{Binding Children}">
             <StackPanel Orientation="Horizontal">
                 <Rectangle Name="icon"
-                           Width="14"
-                           Height="11"
+                           Classes="nodeIcon"
                            Stroke="{DynamicResource NoImportStroke}"
-                           StrokeThickness="1"
-                           Margin="3,5,6,3"
-                           Fill="{DynamicResource NoImportBrush}"
-                           VerticalAlignment="Top" />
+                           Fill="{DynamicResource NoImportBrush}" />
                 <TextBlock x:Name="label"
                            Text="NoImport"
                            Margin="0,0,6,0" />
@@ -381,13 +345,9 @@
         <DataTemplate DataType="{x:Type l:Error}">
             <StackPanel Orientation="Horizontal">
                 <Rectangle Name="icon"
-                           Width="14"
-                           Height="11"
+                           Classes="nodeIcon"
                            Stroke="{DynamicResource ErrorStroke}"
-                           StrokeThickness="1"
-                           Margin="3,5,6,3"
-                           Fill="{DynamicResource ErrorBrush}"
-                           VerticalAlignment="Top" />
+                           Fill="{DynamicResource ErrorBrush}" />
                 <TextBlock Name="text"
                            Text="{Binding}" />
             </StackPanel>
@@ -404,13 +364,9 @@
         <DataTemplate DataType="{x:Type l:Warning}">
             <StackPanel Orientation="Horizontal">
                 <Rectangle Name="icon"
-                           Width="14"
-                           Height="11"
+                           Classes="nodeIcon"
                            Stroke="{DynamicResource WarningStroke}"
-                           StrokeThickness="1"
-                           Margin="3,5,6,3"
-                           Fill="{DynamicResource WarningBrush}"
-                           VerticalAlignment="Top" />
+                           Fill="{DynamicResource WarningBrush}" />
                 <TextBlock Text="{Binding}" />
             </StackPanel>
         </DataTemplate>
@@ -433,13 +389,9 @@
                           ItemsSource="{Binding Children}">
             <StackPanel Orientation="Horizontal">
                 <Rectangle Name="icon"
-                           Width="14"
-                           Height="11"
+                           Classes="nodeIcon"
                            Stroke="{DynamicResource MessageStroke}"
-                           StrokeThickness="1"
-                           Margin="3,5,6,3"
-                           Fill="{DynamicResource MessageBrush}"
-                           VerticalAlignment="Top" />
+                           Fill="{DynamicResource MessageBrush}" />
                 <TextBlock Name="messageText"
                            Text="{Binding Name}" />
             </StackPanel>

--- a/src/StructuredLogViewer.Avalonia/App.xaml
+++ b/src/StructuredLogViewer.Avalonia/App.xaml
@@ -368,6 +368,15 @@
             </StackPanel>
         </TreeDataTemplate>
         
+        <DataTemplate DataType="{x:Type common:ButtonNode}">
+            <StackPanel Orientation="Horizontal">
+                <Button x:Name="button" 
+                        Content="{Binding Text}" 
+                        Command="{Binding Command}" 
+                        Padding="4,2,4,2"/>
+            </StackPanel>
+        </DataTemplate>
+        
         <DataTemplate DataType="{x:Type l:Error}">
             <StackPanel Orientation="Horizontal">
                 <Rectangle Name="icon"

--- a/src/StructuredLogViewer.Avalonia/App.xaml
+++ b/src/StructuredLogViewer.Avalonia/App.xaml
@@ -10,6 +10,7 @@
                 <ResourceInclude Source="resm:StructuredLogViewer.Avalonia.Resources.xaml?assembly=StructuredLogViewer.Avalonia" />
             </ResourceDictionary.MergedDictionaries>
             
+            <s:ProxyNodeIconConverter x:Key="ProxyNodeIconConverter" />
             <s:ProjectIconConverter x:Key="ProjectIconConverter" />
         </ResourceDictionary>
     </Application.Resources>
@@ -468,14 +469,8 @@
         <TreeDataTemplate DataType="{x:Type common:ProxyNode}"
                           ItemsSource="{Binding Children}">
             <StackPanel Orientation="Horizontal">
-                <Rectangle Name="icon"
-                           Width="14"
-                           Height="11"
-                           Stroke="{DynamicResource ParameterStroke}"
-                           StrokeThickness="1"
-                           Margin="3,5,6,3"
-                           Fill="{DynamicResource ParameterBrush}"
-                           VerticalAlignment="Top" />
+                <ContentPresenter Content="{Binding Converter={StaticResource ProxyNodeIconConverter}}"
+                                  VerticalAlignment="Top" />
                 <ItemsControl Items="{Binding Highlights}"
                               Focusable="False">
                     <ItemsControl.DataTemplates>
@@ -492,170 +487,6 @@
                     </ItemsControl.ItemsPanel>
                 </ItemsControl>
             </StackPanel>
-            <!--<TreeDataTemplate.Triggers>
-                <DataTrigger Binding="{Binding OriginalType}"
-                             Value="Folder">
-                    <Setter TargetName="icon"
-                            Property="Stroke"
-                            Value="{DynamicResource FolderStroke}" />
-                    <Setter TargetName="icon"
-                            Property="Fill"
-                            Value="{DynamicResource ClosedFolderBrush}" />
-                </DataTrigger>
-                <DataTrigger Binding="{Binding OriginalType}"
-                             Value="Target">
-                    <Setter TargetName="icon"
-                            Property="Stroke"
-                            Value="{DynamicResource TargetStroke}" />
-                    <Setter TargetName="icon"
-                            Property="Fill"
-                            Value="{DynamicResource TargetBrush}" />
-                </DataTrigger>
-                <DataTrigger Binding="{Binding OriginalType}"
-                             Value="Task">
-                    <Setter TargetName="icon"
-                            Property="Stroke"
-                            Value="{DynamicResource TaskStroke}" />
-                    <Setter TargetName="icon"
-                            Property="Fill"
-                            Value="{DynamicResource TaskBrush}" />
-                </DataTrigger>
-                <DataTrigger Binding="{Binding OriginalType}"
-                             Value="AddItem">
-                    <Setter TargetName="icon"
-                            Property="Stroke"
-                            Value="{DynamicResource ItemStroke}" />
-                    <Setter TargetName="icon"
-                            Property="Fill"
-                            Value="{DynamicResource ItemBrush}" />
-                </DataTrigger>
-                <DataTrigger Binding="{Binding OriginalType}"
-                             Value="RemoveItem">
-                    <Setter TargetName="icon"
-                            Property="Stroke"
-                            Value="{DynamicResource ItemStroke}" />
-                    <Setter TargetName="icon"
-                            Property="Fill"
-                            Value="{DynamicResource ItemBrush}" />
-                </DataTrigger>
-                <DataTrigger Binding="{Binding OriginalType}"
-                             Value="Item">
-                    <Setter TargetName="icon"
-                            Property="Stroke"
-                            Value="{DynamicResource ItemStroke}" />
-                    <Setter TargetName="icon"
-                            Property="Fill"
-                            Value="{DynamicResource ItemBrush}" />
-                </DataTrigger>
-                <DataTrigger Binding="{Binding OriginalType}"
-                             Value="Metadata">
-                    <Setter TargetName="icon"
-                            Property="Stroke"
-                            Value="{DynamicResource MetadataStroke}" />
-                    <Setter TargetName="icon"
-                            Property="Fill"
-                            Value="{DynamicResource ItemBrush}" />
-                </DataTrigger>
-                <DataTrigger Binding="{Binding OriginalType}"
-                             Value="Property">
-                    <Setter TargetName="icon"
-                            Property="Stroke"
-                            Value="{DynamicResource PropertyStroke}" />
-                    <Setter TargetName="icon"
-                            Property="Fill"
-                            Value="{DynamicResource PropertyBrush}" />
-                </DataTrigger>
-                <DataTrigger Binding="{Binding OriginalType}"
-                             Value="Parameter">
-                    <Setter TargetName="icon"
-                            Property="Stroke"
-                            Value="{DynamicResource ParameterStroke}" />
-                    <Setter TargetName="icon"
-                            Property="Fill"
-                            Value="{DynamicResource ParameterBrush}" />
-                </DataTrigger>
-                <DataTrigger Binding="{Binding OriginalType}"
-                             Value="Message">
-                    <Setter TargetName="icon"
-                            Property="Stroke"
-                            Value="{DynamicResource MessageStroke}" />
-                    <Setter TargetName="icon"
-                            Property="Fill"
-                            Value="{DynamicResource MessageBrush}" />
-                </DataTrigger>
-                <DataTrigger Binding="{Binding OriginalType}"
-                             Value="Error">
-                    <Setter TargetName="icon"
-                            Property="Stroke"
-                            Value="{DynamicResource ErrorStroke}" />
-                    <Setter TargetName="icon"
-                            Property="Fill"
-                            Value="{DynamicResource ErrorBrush}" />
-                </DataTrigger>
-                <DataTrigger Binding="{Binding OriginalType}"
-                             Value="Warning">
-                    <Setter TargetName="icon"
-                            Property="Stroke"
-                            Value="{DynamicResource WarningStroke}" />
-                    <Setter TargetName="icon"
-                            Property="Fill"
-                            Value="{DynamicResource WarningBrush}" />
-                </DataTrigger>
-                <DataTrigger Binding="{Binding ProjectExtension}"
-                             Value=".sln">
-                    <Setter TargetName="icon"
-                            Property="Fill"
-                            Value="{DynamicResource SlnIcon}" />
-                    <Setter TargetName="icon"
-                            Property="Height"
-                            Value="16" />
-                    <Setter TargetName="icon"
-                            Property="Width"
-                            Value="16" />
-                    <Setter TargetName="icon"
-                            Property="Stroke"
-                            Value="Transparent" />
-                    <Setter TargetName="icon"
-                            Property="Margin"
-                            Value="2,2,6,2" />
-                </DataTrigger>
-                <DataTrigger Binding="{Binding ProjectExtension}"
-                             Value=".csproj">
-                    <Setter TargetName="icon"
-                            Property="Fill"
-                            Value="{DynamicResource CSProjIcon}" />
-                    <Setter TargetName="icon"
-                            Property="Height"
-                            Value="16" />
-                    <Setter TargetName="icon"
-                            Property="Width"
-                            Value="16" />
-                    <Setter TargetName="icon"
-                            Property="Stroke"
-                            Value="Transparent" />
-                    <Setter TargetName="icon"
-                            Property="Margin"
-                            Value="2,2,6,2" />
-                </DataTrigger>
-                <DataTrigger Binding="{Binding ProjectExtension}"
-                             Value="other">
-                    <Setter TargetName="icon"
-                            Property="Fill"
-                            Value="{DynamicResource GenericProjectIcon}" />
-                    <Setter TargetName="icon"
-                            Property="Height"
-                            Value="16" />
-                    <Setter TargetName="icon"
-                            Property="Width"
-                            Value="16" />
-                    <Setter TargetName="icon"
-                            Property="Stroke"
-                            Value="Transparent" />
-                    <Setter TargetName="icon"
-                            Property="Margin"
-                            Value="2,2,6,2" />
-                </DataTrigger>
-            </TreeDataTemplate.Triggers>-->
         </TreeDataTemplate>
 
         <DataTemplate DataType="{x:Type common:WelcomeScreen}">

--- a/src/StructuredLogViewer.Avalonia/Controls/BuildControl.xaml
+++ b/src/StructuredLogViewer.Avalonia/Controls/BuildControl.xaml
@@ -51,6 +51,7 @@
                                               BorderBrush="Transparent"
                                               BorderThickness="0"
                                               Classes="searchable"
+                                              AutoScrollToSelectedItem="True"
                                               Items="{Binding Children}"/>
                                 </TabItem>
 
@@ -103,7 +104,8 @@
                                     <ControlTemplate>
                                         <Polygon Points="0,0 3,3 0,6"
                                                  Stroke="Black"
-                                                 Fill="Black" />
+                                                 Fill="Black"
+                                                 VerticalAlignment="Center" />
                                     </ControlTemplate>
                                 </Setter>
                             </Style>

--- a/src/StructuredLogViewer.Avalonia/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer.Avalonia/Controls/BuildControl.xaml.cs
@@ -15,6 +15,7 @@ using Avalonia.Input;
 using Avalonia;
 using Avalonia.Styling;
 using Avalonia.Data;
+using Avalonia.Layout;
 
 namespace StructuredLogViewer.Avalonia.Controls
 {
@@ -147,7 +148,7 @@ namespace StructuredLogViewer.Avalonia.Controls
 
             searchLogControl.ResultsList.Styles.Add(treeViewItemStyle);
             RegisterTreeViewHandlers(searchLogControl.ResultsList);
-            searchLogControl.ResultsList.PropertyChanged += ResultsList_SelectionChanged;
+            searchLogControl.ResultsList.SelectionChanged += ResultsList_SelectionChanged;
             searchLogControl.ResultsList.GotFocus += (s, a) => ActiveTreeView = searchLogControl.ResultsList;
             searchLogControl.ResultsList.ContextMenu = sharedTreeContextMenu;
 
@@ -556,10 +557,8 @@ Recent:
             }
         }
 
-        private void ResultsList_SelectionChanged(object sender, AvaloniaPropertyChangedEventArgs e)
+        private void ResultsList_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (e.Property != TreeView.SelectedItemProperty) return;
-
             var proxy = searchLogControl.ResultsList.SelectedItem as ProxyNode;
             if (proxy != null)
             {
@@ -625,14 +624,16 @@ Recent:
 
         public void SelectItem(ParentedNode item)
         {
-            var parentChain = item.GetParentChainIncludingThis();
-            if (!parentChain.Any())
+            var parentChain = item.GetParentChainExcludingThis();
+            
+            foreach (var node in parentChain)
             {
-                return;
+                if (node is TreeNode treeNode)
+                    treeNode.IsExpanded = true;
             }
 
             SelectTree();
-            treeView.SelectedItem = parentChain;
+            treeView.SelectedItem = item;
         }
 
         private void TreeView_KeyDown(object sender, KeyEventArgs args)

--- a/src/StructuredLogViewer.Avalonia/Controls/ProjectIconConverter.cs
+++ b/src/StructuredLogViewer.Avalonia/Controls/ProjectIconConverter.cs
@@ -3,16 +3,17 @@ using System.Collections.Generic;
 using System.Globalization;
 using Avalonia;
 using Avalonia.Data.Converters;
+using Avalonia.Media;
 
 namespace StructuredLogViewer.Avalonia.Controls
 {
     public class ProjectIconConverter : IValueConverter
     {
-        private readonly Dictionary<string, object> icons = new Dictionary<string, object>();
-            
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        private readonly Dictionary<string, DrawingGroup> icons = new Dictionary<string, DrawingGroup>();
+
+        public DrawingGroup ProjectExtensionToIcon(string projectExtension)
         {
-            switch (value as string)
+            switch (projectExtension)
             {
                 case ".sln":
                     return GetIcon("SlnIcon");
@@ -31,18 +32,22 @@ namespace StructuredLogViewer.Avalonia.Controls
             }
         }
 
-        private object GetIcon(string resourceName)
+        private DrawingGroup GetIcon(string resourceName)
         {
             if (!icons.TryGetValue(resourceName, out var icon))
             {
-                if (!Application.Current.Resources.TryGetResource(resourceName, out icon))
-                    icon = null;
+                if (!Application.Current.Resources.TryGetResource(resourceName, out var resource))
+                    resource = null;
 
+                icon = resource as DrawingGroup;
                 icons[resourceName] = icon;
             }
 
             return icon;
         }
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) 
+            => ProjectExtensionToIcon(value as string);
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) 
             => throw new NotSupportedException();

--- a/src/StructuredLogViewer.Avalonia/Controls/ProxyNodeIconConverter.cs
+++ b/src/StructuredLogViewer.Avalonia/Controls/ProxyNodeIconConverter.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+using Microsoft.Build.Logging.StructuredLogger;
+
+namespace StructuredLogViewer.Avalonia.Controls
+{
+    public class ProxyNodeIconConverter : IValueConverter
+    {
+        private readonly Dictionary<string, object> resources = new Dictionary<string, object>();
+        private readonly ProjectIconConverter projectIconConverter = new ProjectIconConverter();
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var node = value as ProxyNode;
+            if (node == null)
+                return null;
+
+            switch (node.OriginalType)
+            {
+                case nameof(Build):
+                case nameof(Property):
+                    return NodeIcon("PropertyStroke", "PropertyBrush");
+                case nameof(Folder):
+                    return NodeIcon("FolderStroke", "ClosedFolderBrush");
+                case nameof(Target):
+                    return NodeIcon("TargetStroke", "TargetBrush");
+                case nameof(Task):
+                    return NodeIcon("TaskStroke", "TaskBrush");
+                case nameof(AddItem):
+                    return NodeIcon("ItemStroke", "ItemBrush");
+                case nameof(RemoveItem):
+                    return NodeIcon("ItemStroke", "ItemBrush");
+                case nameof(Item):
+                    return NodeIcon("ItemStroke", "ItemBrush");
+                case nameof(Metadata):
+                    return NodeIcon("MetadataStroke", "ItemBrush");
+                case nameof(Parameter):
+                    return NodeIcon("ParameterStroke", "ParameterBrush");
+                case nameof(Message):
+                    return NodeIcon("MessageStroke", "MessageBrush");
+                case nameof(Error):
+                    return NodeIcon("ErrorStroke", "ErrorBrush");
+                case nameof(Warning):
+                    return NodeIcon("WarningStroke", "WarningBrush");
+                case nameof(Import):
+                    return NodeIcon("ImportStroke", "ImportBrush");
+                case nameof(NoImport):
+                    return NodeIcon("NoImportStroke", "NoImportBrush");
+                case nameof(Project):
+                    return ProjectIcon(node.ProjectExtension);
+                default:
+                    return NodeIcon(null, null);
+            }
+        }
+
+        private Rectangle NodeIcon(string stroke, string fill)
+        {
+            return new Rectangle
+            {
+                Width = 14,
+                Height = 11,
+                Margin = new Thickness(3, 5, 6, 3),
+                Stroke = GetResource(stroke) as IBrush,
+                StrokeThickness = 1,
+                Fill = GetResource(fill) as IBrush,
+                VerticalAlignment = VerticalAlignment.Top
+            };
+        }
+
+        private object ProjectIcon(string projectExtension)
+        {
+            return new DrawingPresenter
+            {
+                Width = 16,
+                Height = 16,
+                Margin = new Thickness(2, 4, 6, 2),
+                Drawing = projectIconConverter.ProjectExtensionToIcon(projectExtension),
+                VerticalAlignment = VerticalAlignment.Top
+            };
+        }
+        
+        private object GetResource(string resourceName)
+        {
+            if (string.IsNullOrEmpty(resourceName))
+                return null;
+            
+            if (!resources.TryGetValue(resourceName, out var resource))
+            {
+                if (!Application.Current.Resources.TryGetResource(resourceName, out resource))
+                    resource = null;
+
+                resources[resourceName] = resource;
+            }
+
+            return resource;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) 
+            => throw new NotSupportedException();
+    }
+}

--- a/src/StructuredLogViewer.Avalonia/Controls/ProxyNodeIconConverter.cs
+++ b/src/StructuredLogViewer.Avalonia/Controls/ProxyNodeIconConverter.cs
@@ -63,13 +63,9 @@ namespace StructuredLogViewer.Avalonia.Controls
         {
             return new Rectangle
             {
-                Width = 14,
-                Height = 11,
-                Margin = new Thickness(3, 5, 6, 3),
+                Classes = { "nodeIcon" },
                 Stroke = GetResource(stroke) as IBrush,
-                StrokeThickness = 1,
-                Fill = GetResource(fill) as IBrush,
-                VerticalAlignment = VerticalAlignment.Top
+                Fill = GetResource(fill) as IBrush
             };
         }
 
@@ -77,19 +73,16 @@ namespace StructuredLogViewer.Avalonia.Controls
         {
             return new DrawingPresenter
             {
-                Width = 16,
-                Height = 16,
-                Margin = new Thickness(2, 4, 6, 2),
-                Drawing = projectIconConverter.ProjectExtensionToIcon(projectExtension),
-                VerticalAlignment = VerticalAlignment.Top
+                Classes = { "projectNodeIcon" },
+                Drawing = projectIconConverter.ProjectExtensionToIcon(projectExtension)
             };
         }
-        
+
         private object GetResource(string resourceName)
         {
             if (string.IsNullOrEmpty(resourceName))
                 return null;
-            
+
             if (!resources.TryGetValue(resourceName, out var resource))
             {
                 if (!Application.Current.Resources.TryGetResource(resourceName, out resource))
@@ -101,7 +94,7 @@ namespace StructuredLogViewer.Avalonia.Controls
             return resource;
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) 
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
             => throw new NotSupportedException();
     }
 }

--- a/src/StructuredLogViewer.Avalonia/Controls/TextViewerControl.xaml
+++ b/src/StructuredLogViewer.Avalonia/Controls/TextViewerControl.xaml
@@ -43,6 +43,7 @@
 
         <a:TextEditor Name="textEditor"
                       Grid.Row="1"
+                      ShowLineNumbers="True"
                       LineNumbersForeground="Teal"
                       FontSize="14">
             <a:TextEditor.ContextMenu>

--- a/src/StructuredLogViewer.Avalonia/Controls/TextViewerControl.xaml.cs
+++ b/src/StructuredLogViewer.Avalonia/Controls/TextViewerControl.xaml.cs
@@ -15,7 +15,6 @@ using Avalonia.Interactivity;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Xml;
-using AvaloniaEdit.Editing;
 using AvaloniaEdit.Highlighting.Xshd;
 
 namespace StructuredLogViewer.Avalonia.Controls
@@ -54,20 +53,10 @@ namespace StructuredLogViewer.Avalonia.Controls
                 textEditor.FontFamily = "Monospace";
             }
 
-            // TOOD: add
-            //SearchPanel.Install(textEditor.TextArea);
-
-            // TODO: remove this after bug fix
-            var lineMargin = new LineNumberMargin { Margin = new Thickness(0, 0, 10, 0) };
-            lineMargin[~TextBlock.ForegroundProperty] = textEditor[~TextEditor.LineNumbersForegroundProperty];
-            textEditor.TextArea.LeftMargins.Insert(0, lineMargin);
-
             textEditor.TextArea.PointerPressed += TextAreaMouseRightButtonDown;
 
             var textView = textEditor.TextArea.TextView;
-            textView.CurrentLineBackground = new SolidColorBrush(Color.FromRgb(224, 224, 224));
-            textView.CurrentLineBorder = new Pen(Brushes.Transparent, 0);
-            //textView.Options.HighlightCurrentLine = true;
+            textView.Options.HighlightCurrentLine = true;
             textView.Options.EnableEmailHyperlinks = false;
             textView.Options.EnableHyperlinks = false;
             textEditor.IsReadOnly = true;
@@ -150,11 +139,10 @@ namespace StructuredLogViewer.Avalonia.Controls
                 var highlighting = HighlightingManager.Instance.GetDefinition("XML");
                 highlighting.GetNamedColor("XmlTag").Foreground = new SimpleHighlightingBrush(Color.FromRgb(163, 21, 21));
                 textEditor.SyntaxHighlighting = highlighting;
-
-                // TODO
-                //var foldingManager = FoldingManager.Install(textEditor.TextArea);
-                //var foldingStrategy = new XmlFoldingStrategy();
-                //foldingStrategy.UpdateFoldings(foldingManager, textEditor.Document);
+                
+                var foldingManager = FoldingManager.Install(textEditor.TextArea);
+                var foldingStrategy = new XmlFoldingStrategy();
+                foldingStrategy.UpdateFoldings(foldingManager, textEditor.Document);
             }
             else if (!looksLikeXml && IsXml)
             {
@@ -176,8 +164,8 @@ namespace StructuredLogViewer.Avalonia.Controls
             {
                 Dispatcher.UIThread.InvokeAsync(() =>
                 {
-                    textEditor.ScrollToLine(lineNumber);
                     textEditor.TextArea.Caret.Line = lineNumber;
+                    textEditor.TextArea.Caret.BringCaretToView();
                     textEditor.TextArea.TextView.HighlightedLine = lineNumber;
 
                     if (column > 0)

--- a/src/StructuredLogViewer.Avalonia/MainWindow.xaml
+++ b/src/StructuredLogViewer.Avalonia/MainWindow.xaml
@@ -1,4 +1,8 @@
-﻿<Window xmlns="https://github.com/avaloniaui">
+﻿<Window xmlns="https://github.com/avaloniaui"
+        WindowState="Maximized"
+        WindowStartupLocation="CenterScreen"
+        KeyUp="Window_KeyUp">
+    
     <DockPanel>
         <Menu Name="mainMenu"
               DockPanel.Dock="Top">

--- a/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
@@ -1164,10 +1164,8 @@ Recent:
             {
                 TreeNode parent = root;
 
-                var parentedNode = result.Node as ParentedNode;
-                if (parentedNode != null)
+                if (result.Node is ParentedNode parentedNode)
                 {
-                    var chain = parentedNode.GetParentChainIncludingThis();
                     var project = parentedNode.GetNearestParent<Project>();
                     if (project != null)
                     {

--- a/src/StructuredLogViewer/themes/Generic.xaml
+++ b/src/StructuredLogViewer/themes/Generic.xaml
@@ -151,11 +151,20 @@
       </DrawingGroup>
     </DrawingBrush.Drawing>
   </DrawingBrush>
+  
+  <Style x:Key="NodeIcon" TargetType="{x:Type Rectangle}">
+    <Setter Property="Width" Value="14" />
+    <Setter Property="Height" Value="11" />
+    <Setter Property="Margin" Value="3,3,6,3" />
+    <Setter Property="StrokeThickness" Value="1" />
+    <Setter Property="VerticalAlignment" Value="Top" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+  </Style>
 
   <HierarchicalDataTemplate DataType="{x:Type l:Folder}"
                             ItemsSource="{Binding Children}">
     <StackPanel Orientation="Horizontal">
-      <Rectangle x:Name="icon" Width="14" Height="11" Stroke="{StaticResource FolderStroke}" Margin="3,3,6,3" Fill="{StaticResource ClosedFolderBrush}" />
+      <Rectangle x:Name="icon" Style="{StaticResource NodeIcon}" Stroke="{StaticResource FolderStroke}" Fill="{StaticResource ClosedFolderBrush}" />
       <TextBlock x:Name="nameText" Text="{Binding Name}" />
     </StackPanel>
     <HierarchicalDataTemplate.Triggers>
@@ -172,8 +181,10 @@
   <HierarchicalDataTemplate DataType="{x:Type l:Project}"
                             ItemsSource="{Binding Children}">
     <StackPanel Orientation="Horizontal" x:Name="projectRoot">
-      <Rectangle x:Name="icon" Width="16" Height="16" Margin="2,2,6,2" Fill="{StaticResource GenericProjectIcon}" VerticalAlignment="Top" />
-      <TextBlock Text="{Binding Name}" Margin="0,1,0,0" />
+      <Rectangle x:Name="icon" Style="{StaticResource NodeIcon}"
+                 Width="16" Height="16" Margin="2,2,6,2" StrokeThickness="0"
+                 Fill="{StaticResource GenericProjectIcon}" />
+      <TextBlock Text="{Binding Name}" Margin="0,2,0,0" />
     </StackPanel>
     <HierarchicalDataTemplate.Triggers>
       <DataTrigger Binding="{Binding IsLowRelevance}" Value="True">
@@ -197,7 +208,7 @@
   <HierarchicalDataTemplate DataType="{x:Type l:Target}"
                             ItemsSource="{Binding Children}">
     <StackPanel Orientation="Horizontal" x:Name="targetRoot">
-      <Rectangle x:Name="icon" Width="14" Height="11" Stroke="{StaticResource TargetStroke}" Margin="3,3,6,3" Fill="{StaticResource TargetBrush}" VerticalAlignment="Top" />
+      <Rectangle x:Name="icon" Style="{StaticResource NodeIcon}" Stroke="{StaticResource TargetStroke}" Fill="{StaticResource TargetBrush}" />
       <TextBlock x:Name="label" Text="Target " />
       <TextBlock Text="{Binding Name}" />
     </StackPanel>
@@ -214,7 +225,7 @@
   <HierarchicalDataTemplate DataType="{x:Type l:Task}"
                             ItemsSource="{Binding Children}">
     <StackPanel Orientation="Horizontal">
-      <Rectangle x:Name="icon" Width="14" Height="11" Stroke="{StaticResource TaskStroke}" Margin="3,3,6,3" Fill="{StaticResource TaskBrush}" VerticalAlignment="Top" />
+      <Rectangle x:Name="icon" Style="{StaticResource NodeIcon}" Stroke="{StaticResource TaskStroke}" Fill="{StaticResource TaskBrush}" />
       <TextBlock x:Name="label" Text="Task " />
       <TextBlock Text="{Binding Title}" />
       <TextBlock x:Name="duration" Text="{Binding DurationText}" Margin="6,0,0,0" />
@@ -230,7 +241,7 @@
   <HierarchicalDataTemplate DataType="{x:Type l:AddItem}"
                             ItemsSource="{Binding Children}">
     <StackPanel Orientation="Horizontal">
-      <Rectangle x:Name="icon" Width="14" Height="11" Stroke="{StaticResource ItemStroke}" Margin="3,3,6,3" Fill="{StaticResource ItemBrush}" VerticalAlignment="Top" />
+      <Rectangle x:Name="icon" Style="{StaticResource NodeIcon}" Stroke="{StaticResource ItemStroke}" Fill="{StaticResource ItemBrush}" />
       <TextBlock x:Name="label" Text="Add Item " />
       <TextBlock Text="{Binding Name}" />
     </StackPanel>
@@ -244,7 +255,7 @@
   <HierarchicalDataTemplate DataType="{x:Type l:RemoveItem}"
                             ItemsSource="{Binding Children}">
     <StackPanel Orientation="Horizontal">
-      <Rectangle x:Name="icon" Width="14" Height="11" Stroke="{StaticResource ItemStroke}" Margin="3,3,6,3" Fill="{StaticResource ItemBrush}" VerticalAlignment="Top" />
+      <Rectangle x:Name="icon" Style="{StaticResource NodeIcon}" Stroke="{StaticResource ItemStroke}" Fill="{StaticResource ItemBrush}" />
       <TextBlock x:Name="label" Text="Remove Item " />
       <TextBlock Text="{Binding Name}" />
     </StackPanel>
@@ -258,7 +269,7 @@
   <HierarchicalDataTemplate DataType="{x:Type l:Item}"
                             ItemsSource="{Binding Children}">
     <StackPanel Orientation="Horizontal">
-      <Rectangle x:Name="icon" Width="14" Height="11" Stroke="{StaticResource ItemStroke}" Margin="3,3,6,3" Fill="{StaticResource ItemBrush}" VerticalAlignment="Top" />
+      <Rectangle x:Name="icon" Style="{StaticResource NodeIcon}" Stroke="{StaticResource ItemStroke}" Fill="{StaticResource ItemBrush}" />
       <TextBlock x:Name="nameAndEquals" Text="{Binding NameAndEquals}" />
       <TextBlock Text="{Binding ShortenedText}" />
     </StackPanel>
@@ -271,7 +282,7 @@
 
   <DataTemplate DataType="{x:Type l:Metadata}">
     <StackPanel Orientation="Horizontal">
-      <Rectangle x:Name="icon" Width="14" Height="11" Stroke="{StaticResource MetadataStroke}" Margin="3,3,6,3" Fill="{StaticResource ItemBrush}" VerticalAlignment="Top" />
+      <Rectangle x:Name="icon" Style="{StaticResource NodeIcon}" Stroke="{StaticResource MetadataStroke}" Fill="{StaticResource ItemBrush}" />
       <TextBlock x:Name="label" Text="{Binding NameAndEquals, Mode=OneTime}" />
       <TextBlock Text="{Binding ShortenedValue}" />
     </StackPanel>
@@ -316,7 +327,7 @@
 
   <DataTemplate DataType="{x:Type l:Property}">
     <StackPanel Orientation="Horizontal">
-      <Rectangle x:Name="icon" Width="14" Height="11" Stroke="{StaticResource PropertyStroke}" Margin="3,3,6,3" Fill="{StaticResource PropertyBrush}" VerticalAlignment="Top" />
+      <Rectangle x:Name="icon" Style="{StaticResource NodeIcon}" Stroke="{StaticResource PropertyStroke}" Fill="{StaticResource PropertyBrush}" />
       <TextBlock x:Name="label" Text="{Binding NameAndEquals, Mode=OneTime}" />
       <TextBlock Text="{Binding ShortenedValue}" />
     </StackPanel>
@@ -330,7 +341,7 @@
   <HierarchicalDataTemplate DataType="{x:Type l:Parameter}"
                             ItemsSource="{Binding Children}">
     <StackPanel Orientation="Horizontal">
-      <Rectangle x:Name="icon" Width="14" Height="11" Stroke="{StaticResource ParameterStroke}" Margin="3,3,6,3" Fill="{StaticResource ParameterBrush}" VerticalAlignment="Top" />
+      <Rectangle x:Name="icon" Style="{StaticResource NodeIcon}" Stroke="{StaticResource ParameterStroke}" Fill="{StaticResource ParameterBrush}" />
       <TextBlock x:Name="name" Text="{Binding Name}" />
     </StackPanel>
     <HierarchicalDataTemplate.Triggers>
@@ -342,7 +353,7 @@
 
   <DataTemplate DataType="{x:Type l:Message}">
     <StackPanel Orientation="Horizontal">
-      <Rectangle x:Name="icon" Width="14" Height="11" Stroke="{StaticResource MessageStroke}" Margin="3,3,6,3" Fill="{StaticResource MessageBrush}" VerticalAlignment="Top" />
+      <Rectangle x:Name="icon" Style="{StaticResource NodeIcon}" Stroke="{StaticResource MessageStroke}" Fill="{StaticResource MessageBrush}" />
       <TextBlock x:Name="messageText" Text="{Binding ShortenedText}" />
     </StackPanel>
     <DataTemplate.Triggers>
@@ -355,13 +366,7 @@
   <HierarchicalDataTemplate DataType="{x:Type l:Import}"
                             ItemsSource="{Binding Children}">
     <StackPanel Orientation="Horizontal" x:Name="importPanel">
-      <Rectangle x:Name="icon" 
-                 Width="14" 
-                 Height="11" 
-                 Stroke="{StaticResource ImportStroke}" 
-                 Margin="3,3,6,3" 
-                 Fill="{StaticResource ImportBrush}" 
-                 VerticalAlignment="Top" />
+      <Rectangle x:Name="icon" Style="{StaticResource NodeIcon}" Stroke="{StaticResource ImportStroke}" Fill="{StaticResource ImportBrush}" />
       <TextBlock x:Name="label" Text="Import" Margin="0,0,6,0" />
       <TextBlock x:Name="name" Text="{Binding Name}" />
       <TextBlock x:Name="location" Text="{Binding Location}" />
@@ -379,13 +384,7 @@
   <HierarchicalDataTemplate DataType="{x:Type l:NoImport}"
                             ItemsSource="{Binding Children}">
     <StackPanel Orientation="Horizontal" x:Name="importPanel">
-      <Rectangle x:Name="icon"
-                 Width="14"
-                 Height="11"
-                 Stroke="{StaticResource NoImportStroke}"
-                 Margin="3,3,6,3"
-                 Fill="{StaticResource NoImportBrush}"
-                 VerticalAlignment="Top" />
+      <Rectangle x:Name="icon" Style="{StaticResource NodeIcon}" Stroke="{StaticResource NoImportStroke}" Fill="{StaticResource NoImportBrush}" />
       <TextBlock x:Name="label" Text="NoImport" Margin="0,0,6,0" />
       <TextBlock x:Name="name" Text="{Binding Name}" />
       <TextBlock x:Name="location" Text="{Binding Location}" Margin="0,0,6,0" />
@@ -413,7 +412,7 @@
 
   <DataTemplate DataType="{x:Type l:Error}">
     <StackPanel Orientation="Horizontal">
-      <Rectangle x:Name="icon" Width="14" Height="11" Stroke="{StaticResource ErrorStroke}" Margin="3,3,6,3" Fill="{StaticResource ErrorBrush}" VerticalAlignment="Top" />
+      <Rectangle x:Name="icon" Style="{StaticResource NodeIcon}" Stroke="{StaticResource ErrorStroke}" Fill="{StaticResource ErrorBrush}" />
       <TextBlock x:Name="text" Text="{Binding}" />
     </StackPanel>
     <DataTemplate.Triggers>
@@ -425,7 +424,7 @@
 
   <DataTemplate DataType="{x:Type l:Warning}">
     <StackPanel Orientation="Horizontal">
-      <Rectangle x:Name="icon" Width="14" Height="11" Stroke="{StaticResource WarningStroke}" Margin="3,3,6,3" Fill="{StaticResource WarningBrush}" VerticalAlignment="Top" />
+      <Rectangle x:Name="icon" Style="{StaticResource NodeIcon}" Stroke="{StaticResource WarningStroke}" Fill="{StaticResource WarningBrush}" />
       <TextBlock Text="{Binding}" />
     </StackPanel>
   </DataTemplate>
@@ -443,7 +442,7 @@
   <HierarchicalDataTemplate DataType="{x:Type l:SourceFile}"
                             ItemsSource="{Binding Children}">
     <StackPanel Orientation="Horizontal">
-      <Rectangle x:Name="icon" Width="14" Height="11" Stroke="{StaticResource MessageStroke}" Margin="3,3,6,3" Fill="{StaticResource MessageBrush}" VerticalAlignment="Top" />
+      <Rectangle x:Name="icon" Style="{StaticResource NodeIcon}" Stroke="{StaticResource MessageStroke}" Fill="{StaticResource MessageBrush}" />
       <TextBlock x:Name="messageText" Text="{Binding Name}" />
     </StackPanel>
   </HierarchicalDataTemplate>
@@ -463,8 +462,8 @@
   <HierarchicalDataTemplate DataType="{x:Type core:ProxyNode}"
                             ItemsSource="{Binding Children}">
     <StackPanel Orientation="Horizontal">
-      <Rectangle x:Name="icon" Width="14" Height="11" Stroke="{StaticResource ParameterStroke}" Margin="3,3,6,3" Fill="{StaticResource ParameterBrush}" VerticalAlignment="Top" />
-      <ItemsControl ItemsSource="{Binding Highlights}" Focusable="False">
+      <Rectangle x:Name="icon" Style="{StaticResource NodeIcon}" Stroke="{StaticResource ParameterStroke}" Fill="{StaticResource ParameterBrush}" />
+      <ItemsControl x:Name="text" ItemsSource="{Binding Highlights}" Focusable="False">
         <ItemsControl.Resources>
           <DataTemplate DataType="{x:Type core:HighlightedText}">
             <TextBlock Foreground="Black" Background="Yellow" Text="{Binding Text}" />
@@ -538,22 +537,25 @@
         <Setter TargetName="icon" Property="Fill" Value="{StaticResource SlnIcon}" />
         <Setter TargetName="icon" Property="Height" Value="16" />
         <Setter TargetName="icon" Property="Width" Value="16" />
-        <Setter TargetName="icon" Property="Stroke" Value="Transparent" />
+        <Setter TargetName="icon" Property="StrokeThickness" Value="0" />
         <Setter TargetName="icon" Property="Margin" Value="2,2,6,2" />
+        <Setter TargetName="text" Property="Margin" Value="0,2,0,0" />
       </DataTrigger>
       <DataTrigger Binding="{Binding ProjectExtension}" Value=".csproj">
         <Setter TargetName="icon" Property="Fill" Value="{StaticResource CSProjIcon}" />
         <Setter TargetName="icon" Property="Height" Value="16" />
         <Setter TargetName="icon" Property="Width" Value="16" />
-        <Setter TargetName="icon" Property="Stroke" Value="Transparent" />
+        <Setter TargetName="icon" Property="StrokeThickness" Value="0" />
         <Setter TargetName="icon" Property="Margin" Value="2,2,6,2" />
+        <Setter TargetName="text" Property="Margin" Value="0,2,0,0" />
       </DataTrigger>
       <DataTrigger Binding="{Binding ProjectExtension}" Value="other">
         <Setter TargetName="icon" Property="Fill" Value="{StaticResource GenericProjectIcon}" />
         <Setter TargetName="icon" Property="Height" Value="16" />
         <Setter TargetName="icon" Property="Width" Value="16" />
-        <Setter TargetName="icon" Property="Stroke" Value="Transparent" />
+        <Setter TargetName="icon" Property="StrokeThickness" Value="0" />
         <Setter TargetName="icon" Property="Margin" Value="2,2,6,2" />
+        <Setter TargetName="text" Property="Margin" Value="0,2,0,0" />
       </DataTrigger>
     </HierarchicalDataTemplate.Triggers>
   </HierarchicalDataTemplate>


### PR DESCRIPTION
Here's another round of changes, which aims to significantly improve the search feature in the Avalonia viewer:

- Added the *"show all results"* button
- Added the *"elapsed time"* message
- Search results are now collapsed (Avalonia's `TreeView` does not support virtualization)
- Fixed the node icons in the search results (they were always set to the *Property* icon before)
- Navigate when a search result is selected (for the *"search log"* and *"find in files"* tabs)
- Fixed keyboard shortcuts (so Ctrl+F now works)

This also includes some minor changes in the WPF viewer, for consistency and cleanup:

 - Introduced a `NodeIcon` style to reduce duplication
 - Fixed text alignment on project nodes (whose icons are a  bit taller)
