### PR TITLE
Presents targets in Files tree

### DIFF
--- a/src/StructuredLogger/ObjectModel/Target.cs
+++ b/src/StructuredLogger/ObjectModel/Target.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
         public bool Succeeded { get; internal set; }
         public string DependsOnTargets { get; set; }
         public Project Project => GetNearestParent<Project>();
-        public string SourceFilePath { get; internal set; }
+        public string SourceFilePath { get; set; }
 
         public Target()
         {


### PR DESCRIPTION
I've added targets on the FIles's tree.  This makes the target exploration very easy.

![image](https://user-images.githubusercontent.com/7759991/68076695-657cd380-fdb8-11e9-8aa7-8799bab64243.png)
