### PR TITLE
ClickOnce for GitHub Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,7 @@ publish/
 # TODO: Comment the next line if you want to checkin your web deploy settings 
 # but database connection strings (with potential passwords) will be unencrypted
 *.pubxml
+!src/StructuredLogViewer.Avalonia/Properties/PublishProfiles/ClickOnceProfile.pubxml
 *.publishproj
 
 # NuGet Packages

--- a/src/StructuredLogViewer.Avalonia/Properties/PublishProfiles/ClickOnceProfile.pubxml
+++ b/src/StructuredLogViewer.Avalonia/Properties/PublishProfiles/ClickOnceProfile.pubxml
@@ -1,0 +1,40 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121. 
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ApplicationRevision>1</ApplicationRevision>
+    <ApplicationVersion>2.1.215.*</ApplicationVersion>
+    <BootstrapperEnabled>True</BootstrapperEnabled>
+    <Configuration>Release</Configuration>
+    <CreateDesktopShortcut>True</CreateDesktopShortcut>
+    <GenerateManifests>True</GenerateManifests>
+    <Install>true</Install>
+    <InstallFrom>Web</InstallFrom>
+    <InstallUrl>https://ctaggart.github.io/MSBuildStructuredLog/</InstallUrl>
+    <IsRevisionIncremented>True</IsRevisionIncremented>
+    <IsWebBootstrapper>True</IsWebBootstrapper>
+    <ManifestCertificateThumbprint>1A92BF20220B301077205787F406B1BCEE6DA97E</ManifestCertificateThumbprint>
+    <MapFileExtensions>true</MapFileExtensions>
+    <OpenBrowserOnPublish>false</OpenBrowserOnPublish>
+    <Platform>Mixed Platforms</Platform>
+    <PublishDir>bin\publish\</PublishDir>
+    <PublishUrl>bin\publish\</PublishUrl>
+    <PublishProtocol>ClickOnce</PublishProtocol>
+    <PublishReadyToRun>False</PublishReadyToRun>
+    <PublishSingleFile>False</PublishSingleFile>
+    <SelfContained>False</SelfContained>
+    <SignatureAlgorithm>sha256RSA</SignatureAlgorithm>
+    <SignManifests>True</SignManifests>
+    <TargetFramework>net5.0</TargetFramework>
+    <UpdateEnabled>True</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+  </PropertyGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include="Microsoft.NetCore.CoreRuntime.5.0.x64">
+      <Install>true</Install>
+      <ProductName>.NET Runtime 5.0.1 (x64)</ProductName>
+    </BootstrapperPackage>
+  </ItemGroup>
+</Project>

--- a/src/StructuredLogViewer.Core/StructuredLogViewer.Core.csproj
+++ b/src/StructuredLogViewer.Core/StructuredLogViewer.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/StructuredLogger/StructuredLogger.csproj
+++ b/src/StructuredLogger/StructuredLogger.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
     <NBGV_DoNotEmitNonVersionCustomAttributes>true</NBGV_DoNotEmitNonVersionCustomAttributes>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>


### PR DESCRIPTION
MSBuildStructuredLog is incredibly helpful. I'm experimenting with publishing ClickOnce apps to GitHub Pages and using MSBuildStructuredLog as my test subject. It looks like installation succeeds, but it does not run. 😢 

https://ctaggart.github.io/MSBuildStructuredLog/StructuredLogViewer.Avalonia.application

Turns out it doesn't run when I install directly from `bin\StructuredLogViewer.Avalonia\Release\net5.0\app.publish\StructuredLogViewer.Avalonia.application` either. The `bin\StructuredLogViewer.Avalonia\Release\net5.0\app.publish\StructuredLogViewer.Avalonia.exe` runs well.

I created this `ClickOnceProfile.pubxml` with Visual Studio > Build > Publish wizard. Visual Studio has a publish button, but I figured out that I could run this on the command line:
``` powershell
$env:path+=";C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin"
msbuild src\StructuredLogViewer.Avalonia\StructuredLogViewer.Avalonia.csproj /t:Restore,Publish /p:Configuration=Release /p:PublishProfile=ClickOnceProfile /p:TargetFramework=net5.0
```

I'm not sure what is wrong., but I'm investigating. I'm currently wondering if the [CLR version](https://github.com/ctaggart/MSBuildStructuredLog/blob/gh-pages/Application%20Files/StructuredLogViewer.Avalonia_2_1_215_0/StructuredLogViewer.Avalonia.dll.manifest#L39-L43) is correct for this .NET 5 app:
``` xml
  <dependency>
    <dependentAssembly dependencyType="preRequisite" allowDelayedBinding="true">
      <assemblyIdentity name="Microsoft.Windows.CommonLanguageRuntime" version="4.0.30319.0" />
    </dependentAssembly>
  </dependency>
```
