### PR TITLE
Target net5.0-windows too

### DIFF
--- a/src/StructuredLogViewer.Avalonia/Controls/TextViewerControl.xaml.cs
+++ b/src/StructuredLogViewer.Avalonia/Controls/TextViewerControl.xaml.cs
@@ -186,7 +186,7 @@ namespace StructuredLogViewer.Avalonia.Controls
                 filePath = SettingsService.WriteContentToTempFileAndGetPath(Text, extension);
             }
 
-            Process.Start(filePath);
+            Process.Start(new ProcessStartInfo(filePath) { UseShellExecute = true });
         }
 
         private void copyFullPath_Click(object sender, RoutedEventArgs e)

--- a/src/StructuredLogViewer/MainWindow.xaml.cs
+++ b/src/StructuredLogViewer/MainWindow.xaml.cs
@@ -720,12 +720,12 @@ namespace StructuredLogViewer
 
         private void HelpLink_Click(object sender, RoutedEventArgs e)
         {
-            Process.Start("https://github.com/KirillOsenkov/MSBuildStructuredLog");
+            Process.Start(new ProcessStartInfo("https://github.com/KirillOsenkov/MSBuildStructuredLog") { UseShellExecute = true });
         }
 
         private void HelpLink2_Click(object sender, RoutedEventArgs e)
         {
-            Process.Start("https://msbuildlog.com");
+            Process.Start(new ProcessStartInfo("http://msbuildlog.com") { UseShellExecute = true });
         }
 
         private void HelpAbout_Click(object sender, RoutedEventArgs e)

--- a/src/StructuredLogViewer/StructuredLogViewer.csproj
+++ b/src/StructuredLogViewer/StructuredLogViewer.csproj
@@ -6,12 +6,14 @@
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <Prefer32Bit Condition="$(Prefer32Bit)==''">false</Prefer32Bit>
     <ApplicationIcon>StructuredLogger.ico</ApplicationIcon>
-    <NuspecFileName>MSBuildStructuredLogViewer</NuspecFileName>
-    <ChocolateyFileName>msbuild-structured-log-viewer</ChocolateyFileName>
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
     <Company>Microsoft</Company>
     <Product>MSBuild Structured Log Viewer</Product>
     <AssemblyTitle>MSBuild Structured Log Viewer</AssemblyTitle>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
+	<NuspecFileName>MSBuildStructuredLogViewer</NuspecFileName>
+	<ChocolateyFileName>msbuild-structured-log-viewer</ChocolateyFileName>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AdonisUI" Version="1.16.0" />

--- a/src/StructuredLogViewer/StructuredLogViewer.csproj
+++ b/src/StructuredLogViewer/StructuredLogViewer.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;net5.0-windows</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <UseWPF>true</UseWPF>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
@@ -17,7 +17,7 @@
     <PackageReference Include="AdonisUI" Version="1.16.0" />
     <PackageReference Include="AdonisUI.ClassicTheme" Version="1.16.0" />
     <PackageReference Include="AvalonEdit" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" ExcludeAssets="build" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" ExcludeAssets="build" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="$(NuGetVersionNerdbankGitVersioning)" PrivateAssets="all" />
     <PackageReference Include="squirrel.windows" Version="1.4.4" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />


### PR DESCRIPTION
- Allows the application to be launched with .NET 5.0 (along with .NET Framework runtime)
- Fix some `Process.Start` (there is a [breaking change](https://docs.microsoft.com/fr-fr/dotnet/core/compatibility/fx-core#change-in-default-value-of-useshellexecute) introduced with .NET Core)  