### PR TITLE
Supports HiDPI for BuildParametersScreen,  fix width/height, margin/padding properties 

### DIFF
--- a/src/StructuredLogViewer.Avalonia/App.xaml
+++ b/src/StructuredLogViewer.Avalonia/App.xaml
@@ -24,9 +24,9 @@
         <StyleInclude Source="/Styles.xaml" />
         
         <Style Selector="Rectangle.nodeIcon">
-            <Setter Property="Width" Value="14" />
-            <Setter Property="Height" Value="11" />
-            <Setter Property="Margin" Value="3,3,6,3" />
+            <Setter Property="Width" Value="16" />
+            <Setter Property="Height" Value="12" />
+            <Setter Property="Margin" Value="2,4,6,2" />
             <Setter Property="StrokeThickness" Value="1" />
             <Setter Property="VerticalAlignment" Value="Top" />
         </Style>
@@ -34,11 +34,19 @@
         <Style Selector="Image.projectNodeIcon">
             <Setter Property="Width" Value="16" />
             <Setter Property="Height" Value="16" />
-            <Setter Property="Margin" Value="2,2,6,2" />
+            <Setter Property="Margin" Value="2,2,6,0" />
             <Setter Property="VerticalAlignment" Value="Top" />
         </Style>
-        
+
+        <Style Selector="TextBlock.nodeBeforeText">
+            <Setter Property="Margin" Value="0,2,0,0" />
+        </Style>
+
+        <Style Selector="TextBlock.nodeText">
+            <Setter Property="Margin" Value="0,2,8,0" />
+        </Style>
     </Application.Styles>
+
     <Application.DataTemplates>
 
         <TreeDataTemplate DataType="{x:Type l:Folder}"
@@ -49,6 +57,7 @@
                            Stroke="{StaticResource FolderStroke}"
                            Fill="{StaticResource ClosedFolderBrush}" />
                 <TextBlock Name="nameText"
+                           Classes="nodeText"
                            Text="{Binding Name}"
                            Foreground="{Binding IsSelected, Converter={StaticResource LabelColorConverter}, ConverterParameter={x:Static Brushes.DarkGoldenrod}}" />
             </StackPanel>
@@ -74,8 +83,8 @@
                         <DrawingImage Drawing="{Binding ProjectFileExtension, Converter={StaticResource ProjectIconConverter}}" />
                     </Image.Source>
                 </Image>
-                <TextBlock Text="{Binding Name}"
-                           Margin="0,1,0,0" />
+                <TextBlock Classes="nodeText"
+                           Text="{Binding Name}" />
             </StackPanel>
         </TreeDataTemplate>
 
@@ -89,8 +98,8 @@
                         <DrawingImage Drawing="{Binding ProjectFileExtension, Converter={StaticResource ProjectIconConverter}}" />
                     </Image.Source>
                 </Image>
-                <TextBlock Text="{Binding Name}"
-                           Margin="0,1,0,0" />
+                <TextBlock Classes="nodeText"
+                           Text="{Binding Name}" />
             </StackPanel>
         </TreeDataTemplate>
 
@@ -104,9 +113,11 @@
                            Stroke="{StaticResource TargetStroke}"
                            Fill="{StaticResource TargetBrush}" />
                 <TextBlock Name="label"
+                           Classes="nodeText"
                            Text="Target "
                            Foreground="{Binding IsSelected, Converter={StaticResource LabelColorConverter}, ConverterParameter={StaticResource TargetStroke}}" />
-                <TextBlock Text="{Binding Name}" />
+                <TextBlock Classes="nodeText"
+                           Text="{Binding Name}" />
             </StackPanel>
         </TreeDataTemplate>
 
@@ -116,7 +127,8 @@
                            Classes="nodeIcon"
                            Stroke="{StaticResource TargetStroke}"
                            Fill="{StaticResource TargetBrush}" />
-                <TextBlock Text="{Binding Name}" />
+                <TextBlock Classes="nodeText"
+                           Text="{Binding Name}" />
             </StackPanel>
         </DataTemplate>
 
@@ -128,13 +140,15 @@
                            Stroke="{StaticResource TaskStroke}"
                            Fill="{StaticResource TaskBrush}" />
                 <TextBlock Name="label"
+                           Classes="nodeText"
                            Text="Task "
                            Foreground="{Binding IsSelected, Converter={StaticResource LabelColorConverter}, ConverterParameter={StaticResource TaskStroke}}"/>
-                <TextBlock Text="{Binding Name}" />
+                <TextBlock Classes="nodeText"
+                           Text="{Binding Name}" />
                 <TextBlock Name="duration"
+                           Classes="nodeText"
                            Text="{Binding DurationText}"
-                           Foreground="{Binding IsSelected, Converter={StaticResource LabelColorConverter}, ConverterParameter={x:Static Brushes.LightGray}}"
-                           Margin="6,0,0,0" />
+                           Foreground="{Binding IsSelected, Converter={StaticResource LabelColorConverter}, ConverterParameter={x:Static Brushes.LightGray}}" />
             </StackPanel>
         </TreeDataTemplate>
 
@@ -146,9 +160,11 @@
                            Stroke="{StaticResource ItemStroke}"
                            Fill="{StaticResource ItemBrush}" />
                 <TextBlock Name="label"
+                           Classes="nodeText"
                            Text="Add Item "
                            Foreground="{Binding IsSelected, Converter={StaticResource LabelColorConverter}, ConverterParameter={x:Static Brushes.Teal}}" />
