### PR TITLE
Add location of MsBuild from VS2019

### DIFF
--- a/src/StructuredLogViewer/MSBuildLocator.cs
+++ b/src/StructuredLogViewer/MSBuildLocator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using Microsoft.Build.Locator;
 using Microsoft.Build.Logging.StructuredLogger;
 using Microsoft.Win32;
 
@@ -10,6 +11,19 @@ namespace StructuredLogViewer
 {
     public class MSBuildLocator
     {
+        private static readonly VisualStudioInstanceQueryOptions visualStudioQueryOptions = new VisualStudioInstanceQueryOptions
+        {
+            DiscoveryTypes = DiscoveryType.DotNetSdk | DiscoveryType.DeveloperConsole | DiscoveryType.VisualStudioSetup
+        };
+
+        private static IEnumerable<string> GetMsBuildInstancesFromVisualStudio()
+        {
+            foreach (var instance in Microsoft.Build.Locator.MSBuildLocator.QueryVisualStudioInstances(visualStudioQueryOptions))
+            {
+                yield return Path.Combine(instance.MSBuildPath, "MSBuild.exe");
+            }
+        }
+
         public static string[] GetMSBuildLocations()
         {
             var programFilesX86 = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
@@ -19,12 +33,6 @@ namespace StructuredLogViewer
 
             var hardcoded = new[]
             {
-                Path.Combine(programFilesX86, @"Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe"),
-                Path.Combine(programFilesX86, @"Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\amd64\MSBuild.exe"),
-                Path.Combine(programFilesX86, @"Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\MSBuild.exe"),
-                Path.Combine(programFilesX86, @"Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\amd64\MSBuild.exe"),
-                Path.Combine(programFilesX86, @"Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe"),
-                Path.Combine(programFilesX86, @"Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\amd64\MSBuild.exe"),
                 Path.Combine(programFilesX86, @"MSBuild\14.0\Bin\MSBuild.exe"),
                 Path.Combine(programFilesX86, @"MSBuild\14.0\Bin\amd64\MSBuild.exe"),
                 Path.Combine(programFilesX86, @"MSBuild\12.0\Bin\MSBuild.exe"),
@@ -37,6 +45,7 @@ namespace StructuredLogViewer
             candidates.UnionWith(vs15Locations.Select(l => Path.Combine(l, "MSBuild", "15.0", "Bin", "MSBuild.exe")));
             candidates.UnionWith(vs15Locations.Select(l => Path.Combine(l, "MSBuild", "15.0", "Bin", "amd64", "MSBuild.exe")));
             candidates.UnionWith(hardcoded);
+            candidates.UnionWith(GetMsBuildInstancesFromVisualStudio());
 
             var finalResults = candidates
                 .Where(File.Exists)
@@ -45,7 +54,7 @@ namespace StructuredLogViewer
             return finalResults;
         }
 
-        public static string[] GetVS15Locations()
+        private static string[] GetVS15Locations()
         {
             var programFilesX86 = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
             var installer = Path.Combine(programFilesX86, "Microsoft Visual Studio", "Installer");

--- a/src/StructuredLogViewer/project.json
+++ b/src/StructuredLogViewer/project.json
@@ -1,6 +1,10 @@
 ﻿{
   "dependencies": {
     "AvalonEdit": "5.0.3",
+    "Microsoft.Build.Locator": {
+      "version": "1.2.6",
+      "exclude": "build"
+    },
     "Microsoft.Language.Xml": "1.0.15",
     "Nerdbank.GitVersioning": "2.0.41",
     "squirrel.windows": "1.4.0",


### PR DESCRIPTION
I've removed some of the hardcoded paths and I've used `Microsoft.Build.Locator` for discovering MSBuild instances. Now I'm able to select MSBuild from VS2019 from the suggestion list. No sure, but maybe this  Not sure, but maybe the whole logic of `GetMSBuildLocations` should be implemented using `Microsoft.Build.Locator` - what I mean is to completely get rid of hardcoded paths (at least for Visual Studio).

![image](https://user-images.githubusercontent.com/7759991/68142998-c62f1c00-ff30-11e9-944a-9ec0a1d8f7c6.png)
