### PR TITLE
Targets netcoreapp3.1 too

### DIFF
--- a/src/StructuredLogViewer.Avalonia/Controls/TextViewerControl.xaml.cs
+++ b/src/StructuredLogViewer.Avalonia/Controls/TextViewerControl.xaml.cs
@@ -186,7 +186,7 @@ namespace StructuredLogViewer.Avalonia.Controls
                 filePath = SettingsService.WriteContentToTempFileAndGetPath(Text, extension);
             }
 
-            Process.Start(filePath);
+            Process.Start(new ProcessStartInfo(filePath){ UseShellExecute = true });
         }
 
         private void copyFullPath_Click(object sender, RoutedEventArgs e)

--- a/src/StructuredLogViewer/MainWindow.xaml.cs
+++ b/src/StructuredLogViewer/MainWindow.xaml.cs
@@ -705,12 +705,12 @@ namespace StructuredLogViewer
 
         private void HelpLink_Click(object sender, RoutedEventArgs e)
         {
-            Process.Start("https://github.com/KirillOsenkov/MSBuildStructuredLog");
+            Process.Start(new ProcessStartInfo("https://github.com/KirillOsenkov/MSBuildStructuredLog") { UseShellExecute = true });
         }
 
         private void HelpLink2_Click(object sender, RoutedEventArgs e)
         {
-            Process.Start("http://msbuildlog.com");
+            Process.Start(new ProcessStartInfo("http://msbuildlog.com") { UseShellExecute = true });
         }
 
         private void HelpAbout_Click(object sender, RoutedEventArgs e)

--- a/src/StructuredLogViewer/StructuredLogViewer.csproj
+++ b/src/StructuredLogViewer/StructuredLogViewer.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <Prefer32Bit Condition="$(Prefer32Bit)==''">false</Prefer32Bit>
     <ApplicationIcon>StructuredLogger.ico</ApplicationIcon>
@@ -10,15 +10,10 @@
     <Company>Microsoft</Company>
     <Product>MSBuild Structured Log Viewer</Product>
     <AssemblyTitle>MSBuild Structured Log Viewer</AssemblyTitle>
+    <UseWpf>true</UseWpf>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Controls\ProjectGraphControl.xaml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="System.Xaml" />
-    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AdonisUI" Version="1.16.0" />
@@ -27,7 +22,6 @@
     <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" ExcludeAssets="build" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="$(NuGetVersionNerdbankGitVersioning)" PrivateAssets="all" />
     <PackageReference Include="squirrel.windows" Version="1.4.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="System.IO.Compression" Version="4.3.0" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
     <PackageReference Include="AutomaticGraphLayout.WpfGraphControl" Version="1.1.11" />
@@ -38,38 +32,7 @@
     <ProjectReference Include="..\TaskRunner\TaskRunner.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Page Include="Controls\BuildControl.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="Controls\DocumentWell.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="Controls\SearchAndResultsControl.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="Controls\TextViewerControl.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="Controls\ProjectGraphControl.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="Controls\TimelineControl.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="MainWindow.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="themes\Generic.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
+  
   </ItemGroup>
   <ItemGroup>
     <Resource Include="StructuredLogger.ico" />

--- a/src/StructuredLogger/StructuredLogger.csproj
+++ b/src/StructuredLogger/StructuredLogger.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+	<TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
     <NBGV_DoNotEmitNonVersionCustomAttributes>true</NBGV_DoNotEmitNonVersionCustomAttributes>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
@@ -47,7 +47,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(IconFilePath)" Pack="true" PackagePath=""/>
+    <None Include="$(IconFilePath)" Pack="true" PackagePath="" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
     <StartAction>Program</StartAction>


### PR DESCRIPTION
- Allows the application to be launched with .NET Core runtime (along with .NET Framework runtime)
- Changed the target frameworks for `StructuredLogger` to exactly match the ones supported by `Microsoft.Build`
- Fix some `Process.Start` (there is a [breaking change](https://docs.microsoft.com/fr-fr/dotnet/core/compatibility/fx-core#change-in-default-value-of-useshellexecute) introduced with .NET Core)  