-                <TextBlock Text="{Binding Name}" />
+                <TextBlock Text="{Binding Name}"
+                           Classes="nodeText" />
             </StackPanel>
         </TreeDataTemplate>
 
@@ -160,9 +176,11 @@
                            Stroke="{StaticResource ItemStroke}"
                            Fill="{StaticResource ItemBrush}" />
                 <TextBlock Name="label"
+                           Classes="nodeText"
                            Text="Remove Item "
                            Foreground="{Binding IsSelected, Converter={StaticResource LabelColorConverter}, ConverterParameter={x:Static Brushes.Teal}}"/>
-                <TextBlock Text="{Binding Name}" />
+                <TextBlock Text="{Binding Name}"
+                           Classes="nodeText" />
             </StackPanel>
         </TreeDataTemplate>
 
@@ -174,9 +192,11 @@
                            Stroke="{StaticResource ItemStroke}"
                            Fill="{StaticResource ItemBrush}" />
                 <TextBlock Name="nameAndEquals"
+                           Classes="nodeBeforeText"
                            Text="{Binding NameAndEquals}"
                            Foreground="{Binding IsSelected, Converter={StaticResource LabelColorConverter}, ConverterParameter={x:Static Brushes.Green}}"/>
-                <TextBlock Text="{Binding ShortenedText}" />
+                <TextBlock Text="{Binding ShortenedText}"
+                           Classes="nodeText" />
             </StackPanel>
         </TreeDataTemplate>
 
@@ -187,9 +207,11 @@
                            Stroke="{StaticResource MetadataStroke}"
                            Fill="{StaticResource ItemBrush}" />
                 <TextBlock Name="label"
+                           Classes="nodeBeforeText"
                            Text="{Binding NameAndEquals, Mode=OneTime}"
                            Foreground="{Binding IsSelected, Converter={StaticResource LabelColorConverter}, ConverterParameter={x:Static Brushes.LightSeaGreen}}"/>
-                <TextBlock Text="{Binding ShortenedValue}" />
+                <TextBlock Classes="nodeText"
+                           Text="{Binding ShortenedValue}" />
             </StackPanel>
         </DataTemplate>
         
@@ -227,9 +249,11 @@
                            Stroke="{StaticResource PropertyStroke}"
                            Fill="{StaticResource PropertyBrush}" />
                 <TextBlock Name="label"
+                           Classes="nodeBeforeText"
                            Text="{Binding NameAndEquals, Mode=OneTime}"
                            Foreground="{Binding IsSelected, Converter={StaticResource LabelColorConverter}, ConverterParameter={StaticResource PropertyStroke}}" />
-                <TextBlock Text="{Binding ShortenedValue}" />
+                <TextBlock Text="{Binding ShortenedValue}"
+                           Classes="nodeText" />
             </StackPanel>
         </DataTemplate>
 
@@ -241,6 +265,7 @@
                            Stroke="{StaticResource ParameterStroke}"
                            Fill="{StaticResource ParameterBrush}" />
                 <TextBlock Name="name"
+                           Classes="nodeText"
                            Text="{Binding Name}"
                            Foreground="{Binding IsSelected, Converter={StaticResource LabelColorConverter}, ConverterParameter={StaticResource ParameterStroke}}" />
             </StackPanel>
@@ -253,6 +278,7 @@
                            Stroke="{StaticResource MessageStroke}"
                            Fill="{StaticResource MessageBrush}" />
                 <TextBlock Name="messageText"
+                           Classes="nodeText"
                            Text="{Binding ShortenedText}"
                            Opacity="{Binding IsLowRelevance, Converter={StaticResource RelevanceConverter}}" />
             </StackPanel>
@@ -267,12 +293,14 @@
                            Stroke="{StaticResource ImportStroke}"
                            Fill="{StaticResource ImportBrush}" />
                 <TextBlock x:Name="label"
+                           Classes="nodeText"
                            Text="Import"
-                           Margin="0,0,6,0"
                            Foreground="{Binding IsSelected, Converter={StaticResource LabelColorConverter}, ConverterParameter={StaticResource ImportStroke}}" />
                 <TextBlock x:Name="name"
+                           Classes="nodeText"
                            Text="{Binding Name}" />
                 <TextBlock x:Name="location"
+                           Classes="nodeText"
                            Text="{Binding Location}" />
             </StackPanel>
         </TreeDataTemplate>
@@ -286,15 +314,17 @@
                            Stroke="{StaticResource NoImportStroke}"
                            Fill="{StaticResource NoImportBrush}" />
                 <TextBlock x:Name="label"
+                           Classes="nodeText"
                            Text="NoImport"
-                           Margin="0,0,6,0"
                            Foreground="{Binding IsSelected, Converter={StaticResource LabelColorConverter}, ConverterParameter={StaticResource NoImportStroke}}" />
                 <TextBlock x:Name="name"
+                           Classes="nodeText"
                            Text="{Binding Name}" />
                 <TextBlock x:Name="location"
-                           Text="{Binding Location}"
-                           Margin="0,0,6,0" />
+                           Classes="nodeText"
+                           Text="{Binding Location}" />
                 <TextBlock x:Name="reason"
+                           Classes="nodeText"
                            Text="{Binding Text}" />
             </StackPanel>
         </TreeDataTemplate>
