### PR TITLE
Improve the exception when a property is not found

### DIFF
--- a/src/TaskRunner/Executor.cs
+++ b/src/TaskRunner/Executor.cs
@@ -194,10 +194,6 @@ namespace TaskRunner
         public static void SetPropertyValue<T>(object instance, string propertyName, T value)
         {
             var propertyInfo = FindPropertyInfo(instance, propertyName, out var flags, out var type);
-            if (propertyInfo == null)
-            {
-                throw new ArgumentException("Property " + propertyName + " was not found on type " + type.ToString());
-            }
 
             // Workaround for Reflection bug 791391
             if (propertyInfo.DeclaringType != type)
@@ -214,6 +210,12 @@ namespace TaskRunner
             flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
             type = instance.GetType();
             var propertyInfo = type.GetProperty(propertyName, flags);
+            if (propertyInfo == null)
+            {
+                throw new ArgumentException($"Property {propertyName} was not found on type {type}. " +
+                                            "This probably means that the task being run was recorded with a newer version of " +
+                                            $"MSBuild than the version used by MSBuild Structured Log Viewer ({Microsoft.Build.Evaluation.ProjectCollection.Version}).");
+            }
             return propertyInfo;
         }
     }

--- a/src/TaskRunner/Program.cs
+++ b/src/TaskRunner/Program.cs
@@ -58,7 +58,14 @@ namespace TaskRunner
 
             Microsoft.Build.Locator.MSBuildLocator.RegisterDefaults();
 
-            new Program().Run(binlog, index, taskName);
+            try
+            {
+                new Program().Run(binlog, index, taskName);
+            }
+            catch (Exception exception)
+            {
+                Console.Error.WriteLine(exception);
+            }
 
             if (pause)
             {


### PR DESCRIPTION
FindPropertyInfo is used at three different places but the result was only checked in one place (the SetPropertyValue<T> method). Now the result is checked inside the `FindPropertyInfo` method itself to make sure we have a proper exception rather than a `NullReferenceException` when accessing `propertyInfo.PropertyType` on a null `propertyInfo`.

Also, the message of the exception has been improved to give a hint about the probable root cause of the issue.

Finally, wrap Program.Run in a try/catch so that we can read the exception and decide to close the console by pressing a key.