### PR TITLE
Remove reference to the System.Compression package.

### DIFF
--- a/src/StructuredLogger/StructuredLogger.csproj
+++ b/src/StructuredLogger/StructuredLogger.csproj
@@ -26,7 +26,6 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MSBuildPackageVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MSBuildPackageVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MSBuildPackageVersion)" />
-    <PackageReference Include="System.IO.Compression" Version="4.3.0" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
     <StartAction>Program</StartAction>


### PR DESCRIPTION
It's not needed in .NET Standard 2.0.