### PR TITLE
Sort runtime graph children and fix common properties

### DIFF
--- a/src/StructuredLogViewer.Core/ProjectGraph/MSAGLProjectGraphConstructor.cs
+++ b/src/StructuredLogViewer.Core/ProjectGraph/MSAGLProjectGraphConstructor.cs
@@ -1,10 +1,4 @@
-﻿// --------------------------------------------------------------------
-// 
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
-// --------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;

--- a/src/StructuredLogViewer.Core/ProjectGraph/MSAGLProjectGraphConstructor.cs
+++ b/src/StructuredLogViewer.Core/ProjectGraph/MSAGLProjectGraphConstructor.cs
@@ -69,12 +69,36 @@ namespace StructuredLogViewer.Core.ProjectGraph
                 RecursiveAddNode(root, graph, commonGlobalProperties);
             }
 
+            AddVirtualBuildRequestNodes(graph);
+
             if (commonGlobalProperties.Any())
             {
                 AddNodeForCommonGlobalProperties(commonGlobalProperties, graph);
             }
 
+
             return graph;
+        }
+
+        private void AddVirtualBuildRequestNodes(Graph graph)
+        {
+            var rootNodes = graph.Nodes.Where(n => !n.InEdges.Any()).ToArray();
+
+            foreach (var rootNode in rootNodes)
+            {
+                if (rootNode.UserData != null && rootNode.UserData is Project project)
+                {
+                    var node = graph.AddNode("Build Request");
+                    node.Attr.Color = Color.Gray;
+                    node.Label.FontColor = Color.Gray;
+
+                    var edge = new Edge(node, rootNode, ConnectionToGraph.Connected);
+                    node.AddOutEdge(edge);
+
+                    edge.LabelText = GetTargetString(project);
+                    edge.Label.FontColor = Color.Gray;
+                }
+            }
         }
 
         private void RecursiveAddNode(RuntimeGraph.RuntimeGraphNode node, Graph graph, IDictionary<string, string> commonGlobalProperties)

--- a/src/StructuredLogViewer.Core/ProjectGraph/RuntimeGraph.cs
+++ b/src/StructuredLogViewer.Core/ProjectGraph/RuntimeGraph.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.Build.Logging.StructuredLogger;
+
+#nullable enable
+
+namespace StructuredLogViewer.Core.ProjectGraph
+{
+    public class RuntimeGraph
+    {
+        public class RuntimeGraphNode
+        {
+            private SortedList<DateTime, RuntimeGraphNode>? sortedChildren;
+            private IReadOnlyList<RuntimeGraphNode>? sortedChildrenCached;
+            public Project Project { get; }
+            public RuntimeGraphNode? Parent { get; internal set; }
+
+            /// <summary>
+            ///     Sorted by <see cref="Microsoft.Build.Logging.StructuredLogger.Project.StartTime" />
+            /// </summary>
+            public IReadOnlyList<RuntimeGraphNode> SortedChildren
+            {
+                get
+                {
+                    if (sortedChildren == null)
+                    {
+                        return ImmutableList<RuntimeGraphNode>.Empty;
+                    }
+
+                    sortedChildrenCached ??= sortedChildren.Values.ToImmutableList();
+                    return sortedChildrenCached;
+                }
+            }
+
+            public RuntimeGraphNode(Project p)
+            {
+                Project = p;
+            }
+
+            internal void AddChild(RuntimeGraphNode child)
+            {
+                if (sortedChildren == null)
+                {
+                    sortedChildren = new SortedList<DateTime, RuntimeGraphNode>();
+                }
+
+                sortedChildren.Add(child.Project.StartTime, child);
+                sortedChildrenCached = null;
+            }
+        }
+
+        /// <summary>
+        ///     Sorted by <see cref="Project.StartTime" />
+        /// </summary>
+        public IReadOnlyList<RuntimeGraphNode> SortedRoots { get; }
+
+        public ICollection<RuntimeGraphNode> Nodes { get; }
+
+        private RuntimeGraph(IReadOnlyList<RuntimeGraphNode> sortedRoots, ICollection<RuntimeGraphNode> nodes)
+        {
+            SortedRoots = sortedRoots;
+            Nodes = nodes;
+        }
+
+        public static RuntimeGraph FromBuild(Build build)
+        {
+            var projects = build.FindChildrenRecursive<Project>();
+            var runtimeNodes = new ConcurrentDictionary<Project, RuntimeGraphNode>(1, projects.Count);
+
+            foreach (var project in projects)
+            {
+                var node = GetOrAddNode(runtimeNodes, project);
+
+                var projectParent = project.GetNearestParent<Project>();
+
+                if (projectParent != null)
+                {
+                    var nodeParent = GetOrAddNode(runtimeNodes, projectParent);
+                    node.Parent = nodeParent;
+                    nodeParent.AddChild(node);
+                }
+            }
+
+            var roots = runtimeNodes.Values.Where(n => n.Parent == null).ToArray();
+
+            return new RuntimeGraph(roots, runtimeNodes.Values);
+
+            RuntimeGraphNode GetOrAddNode(ConcurrentDictionary<Project, RuntimeGraphNode> runtimeGraphNodes, Project projectInvocation)
+            {
+                return runtimeGraphNodes.GetOrAdd(projectInvocation, p => new RuntimeGraphNode(p));
+            }
+        }
+    }
+}

--- a/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
@@ -262,7 +262,7 @@ Right-clicking a project node may show the 'Preprocess' option if the version of
 
         private void PopulateProjectGraph()
         {
-            var graph = new MSAGLProjectGraphConstructor().FromBuild(Build);
+            var graph = new MsaglProjectGraphConstructor().FromBuild(Build);
             projectGraphControl.BuildControl = this;
             projectGraphControl.SetGraph(graph);
         }


### PR DESCRIPTION
Fixes:
- Sort children project nodes by `Project.StartTime`. This aids in understanding the flow and order of execution.
- Common global property node is computed right this time. It is also placed on top of root nodes, instead of sometimes being awkwardly placed in the middle of the graph.

Before:
![image](https://user-images.githubusercontent.com/2255729/75466857-adaf9b00-593f-11ea-95a3-89cfc0e874e3.png)

After:
![image](https://user-images.githubusercontent.com/2255729/75466456-15191b00-593f-11ea-8b17-a08b8bcb9567.png)