@@ -307,6 +337,7 @@
                            Stroke="{StaticResource FolderStroke}"
                            Fill="{StaticResource ClosedFolderBrush}" />
                 <TextBlock Name="nameText"
+                           Classes="nodeText"
                            Text="{Binding Name}"
                            Foreground="{Binding IsSelected, Converter={StaticResource LabelColorConverter}, ConverterParameter={x:Static Brushes.DarkGoldenrod}}" />
             </StackPanel>
@@ -329,6 +360,7 @@
                            Stroke="{StaticResource ErrorStroke}"
                            Fill="{StaticResource ErrorBrush}" />
                 <TextBlock Name="text"
+                           Classes="nodeText"
                            Text="{Binding}"
                            Foreground="{Binding IsSelected, Converter={StaticResource LabelColorConverter}, ConverterParameter={StaticResource ErrorStroke}}" />
             </StackPanel>
@@ -340,7 +372,8 @@
                            Classes="nodeIcon"
                            Stroke="{StaticResource WarningStroke}"
                            Fill="{StaticResource WarningBrush}" />
-                <TextBlock Text="{Binding}" />
+                <TextBlock Classes="nodeText"
+                           Text="{Binding}" />
             </StackPanel>
         </DataTemplate>
 
@@ -392,9 +425,14 @@
                               Focusable="False">
                     <ItemsControl.DataTemplates>
                         <DataTemplate DataType="{x:Type common:HighlightedText}">
-                            <TextBlock Foreground="Black"
+                            <TextBlock Classes="nodeBeforeText"
+                                       Foreground="Black"
                                        Background="Yellow"
                                        Text="{Binding Text}" />
+                        </DataTemplate>
+                        <DataTemplate>
+                            <TextBlock Classes="nodeBeforeText"
+                                       Text="{Binding .}" />
                         </DataTemplate>
                     </ItemsControl.DataTemplates>
                     <ItemsControl.ItemsPanel>

--- a/src/StructuredLogViewer.Avalonia/App.xaml
+++ b/src/StructuredLogViewer.Avalonia/App.xaml
@@ -22,28 +22,54 @@
         <StyleInclude Source="avares://Avalonia.Themes.Default/Accents/BaseLight.xaml"/>
         <StyleInclude Source="avares://AvaloniaEdit/AvaloniaEdit.xaml" />
         <StyleInclude Source="/Styles.xaml" />
+
+        <Style Selector="TreeViewItem /template/ ToggleButton#expander">
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <Border Background="Transparent"
+                            Width="16"
+                            Height="16"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center">
+                        <Path Fill="{DynamicResource ThemeForegroundBrush}"
+                              HorizontalAlignment="Left"
+                              VerticalAlignment="Top"
+                              Data="M 6 4 L 10 8 L 6 12 Z"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+        </Style>
+
+        <Style Selector="TreeViewItem /template/ ToggleButton#expander:checked">
+            <Setter Property="RenderTransform">
+                <TransformGroup>
+                    <RotateTransform Angle="45" />
+                    <TranslateTransform X="2" Y="2" />
+                </TransformGroup>
+            </Setter>
+        </Style>
         
         <Style Selector="Rectangle.nodeIcon">
-            <Setter Property="Width" Value="16" />
+            <Setter Property="Width" Value="14" />
             <Setter Property="Height" Value="12" />
-            <Setter Property="Margin" Value="2,4,6,2" />
+            <Setter Property="Margin" Value="2,2,6,2" />
             <Setter Property="StrokeThickness" Value="1" />
-            <Setter Property="VerticalAlignment" Value="Top" />
+            <Setter Property="VerticalAlignment" Value="Center" />
         </Style>
 
         <Style Selector="Image.projectNodeIcon">
             <Setter Property="Width" Value="16" />
             <Setter Property="Height" Value="16" />
-            <Setter Property="Margin" Value="2,2,6,0" />
-            <Setter Property="VerticalAlignment" Value="Top" />
+            <Setter Property="Margin" Value="2,2,6,2" />
+            <Setter Property="VerticalAlignment" Value="Center" />
         </Style>
 
         <Style Selector="TextBlock.nodeBeforeText">
-            <Setter Property="Margin" Value="0,2,0,0" />
+            <Setter Property="Margin" Value="0,2,0,2" />
         </Style>
 
         <Style Selector="TextBlock.nodeText">
-            <Setter Property="Margin" Value="0,2,8,0" />
+            <Setter Property="Margin" Value="0,2,8,2" />
         </Style>
     </Application.Styles>
 

--- a/src/StructuredLogViewer.Avalonia/App.xaml
+++ b/src/StructuredLogViewer.Avalonia/App.xaml
@@ -447,7 +447,10 @@
                           ItemsSource="{Binding Children}">
             <StackPanel Orientation="Horizontal">
                 <ContentPresenter Content="{Binding Converter={StaticResource ProxyNodeIconConverter}}"
-                                  VerticalAlignment="Top" />
+                                  Height="20"
+                                  Width="20"
+                                  HorizontalAlignment="Center"
+                                  VerticalAlignment="Center" />
                 <ItemsControl Items="{Binding Highlights}"
                               Focusable="False">
                     <ItemsControl.DataTemplates>

--- a/src/StructuredLogViewer.Avalonia/App.xaml
+++ b/src/StructuredLogViewer.Avalonia/App.xaml
@@ -219,8 +219,8 @@
                           ItemsSource="{Binding Children}">
             <StackPanel Orientation="Horizontal">
                 <ProgressBar Width="40" 
