### PR TITLE
Make dependency tool tips appear faster and last longer

### DIFF
--- a/src/StructuredLogViewer/themes/Generic.xaml
+++ b/src/StructuredLogViewer/themes/Generic.xaml
@@ -280,7 +280,9 @@
       <controls:NodeHyperlinkControl
             Text="{Binding ParentTargetText}"
             Foreground="LightBlue"
-            ToolTip="{Binding ParentTargetTooltip}" />
+            ToolTip="{Binding ParentTargetTooltip}"
+            ToolTipService.InitialShowDelay="0"
+            ToolTipService.ShowDuration="300000" />
     </StackPanel>
     <HierarchicalDataTemplate.Triggers>
       <DataTrigger Binding="{Binding IsLowRelevance}" Value="True">


### PR DESCRIPTION
It takes my brain longer to parse the information than it's on screen for.