### PR TITLE
Avalonia: Fix search result marker alignment

### DIFF
--- a/src/StructuredLogViewer.Avalonia/Styles.xaml
+++ b/src/StructuredLogViewer.Avalonia/Styles.xaml
@@ -72,13 +72,13 @@
                                               Padding="{TemplateBinding Padding}"
                                               Grid.Column="1"/>
                             <Ellipse Grid.Column="1"
-                                     Width="6" Height="6" Margin="2,4,0,0" StrokeThickness="1"
+                                     Width="6" Height="6" Margin="1,1,0,0" StrokeThickness="1"
                                      HorizontalAlignment="Left" VerticalAlignment="Top"
                                      Fill="{StaticResource ContainsSearchResultBrush}"
                                      Stroke="{StaticResource ContainsSearchResultStroke}"
                                      IsVisible="{Binding ContainsSearchResult}"/>
                             <Ellipse Grid.Column="1"
-                                     Width="6" Height="6" Margin="2,4,0,0" StrokeThickness="1"
+                                     Width="6" Height="6" Margin="1,1,0,0" StrokeThickness="1"
                                      HorizontalAlignment="Left" VerticalAlignment="Top"
                                      Fill="{StaticResource SearchResultBrush}"
                                      Stroke="{StaticResource SearchResultStroke}"


### PR DESCRIPTION
This is just a minor fix to #266: I messed up the alignment of search markers and didn't notice.