-                             Height="9" 
-                             Margin="2,1,6,0" 
+                             Height="12" 
+                             Margin="4,4,8,0" 
                              Minimum="0"
                              Maximum="100"
                              Value="{Binding Value}"
@@ -230,7 +230,7 @@
                            Text="{Binding Title, Mode=OneTime}" />
                 <TextBlock Name="hits" 
                            VerticalAlignment="Center"
-                           Margin="6,0,0,0"
+                           Margin="8,0,0,0"
                            Text="{Binding DurationText, Mode=OneTime}"
                            Foreground="{Binding IsSelected, Converter={StaticResource LabelColorConverter}, ConverterParameter={x:Static Brushes.Blue}}" />
                 <TextBlock Name="code"
@@ -349,7 +349,7 @@
                         Content="{Binding Text}"
                         Command="{Binding Command}"
                         IsEnabled="{Binding IsEnabled}"
-                        Padding="4,2,4,2" />
+                        Padding="4" />
             </StackPanel>
         </DataTemplate>
         
@@ -383,7 +383,7 @@
                         BorderThickness="1"
                         Margin="4"
                         Background="LightYellow"
-                        Padding="6">
+                        Padding="8">
                     <TextBlock Text="{Binding Text}"
                                Foreground="Gray"
                                TextWrapping="Wrap" />
@@ -399,6 +399,7 @@
                            Stroke="{StaticResource MessageStroke}"
                            Fill="{StaticResource MessageBrush}" />
                 <TextBlock Name="messageText"
+                           Classes="nodeText"
                            Text="{Binding Name}" />
             </StackPanel>
         </TreeDataTemplate>
@@ -467,7 +468,7 @@
                                    Grid.Row="0"
                                    FontSize="16"
                                    Foreground="Red"
-                                   Margin="10"
+                                   Margin="8"
                                    TextWrapping="Wrap"
                                    Text="{Binding Message}" />
                         <!--
@@ -493,7 +494,7 @@
                                     </Image>
                                     <TextBlock Text="Open Project/Solution"
                                                FontSize="16"
-                                               Margin="10"
+                                               Margin="8"
                                                HorizontalAlignment="Center" />
                                 </StackPanel>
                             </Button>
@@ -506,54 +507,54 @@
                                     <Canvas Width="100"
                                             Height="100"
                                             Margin="20">
-                                        <Rectangle Width="35"
-                                                   Height="35"
+                                        <Rectangle Width="36"
+                                                   Height="36"
                                                    Canvas.Left="0"
                                                    Canvas.Top="0"
                                                    Stroke="{StaticResource TargetStroke}"
                                                    StrokeThickness="1"
                                                    Fill="{StaticResource TargetBrush}" />
-                                        <Rectangle Width="35"
-                                                   Height="35"
-                                                   Canvas.Left="25"
-                                                   Canvas.Top="35"
+                                        <Rectangle Width="36"
+                                                   Height="36"
+                                                   Canvas.Left="24"
+                                                   Canvas.Top="36"
                                                    Stroke="{StaticResource ParameterStroke}"
                                                    StrokeThickness="1"
                                                    Fill="{StaticResource ParameterBrush}" />
-                                        <Rectangle Width="35"
-                                                   Height="35"
-                                                   Canvas.Left="25"
-                                                   Canvas.Top="70"
+                                        <Rectangle Width="36"
+                                                   Height="36"
+                                                   Canvas.Left="24"
+                                                   Canvas.Top="72"
                                                    Stroke="{StaticResource TaskStroke}"
                                                    StrokeThickness="1"
                                                    Fill="{StaticResource TaskBrush}" />
-                                        <Rectangle Width="35"
-                                                   Height="35"
+                                        <Rectangle Width="36"
+                                                   Height="36"
                                                    Canvas.Left="60"
-                                                   Canvas.Top="35"
+                                                   Canvas.Top="36"
                                                    Stroke="{StaticResource ItemStroke}"
                                                    StrokeThickness="1"
                                                    Fill="{StaticResource ItemBrush}" />
-                                        <Rectangle Width="35"
-                                                   Height="35"
+                                        <Rectangle Width="36"
+                                                   Height="36"
                                                    Canvas.Left="60"
-                                                   Canvas.Top="70"
+                                                   Canvas.Top="72"
                                                    Stroke="{StaticResource FolderStroke}"
                                                    StrokeThickness="1"
                                                    Fill="{StaticResource ClosedFolderBrush}" />
-                                        <Line StartPoint="16,35"
-                                              EndPoint="16,87"
+                                        <Line StartPoint="16,36"
+                                              EndPoint="16,88"
                                               Stroke="Black" />
-                                        <Line StartPoint="16,87"
-                                              EndPoint="25,87"
+                                        <Line StartPoint="16,88"
+                                              EndPoint="24,88"
                                               Stroke="Black" />
-                                        <Line StartPoint="16,53"
-                                              EndPoint="25,53"
+                                        <Line StartPoint="16,52"
+                                              EndPoint="24,52"
                                               Stroke="Black" />
                                     </Canvas>
                                     <TextBlock Text="Open Log File"
                                                FontSize="16"
-                                               Margin="10"
+                                               Margin="8"
                                                HorizontalAlignment="Center" />
                                 </StackPanel>
                             </Button>
