### PR TITLE
Show project entry targets in tree and tool tip

### DIFF
--- a/src/StructuredLogViewer.Avalonia/App.xaml
+++ b/src/StructuredLogViewer.Avalonia/App.xaml
@@ -104,6 +104,16 @@
             </StackPanel>
         </TreeDataTemplate>
 
+        <DataTemplate DataType="{x:Type l:EntryTarget}">
+            <StackPanel Orientation="Horizontal">
+                <Rectangle Name="icon"
+                           Classes="nodeIcon"
+                           Stroke="{StaticResource TargetStroke}"
+                           Fill="{StaticResource TargetBrush}" />
+                <TextBlock Text="{Binding Name}" />
+            </StackPanel>
+        </DataTemplate>
+
         <TreeDataTemplate DataType="{x:Type l:Task}"
                           ItemsSource="{Binding Children}">
             <StackPanel Orientation="Horizontal">

--- a/src/StructuredLogViewer/Controls/BuildControl.xaml
+++ b/src/StructuredLogViewer/Controls/BuildControl.xaml
@@ -5,7 +5,9 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="clr-namespace:StructuredLogViewer.Controls"
              xmlns:structuredLogViewer="clr-namespace:StructuredLogViewer"
+             xmlns:structuredLogger="clr-namespace:Microsoft.Build.Logging.StructuredLogger;assembly=StructuredLogger"
              mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance structuredLogger:Build}"
              d:DesignHeight="300" d:DesignWidth="300">
 
   <local:SplitterPanel Orientation="Vertical" FirstChildRelativeSize="*" SecondChildRelativeSize="50">

--- a/src/StructuredLogViewer/Controls/NodeHyperlinkControl.cs
+++ b/src/StructuredLogViewer/Controls/NodeHyperlinkControl.cs
@@ -38,6 +38,11 @@ namespace StructuredLogViewer.Controls
                 }
             }
 
+            if (DataContext is EntryTarget entryTarget)
+            {
+                return entryTarget.Target;
+            }
+
             return null;
         }
 

--- a/src/StructuredLogViewer/themes/Generic.xaml
+++ b/src/StructuredLogViewer/themes/Generic.xaml
@@ -267,10 +267,22 @@
   </HierarchicalDataTemplate>
 
   <DataTemplate DataType="{x:Type l:EntryTarget}">
-    <StackPanel Orientation="Horizontal">
+    <StackPanel Orientation="Horizontal" x:Name="entryTargetRoot">
       <Rectangle x:Name="icon" Style="{StaticResource NodeIcon}" Stroke="{StaticResource TargetStroke}" Fill="{StaticResource TargetBrush}" />
       <TextBlock Text="{Binding Name}" />
+      <TextBlock x:Name="duration" Text="{Binding DurationText}" Margin="6,0,0,0" ToolTip="{Binding ToolTip}" />
+      <controls:NodeHyperlinkControl
+          Text=" → Show"
+          Foreground="LightBlue" />
     </StackPanel>
+    <DataTemplate.Triggers>
+      <DataTrigger Binding="{Binding IsLowRelevance}" Value="True">
+        <Setter TargetName="entryTargetRoot" Property="Opacity" Value="0.25" />
+      </DataTrigger>
+      <DataTrigger Binding="{Binding IsSelected}" Value="False">
+        <Setter TargetName="duration" Property="Foreground" Value="LightGray" />
+      </DataTrigger>
+    </DataTemplate.Triggers>
   </DataTemplate>
 
   <HierarchicalDataTemplate DataType="{x:Type l:Task}"

--- a/src/StructuredLogViewer/themes/Generic.xaml
+++ b/src/StructuredLogViewer/themes/Generic.xaml
@@ -267,10 +267,10 @@
   </HierarchicalDataTemplate>
 
   <DataTemplate DataType="{x:Type l:EntryTarget}">
