### PR TITLE
Make imports a folder - fixes issue where TaskRunner didn't work when launched from the UI

### DIFF
--- a/src/StructuredLogViewer.Core/Analyzers/ImportTreeAnalyzer.cs
+++ b/src/StructuredLogViewer.Core/Analyzers/ImportTreeAnalyzer.cs
@@ -74,12 +74,12 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 return;
             }
 
-            if (rootProjectNode.Children.First() is TimedNode importsFolder && importsFolder.Name == Strings.Imports)
+            if (rootProjectNode.Children.First() is Folder importsFolder && importsFolder.Name == Strings.Imports)
             {
             }
             else
             {
-                importsFolder = new TimedNode()
+                importsFolder = new Folder()
                 {
                     Name = Strings.Imports
                 };


### PR DESCRIPTION
When attempting to run a task from the UI, the log viewer uses a task
index which is computed as the tree is initially walked. This task index is
then passed onto the TaskRunner executable, which attempts to find the item with
the same index. The analyzers may add new nodes into the graph. Typically
this doesn't affect numbering because indexes are only computed for TimedNodes. But
the import analyzer uses a TimedNode for a folder, which affects numbering, leading
to the inability for the TaskRunner to find the task you want to execute.

Instead of using a TimedNode for the folder, use a Folder.