@@ -563,9 +564,9 @@
                               IsVisible="{Binding ShowRecentProjects}">
                             <Expander IsExpanded="True"
                                       Header="Recent projects and solutions"
-                                      Margin="10">
+                                      Margin="8">
                                 <ListBox Items="{Binding RecentProjects}"
-                                         Margin="10"
+                                         Margin="8"
                                          SelectedItem="{Binding SelectedProject, Mode=OneWayToSource}"
                                          Background="Transparent"
                                          BorderBrush="Transparent"
@@ -588,15 +589,15 @@
                         </Grid>
                         <StackPanel Grid.Row="4">
                             <CheckBox Content="Enable tree virtualization (faster, but may cause hangs)"
-                                      Margin="10,0,10,10"
+                                      Margin="8,0,8,8"
                                       IsChecked="{Binding EnableVirtualization}"
                                       ToolTip.Tip="Disable virtualization if you're experiencing hangs or deadlocks when scrolling the tree" />
                             <CheckBox Content="Display all targets directly under the project (flattened in temporal order)"
-                                      Margin="10,0,10,10"
+                                      Margin="8,0,8,8"
                                       IsChecked="{Binding ParentAllTargetsUnderProject}" 
                                       ToolTip.Tip="Linearize/flatten all targets under the project instead of parenting targets under their dependency target"/>
                             <CheckBox Content="Mark search results with a dot in the main tree"
-                                      Margin="10,0,10,10"
+                                      Margin="8,0,8,8"
                                       IsChecked="{Binding MarkResultsInTree}" 
                                       ToolTip.Tip="Mark tree nodes that appear in search results with a dot"/>
                         </StackPanel>
@@ -704,8 +705,8 @@
                              Value="100"
                              HorizontalAlignment="Center"
                              Width="200"
-                             Height="23"
-                             Margin="10" />
+                             Height="24"
+                             Margin="12" />
                 <!--TODO:
                 IsIndeterminate="True"
                 -->
@@ -713,13 +714,13 @@
                             Margin="40"
                             IsVisible="{Binding ShowCommandLine}">
                     <TextBlock Text="Using command line (press Ctrl+C to copy):"
-                               Margin="0,0,0,7" />
+                               Margin="0,0,0,8" />
                     <TextBox Text="{Binding MSBuildCommandLine}"
                              IsReadOnly="True"
                              TextWrapping="Wrap"
                              AcceptsReturn="True"
                              Background="#E0E0E0"
-                             MinHeight="23" />
+                             MinHeight="24" />
                 </StackPanel>
             </Grid>
         </DataTemplate>

--- a/src/StructuredLogViewer.Avalonia/App.xaml
+++ b/src/StructuredLogViewer.Avalonia/App.xaml
@@ -27,14 +27,14 @@
             <Setter Property="Template">
                 <ControlTemplate>
                     <Border Background="Transparent"
-                            Width="16"
-                            Height="16"
+                            Width="12"
+                            Height="12"
                             HorizontalAlignment="Center"
                             VerticalAlignment="Center">
                         <Path Fill="{DynamicResource ThemeForegroundBrush}"
                               HorizontalAlignment="Left"
                               VerticalAlignment="Top"
-                              Data="M 6 4 L 10 8 L 6 12 Z"/>
+                              Data="M 4 2 L 8 6 L 4 10 Z"/>
                     </Border>
                 </ControlTemplate>
             </Setter>
@@ -52,7 +52,7 @@
         <Style Selector="Rectangle.nodeIcon">
             <Setter Property="Width" Value="14" />
             <Setter Property="Height" Value="12" />
-            <Setter Property="Margin" Value="2,2,6,2" />
+            <Setter Property="Margin" Value="2,1,6,1" />
             <Setter Property="StrokeThickness" Value="1" />
             <Setter Property="VerticalAlignment" Value="Center" />
         </Style>
@@ -60,16 +60,16 @@
         <Style Selector="Image.projectNodeIcon">
             <Setter Property="Width" Value="16" />
             <Setter Property="Height" Value="16" />
-            <Setter Property="Margin" Value="2,2,6,2" />
+            <Setter Property="Margin" Value="2,1,6,1" />
             <Setter Property="VerticalAlignment" Value="Center" />
         </Style>
 
         <Style Selector="TextBlock.nodeBeforeText">
-            <Setter Property="Margin" Value="0,2,0,2" />
+            <Setter Property="Margin" Value="0,1,0,1" />
         </Style>
 
         <Style Selector="TextBlock.nodeText">
-            <Setter Property="Margin" Value="0,2,8,2" />
+            <Setter Property="Margin" Value="0,1,8,1" />
         </Style>
     </Application.Styles>
 
@@ -447,8 +447,6 @@
                           ItemsSource="{Binding Children}">
             <StackPanel Orientation="Horizontal">
                 <ContentPresenter Content="{Binding Converter={StaticResource ProxyNodeIconConverter}}"
-                                  Height="20"
-                                  Width="20"
                                   HorizontalAlignment="Center"
                                   VerticalAlignment="Center" />
                 <ItemsControl Items="{Binding Highlights}"

--- a/src/StructuredLogViewer.Avalonia/App.xaml
+++ b/src/StructuredLogViewer.Avalonia/App.xaml
@@ -456,14 +456,8 @@
                 <Grid HorizontalAlignment="Center"
                       VerticalAlignment="Center">
                     <Rectangle Fill="Black" />
