### PR TITLE
Fix reference paths handling in BinlogTool

### DIFF
--- a/src/BinlogTool/Program.cs
+++ b/src/BinlogTool/Program.cs
@@ -27,7 +27,7 @@ namespace BinlogTool
                 return;
             }
 
-            Console.WriteLine("Usage: binlogtool savefiles input.binlog");
+            Console.WriteLine("Usage: binlogtool savefiles input.binlog output_path");
         }
 
         private static void CompareStrings()

--- a/src/BinlogTool/SaveFiles.cs
+++ b/src/BinlogTool/SaveFiles.cs
@@ -65,6 +65,7 @@ namespace BinlogTool
                     var reference = TryGetReference(argument);
                     if (reference != null)
                     {
+                        reference = ArchiveFile.CalculateArchivePath(reference);
                         var physicalReferencePath = GetPhysicalPath(outputDirectory, reference);
                         WriteEmptyAssembly(physicalReferencePath);
                     }
@@ -103,16 +104,30 @@ namespace BinlogTool
 
         private string TryGetReference(string argument)
         {
+            string reference;
             if (argument.StartsWith("/r:"))
             {
-                return argument.Substring(3);
+                reference = argument.Substring(3);
             }
             else if (argument.StartsWith("/reference:"))
             {
-                return argument.Substring(11);
+                reference = argument.Substring(11);
+            }
+            else
+            {
+                return null;
             }
 
-            return null;
+            if (reference.Length >= 2)
+            {
+                // Remove enclosing quotes if present
+                if ((reference.StartsWith('\'') && reference.EndsWith('\'')) ||
+                    (reference.StartsWith('"') && reference.EndsWith('"')))
+                {
+                    return reference.Substring(1, reference.Length - 2);
+                }
+            }
+            return reference;
         }
 
         private void SaveFilesFrom(Build build, string outputDirectory)


### PR DESCRIPTION
I ran into crashes with the BinlogTool and a particular binlog which had references with absolute paths such as:

`/r:"D:\some\path\assembly.dll"`

This PR fixes it by:
- Removing the enclosing quotes.
- Mapping the reference path to the output file path (removes the colon before path-combining).

Also adding the missing `output_path` argument to the usage text.