### PR TITLE
Insert a space after clicking a node kind link

### DIFF
--- a/src/StructuredLogViewer.Avalonia/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer.Avalonia/Controls/BuildControl.xaml.cs
@@ -309,7 +309,7 @@ Use syntax like '$property Prop' to narrow results down by item kind. Supported 
 Examples:
 ";
 
-            //Inline MakeLink(string query, string before = " • ", string after = "\r\n")
+            //Inline MakeLink(string query, string before = " \u2022 ", string after = "\r\n")
             //{
             //    var hyperlink = new Hyperlink(new Run(query));
             //    hyperlink.Click += (s, e) => searchLogControl.SearchText = query;
@@ -359,7 +359,7 @@ Examples:
             foreach (var example in searchExamples)
             {
                 //text += (MakeLink(example));
-                text += example;
+                text += " \u2022 " + example + Environment.NewLine;
             }
 
             var recentSearches = SettingsService.GetRecentSearchStrings();
@@ -372,7 +372,7 @@ Recent:
                 foreach (var recentSearch in recentSearches.Where(s => !searchExamples.Contains(s) && !nodeKinds.Contains(s)))
                 {
                     //text += MakeLink(recentSearch));
-                    text += recentSearch;
+                    text += " \u2022 " + recentSearch + Environment.NewLine;
                 }
             }
 

--- a/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
@@ -532,9 +532,9 @@ Right-clicking a project node may show the 'Preprocess' option if the version of
             "$noimport"
         };
 
-        Inline MakeLink(string query, SearchAndResultsControl searchControl, string before = " • ", string after = "\r\n")
+        private static Inline MakeLink(string query, SearchAndResultsControl searchControl, string before = " \u2022 ", string after = "\r\n")
         {
-            var hyperlink = new Hyperlink(new Run(query));
+            var hyperlink = new Hyperlink(new Run(query.Trim()));
             hyperlink.Click += (s, e) => searchControl.SearchText = query;
 
             var span = new System.Windows.Documents.Span();
@@ -589,7 +589,7 @@ Examples:
                 }
 
                 isFirst = false;
-                watermark.Inlines.Add(MakeLink(nodeKind, searchLogControl, before: null, after: null));
+                watermark.Inlines.Add(MakeLink(nodeKind + " ", searchLogControl, before: null, after: null));
             }
 
             watermark.Inlines.Add(new LineBreak());
@@ -626,7 +626,7 @@ Recent:
                 "Surround the search term in quotes to find an exact match " +
                 "(turns off substring search). Prefix the search term with " +
                 "[[name=]] or [[value=]] to only search property and metadata names " +
-                "or values. Add [[$property]], [[$item]] or [[$metadata]] to limit search " +
+                "or values. Add [[$property ]], [[$item ]] or [[$metadata ]] to limit search " +
                 "to a specific node type.";
 
             var watermark = new TextBlock();


### PR DESCRIPTION
This lets the user type the desired value immediately after clicking on one of those links, without having to add a space first:

![image](https://user-images.githubusercontent.com/7913492/121779977-85809580-cb9e-11eb-8edf-18aca06cf690.png)

e.g. clicking on `$task` will insert `$task |` instead of `$task|`, where `|` is the cursor.

This also reformats the text in the Avalonia version.
