### PR TITLE
Fix dictionary key collision in RuntimeGraphNode

### DIFF
--- a/src/StructuredLogViewer.Core/ProjectGraph/RuntimeGraph.cs
+++ b/src/StructuredLogViewer.Core/ProjectGraph/RuntimeGraph.cs
@@ -13,7 +13,7 @@ namespace StructuredLogViewer.Core.ProjectGraph
 {
     public class RuntimeGraph
     {
-        [DebuggerDisplay("{DebuggerDisplayString()}")]
+        [DebuggerDisplay("{ToString()}")]
         public class RuntimeGraphNode
         {
             private SortedList<DateTime, RuntimeGraphNode>? sortedChildren;
@@ -43,11 +43,11 @@ namespace StructuredLogViewer.Core.ProjectGraph
                 Project = p;
             }
 
-            public string DebuggerDisplayString()
+            public override string ToString()
             {
                 var sb = new StringBuilder();
 
-                sb.Append($"ReferenceCount: {SortedChildren.Count}, {Project.DebuggerDisplayString()}");
+                sb.Append($"ReferenceCount: {SortedChildren.Count}, {Project}");
 
                 return sb.ToString();
             }

--- a/src/StructuredLogViewer.Core/ProjectGraph/RuntimeGraph.cs
+++ b/src/StructuredLogViewer.Core/ProjectGraph/RuntimeGraph.cs
@@ -2,7 +2,9 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
+using System.Text;
 using Microsoft.Build.Logging.StructuredLogger;
 
 #nullable enable
@@ -11,6 +13,7 @@ namespace StructuredLogViewer.Core.ProjectGraph
 {
     public class RuntimeGraph
     {
+        [DebuggerDisplay("{DebuggerDisplayString()}")]
         public class RuntimeGraphNode
         {
             private SortedList<DateTime, RuntimeGraphNode>? sortedChildren;
@@ -38,6 +41,15 @@ namespace StructuredLogViewer.Core.ProjectGraph
             public RuntimeGraphNode(Project p)
             {
                 Project = p;
+            }
+
+            public string DebuggerDisplayString()
+            {
+                var sb = new StringBuilder();
+
+                sb.Append($"ReferenceCount: {SortedChildren.Count}, {Project.DebuggerDisplayString()}");
+
+                return sb.ToString();
             }
 
             internal void AddChild(RuntimeGraphNode child)

--- a/src/StructuredLogViewer.Core/ProjectGraph/RuntimeGraph.cs
+++ b/src/StructuredLogViewer.Core/ProjectGraph/RuntimeGraph.cs
@@ -69,7 +69,7 @@ namespace StructuredLogViewer.Core.ProjectGraph
                 {
                     while (collection.ContainsKey(newKey))
                     {
-                        newKey = new DateTime(newKey.Ticks + 1);
+                        newKey = newKey.AddTicks(1);
                     }
 
                     return newKey;

--- a/src/StructuredLogViewer.Core/ProjectGraph/RuntimeGraph.cs
+++ b/src/StructuredLogViewer.Core/ProjectGraph/RuntimeGraph.cs
@@ -59,8 +59,21 @@ namespace StructuredLogViewer.Core.ProjectGraph
                     sortedChildren = new SortedList<DateTime, RuntimeGraphNode>();
                 }
 
-                sortedChildren.Add(child.Project.StartTime, child);
+                // some projects appear to have the same timestamp, add 1 tick to avoid a key already exists exception from the sorted list
+                var projectStartTime = GetNearestNonConflictingDateTime(child.Project.StartTime, sortedChildren);
+
+                sortedChildren.Add(projectStartTime, child);
                 sortedChildrenCached = null;
+
+                DateTime GetNearestNonConflictingDateTime(DateTime newKey, SortedList<DateTime, RuntimeGraphNode> collection)
+                {
+                    while (collection.ContainsKey(newKey))
+                    {
+                        newKey = new DateTime(newKey.Ticks + 1);
+                    }
+
+                    return newKey;
+                }
             }
         }
 

--- a/src/StructuredLogger/ObjectModel/Project.cs
+++ b/src/StructuredLogger/ObjectModel/Project.cs
@@ -8,7 +8,7 @@ using System.Text;
 
 namespace Microsoft.Build.Logging.StructuredLogger
 {
-    [DebuggerDisplay("{DebuggerDisplayString()}")]
+    [DebuggerDisplay("{ToString()}")]
     public class Project : TimedNode, IPreprocessable, IHasSourceFile, IHasRelevance
     {
         /// <summary>
@@ -34,13 +34,13 @@ namespace Microsoft.Build.Logging.StructuredLogger
         private readonly ConcurrentDictionary<string, Target> _targetNameToTargetMap = new ConcurrentDictionary<string, Target>(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<int, Target> targetsById = new Dictionary<int, Target>();
 
-        public string DebuggerDisplayString()
+        public override string ToString()
         {
             var sb = new StringBuilder();
 
-            sb.Append(ProjectFile);
-            sb.Append($", /t:[{string.Join(",", EntryTargets)}]");
-            sb.Append($", GlobalProperties: [{string.Join(",", GlobalProperties.Select(kvp => $"{kvp.Key}={kvp.Value}"))}]");
+            sb.Append($"Project Name={Name} File={ProjectFile}");
+            sb.Append($" Targets=[{string.Join(",", EntryTargets)}]");
+            sb.Append($" GlobalProperties=[{string.Join(",", GlobalProperties.Select(kvp => $"{kvp.Key}={kvp.Value}"))}]");
 
             return sb.ToString();
         }
@@ -184,6 +184,5 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
         public IReadOnlyList<string> EntryTargets { get; set; }
         public IDictionary<string, string> GlobalProperties { get; set; }
-        public override string ToString() => $"Project Name={Name} File={ProjectFile}";
     }
 }

--- a/src/StructuredLogger/ObjectModel/Project.cs
+++ b/src/StructuredLogger/ObjectModel/Project.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text;
 
 namespace Microsoft.Build.Logging.StructuredLogger
 {
+    [DebuggerDisplay("{DebuggerDisplayString()}")]
     public class Project : TimedNode, IPreprocessable, IHasSourceFile, IHasRelevance
     {
         /// <summary>
@@ -30,6 +33,17 @@ namespace Microsoft.Build.Logging.StructuredLogger
         /// </summary>
         private readonly ConcurrentDictionary<string, Target> _targetNameToTargetMap = new ConcurrentDictionary<string, Target>(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<int, Target> targetsById = new Dictionary<int, Target>();
+
+        public string DebuggerDisplayString()
+        {
+            var sb = new StringBuilder();
+
+            sb.Append(ProjectFile);
+            sb.Append($", /t:[{string.Join(",", EntryTargets)}]");
+            sb.Append($", GlobalProperties: [{string.Join(",", GlobalProperties.Select(kvp => $"{kvp.Key}={kvp.Value}"))}]");
+
+            return sb.ToString();
+        }
 
         public void TryAddTarget(Target target)
         {


### PR DESCRIPTION
Sometimes msbuild give the same start time for different Projects, which caused a key already exists exception. Fixed by using a nearest non conflicting start time.