-                    <Grid Background="White">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                        </Grid.RowDefinitions>
+                    <Grid Background="White"
+                          RowDefinitions="Auto,Auto,Auto,Auto,Auto">
                         <TextBlock Name="customMessage"
                                    Grid.Row="0"
                                    FontSize="16"
@@ -475,11 +469,8 @@
                                    IsVisible="{Binding Message, Converter={StaticResource StringEmptinessToVisibilityConverter}}"
                         -->
                         <Grid Name="openLogOrProjectCompartment"
-                              Grid.Row="1">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="Auto" />
-                            </Grid.ColumnDefinitions>
+                              Grid.Row="1"
+                              ColumnDefinitions="Auto,Auto">
                             <Button Margin="20"
                                     MinWidth="200"
                                     MinHeight="200"
@@ -610,11 +601,8 @@
             <Grid Name="buildParameters"
                   HorizontalAlignment="Center"
                   VerticalAlignment="Center"
-                  Margin="40">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
+                  Margin="40"
+                  RowDefinitions="Auto,Auto">
                 <StackPanel Grid.Row="0"
                             Margin="40,40,40,12">
                     <TextBlock Text="Specify custom MSBuild command line arguments:"
@@ -691,12 +679,8 @@
             <Grid Name="buildProgress"
                   HorizontalAlignment="Center"
                   VerticalAlignment="Center"
-                  Margin="40">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
+                  Margin="40"
+                  RowDefinitions="Auto,Auto,Auto">
                 <TextBlock Name="text"
                            Text="{Binding ProgressText}"
                            HorizontalAlignment="Center"

--- a/src/StructuredLogViewer.Avalonia/App.xaml
+++ b/src/StructuredLogViewer.Avalonia/App.xaml
@@ -577,16 +577,16 @@
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
                 <StackPanel Grid.Row="0"
-                            Margin="40,40,40,10">
+                            Margin="40,40,40,12">
                     <TextBlock Text="Specify custom MSBuild command line arguments:"
-                               Margin="0,0,0,7" />
+                               Margin="0,0,0,8" />
                     <WrapPanel Orientation="Horizontal">
                         <ComboBox Items="{Binding MSBuildLocations}"
                                   ToolTip.Tip="Select MSBuild toolset to use for building"
-                                  Height="22" />
+                                  Height="24" />
                         <Button Command="{Binding BrowseForMSBuildCommand}"
-                                Width="22"
-                                Height="22"
+                                Width="24"
+                                Height="24"
                                 ToolTip.Tip="Browse for custom MSBuild.exe location..."
                                 Margin="0,0,8,0">
                             <StackPanel Orientation="Horizontal">
@@ -605,11 +605,11 @@
                             </StackPanel>
                         </Button>
                         <TextBlock Text="{Binding PrefixArguments}"
-                                   Margin="0,3,0,0"
+                                   Margin="0,4,0,0"
                                    TextWrapping="Wrap" />
                         <TextBox Name="argumentsText"
                                  Margin="4,0,4,0"
-                                 Padding="0,1,0,0"
+                                 Padding="0,4,0,0"
                                  Text="{Binding MSBuildArguments}"
                                  TextWrapping="Wrap"
                                  MinWidth="300">
@@ -620,29 +620,30 @@
                         </TextBox>
 
                         <TextBlock Text="{Binding PostfixArguments}"
+                                   Margin="0,4,0,0"
                                    TextWrapping="Wrap" />
                     </WrapPanel>
                     <Button Content="Copy command line to clipboard"
                             Command="{Binding CopyCommand}"
                             Padding="4,0,4,0"
-                            Height="23"
+                            Height="24"
                             HorizontalAlignment="Right"
                             Margin="4" />
                 </StackPanel>
                 <StackPanel Grid.Row="1"
                             HorizontalAlignment="Center"
-                            Margin="40,10,40,40"
+                            Margin="40,12,40,40"
                             Orientation="Horizontal">
                     <Button Content="Build"
                             Command="{Binding BuildCommand}"
-                            Width="75"
-                            Height="23"
-                            Margin="7" />
+                            Width="76"
+                            Height="24"
+                            Margin="8" />
                     <Button Content="Cancel"
                             Command="{Binding CancelCommand}"
-                            Width="75"
-                            Height="23"
-                            Margin="0,7,7,7" />
+                            Width="76"
+                            Height="24"
+                            Margin="8" />
                 </StackPanel>
             </Grid>
         </DataTemplate>

--- a/src/StructuredLogViewer.Avalonia/App.xaml
+++ b/src/StructuredLogViewer.Avalonia/App.xaml
@@ -50,7 +50,7 @@
         </Style>
         
         <Style Selector="Rectangle.nodeIcon">
-            <Setter Property="Width" Value="14" />
+            <Setter Property="Width" Value="16" />
             <Setter Property="Height" Value="12" />
             <Setter Property="Margin" Value="2,1,6,1" />
             <Setter Property="StrokeThickness" Value="1" />
@@ -407,7 +407,7 @@
             <StackPanel Orientation="Horizontal">
                 <Border BorderBrush="LightGray"
                         BorderThickness="1"
-                        Margin="4"
+                        Margin="2,4"
                         Background="LightYellow"
                         Padding="8">
                     <TextBlock Text="{Binding Text}"

--- a/src/StructuredLogViewer.Avalonia/App.xaml
+++ b/src/StructuredLogViewer.Avalonia/App.xaml
@@ -113,7 +113,7 @@
                            Stroke="{StaticResource TargetStroke}"
                            Fill="{StaticResource TargetBrush}" />
                 <TextBlock Name="label"
