### PR TITLE
Quote the binlog file path in Process.Start arguments

### DIFF
--- a/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
@@ -681,7 +681,7 @@ Recent:
 
             try
             {
-                Process.Start(taskRunner.QuoteIfNeeded(), $"{logFilePath} {task.Index} pause{(debug ? " debug" : "")}");
+                Process.Start(taskRunner.QuoteIfNeeded(), $"{logFilePath.QuoteIfNeeded()} {task.Index} pause{(debug ? " debug" : "")}");
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
So that everything works if the path contains spaces