### PR TITLE
Make target's parent symbol depend on build reason

### DIFF
--- a/src/StructuredLogger/ObjectModel/Target.cs
+++ b/src/StructuredLogger/ObjectModel/Target.cs
@@ -49,8 +49,14 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 {
                     return string.Empty;
                 }
-
-                return " ← " + ParentTarget;
+                var connectingSymbol = TargetBuiltReason switch
+                {
+                    TargetBuiltReason.AfterTargets => "↑",
+                    TargetBuiltReason.BeforeTargets => "↓",
+                    TargetBuiltReason.DependsOn => "→",
+                    _ => "→",
+                };
+                return $" {connectingSymbol} " + ParentTarget;
             }
         }
 


### PR DESCRIPTION
This allows you to quickly tell what the reason target was the cause of the target. 