### PR TITLE
Optimize search results markers

### DIFF
--- a/src/StructuredLogViewer.Avalonia/App.xaml
+++ b/src/StructuredLogViewer.Avalonia/App.xaml
@@ -76,6 +76,18 @@
             </StackPanel>
         </TreeDataTemplate>
 
+        <TreeDataTemplate DataType="{x:Type l:ProjectEvaluation}"
+                          ItemsSource="{Binding Children}">
+            <StackPanel Orientation="Horizontal"
+                        Name="projectRoot"
+                        Opacity="{Binding IsLowRelevance, Converter={StaticResource RelevanceConverter}}">
+                <DrawingPresenter Classes="projectNodeIcon"
+                                  Drawing="{Binding ProjectFileExtension, Converter={StaticResource ProjectIconConverter}}" />
+                <TextBlock Text="{Binding Name}"
+                           Margin="0,1,0,0" />
+            </StackPanel>
+        </TreeDataTemplate>
+
         <TreeDataTemplate DataType="{x:Type l:Target}"
                           ItemsSource="{Binding Children}">
             <StackPanel Orientation="Horizontal"
@@ -268,6 +280,19 @@
                            Margin="0,0,6,0" />
                 <TextBlock x:Name="reason"
                            Text="{Binding Text}" />
+            </StackPanel>
+        </TreeDataTemplate>
+
+        <TreeDataTemplate DataType="{x:Type l:TimedNode}"
+                          ItemsSource="{Binding Children}">
+            <StackPanel Orientation="Horizontal">
+                <Rectangle Name="icon"
+                           Classes="nodeIcon"
+                           Stroke="{StaticResource FolderStroke}"
+                           Fill="{StaticResource ClosedFolderBrush}" />
+                <TextBlock Name="nameText"
+                           Text="{Binding Name}"
+                           Foreground="{Binding IsSelected, Converter={StaticResource LabelColorConverter}, ConverterParameter={x:Static Brushes.DarkGoldenrod}}" />
             </StackPanel>
         </TreeDataTemplate>
         

--- a/src/StructuredLogViewer.Avalonia/App.xaml
+++ b/src/StructuredLogViewer.Avalonia/App.xaml
@@ -273,10 +273,11 @@
         
         <DataTemplate DataType="{x:Type common:ButtonNode}">
             <StackPanel Orientation="Horizontal">
-                <Button x:Name="button" 
-                        Content="{Binding Text}" 
-                        Command="{Binding Command}" 
-                        Padding="4,2,4,2"/>
+                <Button x:Name="button"
+                        Content="{Binding Text}"
+                        Command="{Binding Command}"
+                        IsEnabled="{Binding IsEnabled}"
+                        Padding="4,2,4,2" />
             </StackPanel>
         </DataTemplate>
         

--- a/src/StructuredLogViewer.Avalonia/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer.Avalonia/Controls/BuildControl.xaml.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -171,7 +171,6 @@ namespace StructuredLogViewer.Avalonia.Controls
                 filesTree.Styles.Add(treeViewItemStyle);
                 RegisterTreeViewHandlers(filesTree);
 
-                var filesNote = new TextBlock();
                 var text =
 @"This log contains the full text of projects and imported files used during the build.
 You can use the 'Files' tab in the bottom left to view these files and the 'Find in Files' tab for full-text search.
@@ -959,11 +958,18 @@ Recent:
             
             if (moreAvailable)
             {
-                root.Children.Add(new ButtonNode
+                var showAllButton = new ButtonNode
                 {
-                    Text = $"Showing first {results.Count} results. Show all results instead (slow).",
-                    OnClick = () => searchLogControl.TriggerSearch(searchLogControl.SearchText, int.MaxValue)
-                });
+                    Text = $"Showing first {results.Count} results. Show all results instead (slow)."
+                };
+
+                showAllButton.OnClick = () =>
+                {
+                    showAllButton.IsEnabled = false;
+                    searchLogControl.TriggerSearch(searchLogControl.SearchText, int.MaxValue);
+                };
+
+                root.Children.Add(showAllButton);
             }
             
             root.Children.Add(new Message

--- a/src/StructuredLogViewer.Avalonia/Controls/SearchAndResultsControl.xaml.cs
+++ b/src/StructuredLogViewer.Avalonia/Controls/SearchAndResultsControl.xaml.cs
@@ -47,7 +47,7 @@ namespace StructuredLogViewer.Avalonia.Controls
         public Func<object, bool, IEnumerable> ResultsTreeBuilder { get; set; }
         public event Action WatermarkDisplayed;
 
-        public Func<string, int, object> ExecuteSearch
+        public ExecuteSearchFunc ExecuteSearch
         {
             get => typingConcurrentOperation.ExecuteSearch;
             set => typingConcurrentOperation.ExecuteSearch = value;
@@ -55,7 +55,7 @@ namespace StructuredLogViewer.Avalonia.Controls
         
         public void TriggerSearch(string text, int maxResults)
         {
-            typingConcurrentOperation.TextChanged(text, maxResults);
+            typingConcurrentOperation.TriggerSearch(text, maxResults);
         }
         
         private void searchTextBox_TextChanged(object sender, AvaloniaPropertyChangedEventArgs e)
@@ -70,7 +70,7 @@ namespace StructuredLogViewer.Avalonia.Controls
                 return;
             }
 
-            typingConcurrentOperation.TextChanged(searchText);
+            typingConcurrentOperation.TextChanged(searchText, Search.DefaultMaxResults);
         }
 
         private void DisplaySearchResults(object results, bool moreAvailable = false)