-      <StackPanel Orientation="Horizontal">
-          <Rectangle x:Name="icon" Style="{StaticResource NodeIcon}" Stroke="{StaticResource TargetStroke}" Fill="{StaticResource TargetBrush}" />
-          <TextBlock Text="{Binding Name}" />
-      </StackPanel>
+    <StackPanel Orientation="Horizontal">
+      <Rectangle x:Name="icon" Style="{StaticResource NodeIcon}" Stroke="{StaticResource TargetStroke}" Fill="{StaticResource TargetBrush}" />
+      <TextBlock Text="{Binding Name}" />
+    </StackPanel>
   </DataTemplate>
 
   <HierarchicalDataTemplate DataType="{x:Type l:Task}"

--- a/src/StructuredLogViewer/themes/Generic.xaml
+++ b/src/StructuredLogViewer/themes/Generic.xaml
@@ -266,6 +266,13 @@
     </HierarchicalDataTemplate.Triggers>
   </HierarchicalDataTemplate>
 
+  <DataTemplate DataType="{x:Type l:EntryTarget}">
+      <StackPanel Orientation="Horizontal">
+          <Rectangle x:Name="icon" Style="{StaticResource NodeIcon}" Stroke="{StaticResource TargetStroke}" Fill="{StaticResource TargetBrush}" />
+          <TextBlock Text="{Binding Name}" />
+      </StackPanel>
+  </DataTemplate>
+
   <HierarchicalDataTemplate DataType="{x:Type l:Task}"
                             ItemsSource="{Binding Children}">
     <StackPanel Orientation="Horizontal">

--- a/src/StructuredLogViewer/themes/Generic.xaml
+++ b/src/StructuredLogViewer/themes/Generic.xaml
@@ -198,7 +198,7 @@
       <Rectangle x:Name="icon" Style="{StaticResource NodeIcon}"
                  Width="16" Height="16" Margin="2,2,6,2" StrokeThickness="0"
                  Fill="{StaticResource GenericProjectIcon}" />
-      <TextBlock Text="{Binding Name}" Margin="0,2,0,0" />
+      <TextBlock Text="{Binding Name}" Margin="0,2,0,0" ToolTip="{Binding ToolTip}" ToolTipService.ShowDuration="60000" />
     </StackPanel>
     <HierarchicalDataTemplate.Triggers>
       <DataTrigger Binding="{Binding IsLowRelevance}" Value="True">

--- a/src/StructuredLogger/Construction/Construction.cs
+++ b/src/StructuredLogger/Construction/Construction.cs
@@ -711,13 +711,11 @@ namespace Microsoft.Build.Logging.StructuredLogger
                     ? ImmutableArray<string>.Empty
                     : stringTable.InternList(TextUtilities.SplitSemicolonDelimitedList(args.TargetNames));
 
-                var internedGlobalProperties = stringTable.InternStringDictionary(args.GlobalProperties) ?? ImmutableDictionary<string, string>.Empty;
-
-                project.GlobalProperties = internedGlobalProperties;
+                project.GlobalProperties = stringTable.InternStringDictionary(args.GlobalProperties) ?? ImmutableDictionary<string, string>.Empty;
 
                 if (args.GlobalProperties != null)
                 {
-                    AddGlobalProperties(project, internedGlobalProperties);
+                    AddGlobalProperties(project);
                 }
 
                 if (args.Properties != null)
@@ -903,9 +901,10 @@ namespace Microsoft.Build.Logging.StructuredLogger
             _taskToAssemblyMap.GetOrAdd(taskName, t => assembly);
         }
 
