### PR TITLE
Update MSBuild to version 16.10.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,7 @@
     <DebugType Condition="$(OS) == 'Windows_NT'">embedded</DebugType>
     <LangVersion>latest</LangVersion>
 
-    <MSBuildPackageVersion>16.4.0</MSBuildPackageVersion>
+    <MSBuildPackageVersion>16.10.0</MSBuildPackageVersion>
     <NuGetVersionNerdbankGitVersioning>3.4.194</NuGetVersionNerdbankGitVersioning>
   </PropertyGroup>
 


### PR DESCRIPTION
So that all known task parameters are known and the safety net introduced in #508 won't even trigger.