--- a/src/StructuredLogViewer.Core/ButtonNode.cs
+++ b/src/StructuredLogViewer.Core/ButtonNode.cs
@@ -6,6 +6,16 @@ namespace Microsoft.Build.Logging.StructuredLogger
     public class ButtonNode : TextNode
     {
         public ICommand Command => new Command(OnClick);
+
         public Action OnClick { get; set; }
+
+        private bool isEnabled = true;
+        public bool IsEnabled
+        {
+            get => isEnabled;
+            set => SetField(ref isEnabled, value);
+        }
+
+        protected override bool IsSelectable => false;
     }
 }

--- a/src/StructuredLogViewer.Core/Note.cs
+++ b/src/StructuredLogViewer.Core/Note.cs
@@ -2,5 +2,6 @@
 {
     public class Note : TextNode
     {
+        protected override bool IsSelectable => false;
     }
 }

--- a/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -180,7 +180,6 @@ namespace StructuredLogViewer.Controls
 
                 filesTree.TextChanged += FilesTree_SearchTextChanged;
 
-                var filesNote = new TextBlock();
                 var text =
 @"This log contains the full text of projects and imported files used during the build.
 You can use the 'Files' tab in the bottom left to view these files and the 'Find in Files' tab for full-text search.
@@ -1244,11 +1243,18 @@ Recent:
 
             if (moreAvailable)
             {
-                root.Children.Add(new ButtonNode
+                var showAllButton = new ButtonNode
                 {
-                    Text = $"Showing first {results.Count} results. Show all results instead (slow).",
-                    OnClick = () => searchLogControl.TriggerSearch(searchLogControl.SearchText, int.MaxValue)
-                });
+                    Text = $"Showing first {results.Count} results. Show all results instead (slow)."
+                };
+
+                showAllButton.OnClick = () =>
+                {
+                    showAllButton.IsEnabled = false;
+                    searchLogControl.TriggerSearch(searchLogControl.SearchText, int.MaxValue);
+                };
+
+                root.Children.Add(showAllButton);
             }
 
             root.Children.Add(new Message

--- a/src/StructuredLogViewer/Controls/SearchAndResultsControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/SearchAndResultsControl.xaml.cs
@@ -28,7 +28,7 @@ namespace StructuredLogViewer.Controls
         public event Action WatermarkDisplayed;
         public event Action<string> TextChanged;
 
-        public Func<string, int, object> ExecuteSearch
+        public ExecuteSearchFunc ExecuteSearch
         {
             get => typingConcurrentOperation.ExecuteSearch;
             set => typingConcurrentOperation.ExecuteSearch = value;
@@ -36,7 +36,7 @@ namespace StructuredLogViewer.Controls
 
         public void TriggerSearch(string text, int maxResults)
         {
-            typingConcurrentOperation.TextChanged(text, maxResults);
+            typingConcurrentOperation.TriggerSearch(text, maxResults);
         }
 
         private void searchTextBox_TextChanged(object sender, TextChangedEventArgs e)
@@ -59,7 +59,7 @@ namespace StructuredLogViewer.Controls
                 return;
             }
 
-            typingConcurrentOperation.TextChanged(searchText);
+            typingConcurrentOperation.TextChanged(searchText, Search.DefaultMaxResults);
         }
 
         private void DisplaySearchResults(object results, bool moreAvailable = false)

--- a/src/StructuredLogViewer/themes/Generic.xaml
+++ b/src/StructuredLogViewer/themes/Generic.xaml
@@ -445,10 +445,11 @@
 
   <DataTemplate DataType="{x:Type core:ButtonNode}">
     <StackPanel Orientation="Horizontal">
-      <Button x:Name="button" 
-              Content="{Binding Text}" 
-              Command="{Binding Command}" 
-              Padding="4,2,4,2"/>
+      <Button x:Name="button"
+              Content="{Binding Text}"
+              Command="{Binding Command}"
+              IsEnabled="{Binding IsEnabled}"
+              Padding="4,2,4,2" />
     </StackPanel>
   </DataTemplate>
 

--- a/src/StructuredLogger/ObjectModel/BaseNode.cs
+++ b/src/StructuredLogger/ObjectModel/BaseNode.cs
@@ -16,11 +16,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
         public bool IsSelected
         {
-            get
-            {
-                return selectedNode == this;
-            }
-
+            get => selectedNode == this;
             set
             {
                 if (IsSelected == value)
@@ -29,12 +25,14 @@ namespace Microsoft.Build.Logging.StructuredLogger
                     return;
                 }
 
-                selectedNode = value ? this : null;
+                selectedNode = value && IsSelectable ? this : null;
 
                 RaisePropertyChanged();
                 RaisePropertyChanged("IsLowRelevance");
             }
         }
+
+        protected virtual bool IsSelectable => true;
 
         public bool IsSearchResult
         {


### PR DESCRIPTION
This should handle #319. The solution was to use a simpler algorithm which gets rid of the second pass. This means the user can now *see* the search markers getting updated while the search is running, but I don't think that's a problem.

I also added search cancellation support, made the "search all" button disable itself once clicked, and some fixes for Avalonia.