-                           Classes="nodeText"
+                           Classes="nodeBeforeText"
                            Text="Target "
                            Foreground="{Binding IsSelected, Converter={StaticResource LabelColorConverter}, ConverterParameter={StaticResource TargetStroke}}" />
                 <TextBlock Classes="nodeText"
@@ -140,7 +140,7 @@
                            Stroke="{StaticResource TaskStroke}"
                            Fill="{StaticResource TaskBrush}" />
                 <TextBlock Name="label"
-                           Classes="nodeText"
+                           Classes="nodeBeforeText"
                            Text="Task "
                            Foreground="{Binding IsSelected, Converter={StaticResource LabelColorConverter}, ConverterParameter={StaticResource TaskStroke}}"/>
                 <TextBlock Classes="nodeText"
@@ -160,7 +160,7 @@
                            Stroke="{StaticResource ItemStroke}"
                            Fill="{StaticResource ItemBrush}" />
                 <TextBlock Name="label"
-                           Classes="nodeText"
+                           Classes="nodeBeforeText"
                            Text="Add Item "
                            Foreground="{Binding IsSelected, Converter={StaticResource LabelColorConverter}, ConverterParameter={x:Static Brushes.Teal}}" />
                 <TextBlock Text="{Binding Name}"
@@ -176,7 +176,7 @@
                            Stroke="{StaticResource ItemStroke}"
                            Fill="{StaticResource ItemBrush}" />
                 <TextBlock Name="label"
-                           Classes="nodeText"
+                           Classes="nodeBeforeText"
                            Text="Remove Item "
                            Foreground="{Binding IsSelected, Converter={StaticResource LabelColorConverter}, ConverterParameter={x:Static Brushes.Teal}}"/>
                 <TextBlock Text="{Binding Name}"
@@ -293,7 +293,7 @@
                            Stroke="{StaticResource ImportStroke}"
                            Fill="{StaticResource ImportBrush}" />
                 <TextBlock x:Name="label"
-                           Classes="nodeText"
+                           Classes="nodeBeforeText"
                            Text="Import"
                            Foreground="{Binding IsSelected, Converter={StaticResource LabelColorConverter}, ConverterParameter={StaticResource ImportStroke}}" />
                 <TextBlock x:Name="name"
@@ -314,7 +314,7 @@
                            Stroke="{StaticResource NoImportStroke}"
                            Fill="{StaticResource NoImportBrush}" />
                 <TextBlock x:Name="label"
-                           Classes="nodeText"
+                           Classes="nodeBeforeText"
                            Text="NoImport"
                            Foreground="{Binding IsSelected, Converter={StaticResource LabelColorConverter}, ConverterParameter={StaticResource NoImportStroke}}" />
                 <TextBlock x:Name="name"

--- a/src/StructuredLogViewer.Avalonia/Controls/BuildControl.xaml
+++ b/src/StructuredLogViewer.Avalonia/Controls/BuildControl.xaml
@@ -45,7 +45,7 @@
                             <TabControl Name="centralTabControl"
                                         TabStripPlacement="Bottom"
                                         SelectedIndex="0"
-                                        MinWidth="10">
+                                        MinWidth="12">
                                 <TabItem Name="mainTreeTab"
                                          Header="Log">
                                     <TreeView Name="treeView"

--- a/src/StructuredLogViewer.Avalonia/Controls/DocumentWell.xaml
+++ b/src/StructuredLogViewer.Avalonia/Controls/DocumentWell.xaml
@@ -3,6 +3,9 @@
              xmlns:local="clr-namespace:StructuredLogViewer.Avalonia.Controls;assembly=StructuredLogViewer.Avalonia"
              x:Class="StructuredLogViewer.Avalonia.Controls.DocumentWell"
              Name="documentWell">
+    <Design.DataContext>
+        <local:DocumentWell />
+    </Design.DataContext>
     <Grid>
         <TabControl Name="tabControl" Items="{Binding #documentWell.Tabs}">
             <TabControl.ItemTemplate>

--- a/src/StructuredLogViewer.Avalonia/Controls/DocumentWell.xaml
+++ b/src/StructuredLogViewer.Avalonia/Controls/DocumentWell.xaml
@@ -8,7 +8,7 @@
             <TabControl.ItemTemplate>
                 <DataTemplate DataType="{x:Type local:SourceFileTab}">
                     <StackPanel Orientation="Horizontal">
-                        <TextBlock MinWidth="50"
+                        <TextBlock MinWidth="52"
                                    Text="{Binding FileName}"
                                    VerticalAlignment="Center" />
                         <Button Name="HideButton"

--- a/src/StructuredLogViewer.Avalonia/Controls/SearchAndResultsControl.xaml
+++ b/src/StructuredLogViewer.Avalonia/Controls/SearchAndResultsControl.xaml
@@ -5,20 +5,20 @@
     <DockPanel>
         <Grid DockPanel.Dock="Top">
             <TextBox Name="searchTextBox"
-                     MinHeight="23"
+                     MinHeight="24"
                      BorderThickness="0,0,0,1" />
             <Path Name="magnifyingGlass"
                   Data="{DynamicResource SearchGeometry}"
                   Fill="#717171"
                   HorizontalAlignment="Right"
                   VerticalAlignment="Center"
