### PR TITLE
Improve exception message when a property is not found

### DIFF
--- a/src/TaskRunner/Executor.cs
+++ b/src/TaskRunner/Executor.cs
@@ -68,7 +68,15 @@ namespace TaskRunner
 
             foreach (var parameter in parametersNode.Children)
             {
-                SetParameter(parameter, instance);
+                try
+                {
+                    SetParameter(parameter, instance);
+                }
+                catch (MissingPropertyException exception)
+                {
+                    exception.MSBuildVersion = task.GetNearestParent<Build>()?.MSBuildVersion;
+                    throw;
+                }
             }
         }
 
@@ -212,9 +220,7 @@ namespace TaskRunner
             var propertyInfo = type.GetProperty(propertyName, flags);
             if (propertyInfo == null)
             {
-                throw new ArgumentException($"Property {propertyName} was not found on type {type}. " +
-                                            "This probably means that the task being run was recorded with a newer version of " +
-                                            $"MSBuild than the version used by MSBuild Structured Log Viewer ({Microsoft.Build.Evaluation.ProjectCollection.Version}).");
+                throw new MissingPropertyException(className: type.FullName, propertyName: propertyName);
             }
             return propertyInfo;
         }

--- a/src/TaskRunner/MissingPropertyException.cs
+++ b/src/TaskRunner/MissingPropertyException.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace TaskRunner
+{
+    public class MissingPropertyException : MissingMemberException
+    {
+        public MissingPropertyException(string className, string propertyName) : base(className, propertyName)
+        {
+        }
+
+        public string MSBuildVersion { get; set; }
+
+        public override string Message
+            => $"Property {MemberName} was not found on type {ClassName}. " +
+               $"This probably means that the task being run was recorded with a newer version of MSBuild ({MSBuildVersion ?? "N/A"}) " +
+               $"than the version used by MSBuild Structured Log Viewer ({Microsoft.Build.Evaluation.ProjectCollection.Version}).";
+    }
+}


### PR DESCRIPTION
Building on top of #508 to provide an even better exception message that include both MSBuild version numbers (version from the binlog + version used by MSBuild Structured Log Viewer) for easy understanding of the problem.

Example exception message:
> TaskRunner.MissingPropertyException: Property OutputUnresolvedAssemblyConflicts was not found on type Microsoft.Build.Tasks.ResolveAssemblyReference. This probably means that the task being run was recorded with a newer version of MSBuild (16.10.1+2fd48ab73) than the version used by MSBuild Structured Log Viewer (16.4.0.56501).