-        private void AddGlobalProperties(Project project, IEnumerable<KeyValuePair<string, string>> properties)
+        private void AddGlobalProperties(Project project)
         {
             var propertiesNode = project.GetOrCreateNodeWithName<Folder>("Properties");
+            var properties = project.GlobalProperties;
             if (properties != null && properties.Any())
             {
                 var global = propertiesNode.GetOrCreateNodeWithName<Folder>("Global");

--- a/src/StructuredLogger/Construction/Construction.cs
+++ b/src/StructuredLogger/Construction/Construction.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Build.Execution;
@@ -718,6 +717,11 @@ namespace Microsoft.Build.Logging.StructuredLogger
                     AddGlobalProperties(project);
                 }
 
+                if (!string.IsNullOrEmpty(args.TargetNames))
+                {
+                    AddEntryTargets(project);
+                }
+
                 if (args.Properties != null)
                 {
                     var properties = project.GetOrCreateNodeWithName<Folder>(Intern("Properties"));
@@ -909,6 +913,23 @@ namespace Microsoft.Build.Logging.StructuredLogger
             {
                 var global = propertiesNode.GetOrCreateNodeWithName<Folder>("Global");
                 AddProperties(global, properties);
+            }
+        }
+
+        private static void AddEntryTargets(Project project)
+        {
+            var targetsNode = project.GetOrCreateNodeWithName<Folder>("Entry Targets");
+            var entryTargets = project.EntryTargets;
+            if (entryTargets != null)
+            {
+                foreach (var entryTarget in entryTargets)
+                {
+                    var property = new EntryTarget
+                    {
+                        Name = entryTarget,
+                    };
+                    targetsNode.AddChild(property);
+                }
             }
         }
 

--- a/src/StructuredLogger/ObjectModel/EntryTarget.cs
+++ b/src/StructuredLogger/ObjectModel/EntryTarget.cs
@@ -1,0 +1,7 @@
+﻿namespace Microsoft.Build.Logging.StructuredLogger
+{
+    public class EntryTarget : NamedNode
+    {
+        public override string TypeName => nameof(EntryTarget);
+    }
+}

--- a/src/StructuredLogger/ObjectModel/EntryTarget.cs
+++ b/src/StructuredLogger/ObjectModel/EntryTarget.cs
@@ -1,7 +1,15 @@
-﻿namespace Microsoft.Build.Logging.StructuredLogger
+﻿#nullable enable
+
+namespace Microsoft.Build.Logging.StructuredLogger
 {
-    public class EntryTarget : NamedNode
+    public class EntryTarget : NamedNode, IHasRelevance
     {
+        private Project? project;
+        private Target? target;
         public override string TypeName => nameof(EntryTarget);
+        private Project? Project => project ??= GetNearestParent<Project>();
+        public Target? Target => target ??= Project?.FindFirstDescendant<Target>(t => t.Name == Name);
+        public bool IsLowRelevance => Target?.IsLowRelevance ?? true;
+        public string? DurationText => Target?.DurationText;
     }
 }

--- a/src/StructuredLogger/ObjectModel/Project.cs
+++ b/src/StructuredLogger/ObjectModel/Project.cs
@@ -193,5 +193,42 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
         public IReadOnlyList<string> EntryTargets { get; set; } = Array.Empty<string>();
         public IDictionary<string, string> GlobalProperties { get; set; } = ImmutableDictionary<string, string>.Empty;
+
+        public override string ToolTip
+        {
+            get
+            {
+                var sb = new StringBuilder();
+
+                sb.AppendLine(ProjectFile);
+
+                if (EntryTargets != null)
+                {
+                    sb.AppendLine();
+                    sb.AppendLine("Targets:");
+                    sb.AppendLine();
+                    foreach (var target in EntryTargets.OrderBy(target => target, StringComparer.InvariantCultureIgnoreCase))
+                    {
+                        sb.AppendLine(target);
+                    }
+                }
+
+                if (GlobalProperties != null)
+                {
+                    sb.AppendLine();
+                    sb.AppendLine("Global Properties:");
+                    sb.AppendLine();
+                    foreach (var pair in GlobalProperties.OrderBy(pair => pair.Key, StringComparer.InvariantCultureIgnoreCase))
+                    {
+                        sb.AppendLine($"{pair.Key} = {pair.Value}");
+                    }
+                }
+
+                sb.AppendLine();
+                sb.Append(GetTimeAndDurationText());
+
+                return sb.ToString();
+            }
+        }
     }
 }


### PR DESCRIPTION
Makes it easier to see entry targets where there are many (such as in VS design-time builds).

![image](https://user-images.githubusercontent.com/350947/88002267-7c7d7480-cb45-11ea-8b03-2c1e12ef7225.png)