-                  Margin="3"
+                  Margin="4"
                   IsVisible="{Binding #searchTextBox.Text, Converter={x:Static StringConverters.IsNullOrEmpty}}" />
             <Button Name="clearSearchButton"
                     Classes="close"
                     HorizontalAlignment="Right"
                     VerticalAlignment="Stretch"
-                    Margin="0,0,0,1"
+                    Margin="0,0,0,4"
                     Width="20"
                     IsVisible="{Binding #searchTextBox.Text, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
         </Grid>

--- a/src/StructuredLogViewer.Avalonia/Controls/TextViewerControl.xaml
+++ b/src/StructuredLogViewer.Avalonia/Controls/TextViewerControl.xaml
@@ -12,11 +12,11 @@
                     VerticalAlignment="Center"
                     BorderThickness="0"
                     Background="Transparent"
-                    Padding="6,3,6,3"
+                    Padding="8,4,8,4"
                     ToolTip.Tip="Open in external editor" />
             <Button Name="copyFullPath"
                     Content="Copy Path"
-                    Padding="6,3,6,3"
+                    Padding="8,4,8,4"
                     BorderThickness="0"
                     Background="Transparent"
                     VerticalAlignment="Center"
@@ -24,7 +24,7 @@
                     ToolTip.Tip="Copy full path" />
             <Button Name="preprocess"
                     Content="Preprocess"
-                    Padding="6,3,6,3"
+                    Padding="8,4,8,4"
                     BorderThickness="0"
                     Background="Transparent"
                     VerticalAlignment="Center"

--- a/src/StructuredLogViewer.Avalonia/MainWindow.xaml
+++ b/src/StructuredLogViewer.Avalonia/MainWindow.xaml
@@ -54,7 +54,7 @@
         <Grid>
             <ContentPresenter Name="mainContent"
                               Classes="mainContent"
-                              Margin="7" />
+                              Margin="8" />
         </Grid>
     </DockPanel>
 </Window>

--- a/src/StructuredLogViewer.Avalonia/Styles.xaml
+++ b/src/StructuredLogViewer.Avalonia/Styles.xaml
@@ -17,7 +17,7 @@
                 <Border Name="border"
                         Background="Transparent"
                         IsVisible="{TemplateBinding IsVisible}">
-                    <Path Width="10"
+                    <Path Width="12"
                           Height="8"
                           VerticalAlignment="Center"
                           HorizontalAlignment="Center"
@@ -81,13 +81,13 @@
                                               Padding="{TemplateBinding Padding}"
                                               Grid.Column="1"/>
                             <Ellipse Grid.Column="1"
-                                     Width="6" Height="6" Margin="1,1,0,0" StrokeThickness="1"
+                                     Width="8" Height="8" Margin="4,4,0,0" StrokeThickness="1"
                                      HorizontalAlignment="Left" VerticalAlignment="Top"
                                      Fill="{StaticResource ContainsSearchResultBrush}"
                                      Stroke="{StaticResource ContainsSearchResultStroke}"
                                      IsVisible="{Binding ContainsSearchResult}"/>
                             <Ellipse Grid.Column="1"
-                                     Width="6" Height="6" Margin="1,1,0,0" StrokeThickness="1"
+                                     Width="8" Height="8" Margin="4,4,0,0" StrokeThickness="1"
                                      HorizontalAlignment="Left" VerticalAlignment="Top"
                                      Fill="{StaticResource SearchResultBrush}"
                                      Stroke="{StaticResource SearchResultStroke}"


### PR DESCRIPTION
Supports HiDPI for `BuildParametersScreen`,  fix width/height, margin/padding properties 

Scale: 125%

Before (Avalonia) | After (Avalonia) | Last (Avalonia) |(WPF)  |
------------------  | ----------------- | ------- |---|
![BeforeAvalonia1](https://user-images.githubusercontent.com/2669927/115990813-01625680-a5ce-11eb-8d6b-44d25227a0c9.png) | ![AfterAvalonia1](https://user-images.githubusercontent.com/2669927/115990809-00312980-a5ce-11eb-9de9-7a278385f4f3.png) | |![Wpf1](https://user-images.githubusercontent.com/2669927/115990816-01faed00-a5ce-11eb-96e0-c13bcb36aae0.png) |
![BeforeAvalonia2](https://user-images.githubusercontent.com/2669927/115990814-01625680-a5ce-11eb-8014-a499ca4a1ba6.png) | ![AfterAvalonia2](https://user-images.githubusercontent.com/2669927/115990811-00c9c000-a5ce-11eb-859d-bb1eb9bf9b83.png) | | ![Wpf2](https://user-images.githubusercontent.com/2669927/115990979-d6c4cd80-a5ce-11eb-94e7-ef49387bb57f.png) |
![BeforeAvalonia3](https://user-images.githubusercontent.com/2669927/115990815-01faed00-a5ce-11eb-87aa-c21d6aa77b83.png) | ![AfterAvalonia3](https://user-images.githubusercontent.com/2669927/115991522-7edb9600-a5d1-11eb-91fe-d1495a184ad3.png) | ![LastAvalonia3](https://user-images.githubusercontent.com/2669927/116411877-cd419c80-a83e-11eb-80eb-4c89f494d98e.png) | ![Wpf3](https://user-images.githubusercontent.com/2669927/115990819-02938380-a5ce-11eb-8af7-8bc21bf959bb.png) |


