### PR TITLE
Use a different suffix for line breaks in shortened text

### DIFF
--- a/src/StructuredLogger/TextUtilities.cs
+++ b/src/StructuredLogger/TextUtilities.cs
@@ -311,7 +311,14 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 }
             }
 
-            return text.Substring(0, newLength) + trimPrompt;
+            var shortText = text.Substring(0, newLength);
+
+            if (lineBreak == newLength && IsWhitespace(text, new Span(newLength, text.Length - newLength)))
+            {
+                return shortText + '\u21b5';
+            }
+
+            return shortText + trimPrompt;
         }
 
         public static int IndexOfFirstLineBreak(this string text)


### PR DESCRIPTION
Tasks can log lines with a line break at the end, and the viewer currently displays these like this:

![image](https://user-images.githubusercontent.com/7913492/121775402-b1445100-cb87-11eb-94c5-c92392798d25.png)

This suggests there is more information in the message, but it's not true. This PR changes the display to this:

![image](https://user-images.githubusercontent.com/7913492/121775446-1304bb00-cb88-11eb-8fb8-d2bbc0b6999a.png)

If there's only whitespace after the line break, it changes the suffix to "↵". This tells the user there's a line break, but there's nothing interesting afterwards.

Note that the space before the suffix belongs to the message in the example screenshots - the actual suffix is `"↵"`, not `" ↵"`.