### PR TITLE
Navigate into `Import` elements

### DIFF
--- a/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
@@ -1638,7 +1638,7 @@ Recent:
                 preprocess = preprocessedFileManager.GetPreprocessAction(preprocessableFilePath, PreprocessedFileManager.GetEvaluationKey(evaluation));
             }
 
-            documentWell.DisplaySource(preprocessableFilePath, text.Text, lineNumber, column, preprocess);
+            documentWell.DisplaySource(preprocessableFilePath, text.Text, lineNumber, column, preprocess, Build);
             return true;
         }
 

--- a/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
@@ -34,6 +34,7 @@ namespace StructuredLogViewer.Controls
         private SourceFileResolver sourceFileResolver;
         private ArchiveFileResolver archiveFile => sourceFileResolver.ArchiveFile;
         private PreprocessedFileManager preprocessedFileManager;
+        private NavigationHelper navigationHelper;
 
         private MenuItem copyItem;
         private MenuItem copySubtreeItem;
@@ -328,6 +329,9 @@ Right-clicking a project node may show the 'Preprocess' option if the version of
 
             preprocessedFileManager = new PreprocessedFileManager(this.Build, sourceFileResolver);
             preprocessedFileManager.DisplayFile += filePath => DisplayFile(filePath);
+
+            navigationHelper = new NavigationHelper(Build, sourceFileResolver);
+            navigationHelper.OpenFileRequested += filePath => DisplayFile(filePath);
 
             centralTabControl.SelectionChanged += CentralTabControl_SelectionChanged;
         }
@@ -1638,7 +1642,7 @@ Recent:
                 preprocess = preprocessedFileManager.GetPreprocessAction(preprocessableFilePath, PreprocessedFileManager.GetEvaluationKey(evaluation));
             }
 
-            documentWell.DisplaySource(preprocessableFilePath, text.Text, lineNumber, column, preprocess, Build);
+            documentWell.DisplaySource(preprocessableFilePath, text.Text, lineNumber, column, preprocess, navigationHelper);
             return true;
         }
 

--- a/src/StructuredLogViewer/Controls/DocumentWell.xaml.cs
+++ b/src/StructuredLogViewer/Controls/DocumentWell.xaml.cs
@@ -2,13 +2,11 @@
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.IO;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
-using Microsoft.Build.Logging.StructuredLogger;
 
 namespace StructuredLogViewer.Controls
 {
@@ -66,7 +64,7 @@ namespace StructuredLogViewer.Controls
             int lineNumber = 0,
             int column = 0,
             Action preprocess = null,
-            Build build = null,
+            NavigationHelper navigationHelper = null,
             bool displayPath = true)
         {
             var existing = Find(sourceFilePath);
@@ -91,7 +89,7 @@ namespace StructuredLogViewer.Controls
             }
 
             var textViewerControl = new TextViewerControl();
-            textViewerControl.DisplaySource(sourceFilePath, text, lineNumber, column, preprocess, build);
+            textViewerControl.DisplaySource(sourceFilePath, text, lineNumber, column, preprocess, navigationHelper);
             var tab = new SourceFileTab()
             {
                 FilePath = sourceFilePath,

--- a/src/StructuredLogViewer/Controls/DocumentWell.xaml.cs
+++ b/src/StructuredLogViewer/Controls/DocumentWell.xaml.cs
@@ -8,6 +8,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
+using Microsoft.Build.Logging.StructuredLogger;
 
 namespace StructuredLogViewer.Controls
 {
@@ -65,6 +66,7 @@ namespace StructuredLogViewer.Controls
             int lineNumber = 0,
             int column = 0,
             Action preprocess = null,
+            Build build = null,
             bool displayPath = true)
         {
             var existing = Find(sourceFilePath);
@@ -89,7 +91,7 @@ namespace StructuredLogViewer.Controls
             }
 
             var textViewerControl = new TextViewerControl();
-            textViewerControl.DisplaySource(sourceFilePath, text, lineNumber, column, preprocess);
+            textViewerControl.DisplaySource(sourceFilePath, text, lineNumber, column, preprocess, build);
             var tab = new SourceFileTab()
             {
                 FilePath = sourceFilePath,

--- a/src/StructuredLogViewer/Controls/ImportLinkHighlighter.cs
+++ b/src/StructuredLogViewer/Controls/ImportLinkHighlighter.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Media.TextFormatting;
+using ICSharpCode.AvalonEdit;
+using ICSharpCode.AvalonEdit.Document;
+using ICSharpCode.AvalonEdit.Rendering;
+using Microsoft.Build.Logging.StructuredLogger;
+
+namespace StructuredLogViewer.Controls
+{
+    internal static class ImportLinkHighlighter
+    {
+        private const string ImportElementName = "Import";
+
+        public static void Install(TextEditor textEditor, Build build, string filePath)
+        {
+            if (build == null || string.IsNullOrEmpty(filePath))
+                return;
+
+            var importsByLocation = new Dictionary<TextLocation, string>();
+            var ambiguousLocations = new HashSet<TextLocation>();
+
+            foreach (var import in build.EvaluationFolder.Children.OfType<ProjectEvaluation>().SelectMany(i => i.GetAllImports()))
+            {
+                if (!string.Equals(import.ProjectFilePath, filePath, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                if (string.IsNullOrEmpty(import.ImportedProjectFilePath))
+                    continue;
+
+                var location = new TextLocation(import.Line, import.Column);
+
+                if (importsByLocation.TryGetValue(location, out var existingImport))
+                {
+                    if (!string.Equals(existingImport, import.ImportedProjectFilePath, StringComparison.OrdinalIgnoreCase))
+                        ambiguousLocations.Add(location);
+                }
+                else
+                {
+                    importsByLocation.Add(location, import.ImportedProjectFilePath);
+                }
+            }
+
+            foreach (var location in ambiguousLocations)
+                importsByLocation.Remove(location);
+
+            if (importsByLocation.Count == 0)
+                return;
+
+            textEditor.TextArea.TextView.ElementGenerators.Add(new ImportLinkGenerator(importsByLocation));
+        }
+
+        private class ImportLinkGenerator : VisualLineElementGenerator
+        {
+            private readonly Dictionary<TextLocation, string> imports;
+
+            public ImportLinkGenerator(Dictionary<TextLocation, string> imports)
+            {
+                this.imports = imports;
+            }
+
+            public override int GetFirstInterestedOffset(int startOffset)
+            {
+                var endOffset = CurrentContext.VisualLine.LastDocumentLine.EndOffset;
+                var relevantText = CurrentContext.GetText(startOffset, endOffset - startOffset);
+
+                var index = relevantText.Text.IndexOf("<" + ImportElementName, relevantText.Offset, relevantText.Count, StringComparison.Ordinal);
+                if (index < 0)
+                    return -1;
+
+                var elementStartOffset = index - relevantText.Offset + startOffset;
+                return elementStartOffset + 1;
+            }
+
+            public override VisualLineElement ConstructElement(int offset)
+            {
+                // The offset should point to the "I" in "<Import"
+                var text = CurrentContext.GetText(offset, ImportElementName.Length);
+                if (text.Text.IndexOf(ImportElementName, text.Offset, text.Count, StringComparison.Ordinal) != text.Offset)
+                    return null;
+
+                var location = CurrentContext.Document.GetLocation(offset - 1);
+
+                if (!imports.TryGetValue(location, out var importedPath))
+                    return null;
+
+                return new ImportLinkElement(CurrentContext.VisualLine, text.Count, importedPath);
+            }
+        }
+
+        private class ImportLinkElement : VisualLineText
+        {
+            public string ImportedPath { get; }
+
+            public ImportLinkElement(VisualLine parentVisualLine, int length, string importedPath)
+                : base(parentVisualLine, length)
+            {
+                ImportedPath = importedPath;
+            }
+
+            public override TextRun CreateTextRun(int startVisualColumn, ITextRunConstructionContext context)
+            {
+                TextRunProperties.SetTextDecorations(TextDecorations.Underline);
+                return base.CreateTextRun(startVisualColumn, context);
+            }
+
+            protected override VisualLineText CreateInstance(int length)
+            {
+                return new ImportLinkElement(ParentVisualLine, length, ImportedPath);
+            }
+        }
+    }
+}

--- a/src/StructuredLogViewer/Controls/NavigationHelper.cs
+++ b/src/StructuredLogViewer/Controls/NavigationHelper.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Microsoft.Build.Logging.StructuredLogger;
+
+namespace StructuredLogViewer.Controls
+{
+    public class NavigationHelper
+    {
+        public Build Build { get; }
+        public SourceFileResolver SourceFileResolver { get; }
+
+        public event Action<string> OpenFileRequested;
+
+        public NavigationHelper(Build build, SourceFileResolver sourceFileResolver)
+        {
+            Build = build;
+            SourceFileResolver = sourceFileResolver;
+        }
+
+        public void OpenFile(string filePath)
+        {
+            OpenFileRequested?.Invoke(filePath);
+        }
+    }
+}

--- a/src/StructuredLogViewer/Controls/TextViewerControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/TextViewerControl.xaml.cs
@@ -91,11 +91,12 @@ namespace StructuredLogViewer.Controls
         }
 
         public void DisplaySource(
-            string sourceFilePath, 
-            string text, 
-            int lineNumber = 0, 
-            int column = 0, 
-            Action showPreprocessed = null)
+            string sourceFilePath,
+            string text,
+            int lineNumber = 0,
+            int column = 0,
+            Action showPreprocessed = null,
+            Build build = null)
         {
             this.FilePath = sourceFilePath;
             this.Preprocess = showPreprocessed;
@@ -106,6 +107,9 @@ namespace StructuredLogViewer.Controls
 
             SetText(text);
             DisplaySource(lineNumber, column);
+
+            if (IsXml)
+                ImportLinkHighlighter.Install(textEditor, build, sourceFilePath);
         }
 
         protected override void OnKeyUp(KeyEventArgs e)

--- a/src/StructuredLogViewer/Controls/TextViewerControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/TextViewerControl.xaml.cs
@@ -96,7 +96,7 @@ namespace StructuredLogViewer.Controls
             int lineNumber = 0,
             int column = 0,
             Action showPreprocessed = null,
-            Build build = null)
+            NavigationHelper navigationHelper = null)
         {
             this.FilePath = sourceFilePath;
             this.Preprocess = showPreprocessed;
@@ -109,7 +109,7 @@ namespace StructuredLogViewer.Controls
             DisplaySource(lineNumber, column);
 
             if (IsXml)
-                ImportLinkHighlighter.Install(textEditor, build, sourceFilePath);
+                ImportLinkHighlighter.Install(textEditor, sourceFilePath, navigationHelper);
         }
 
         protected override void OnKeyUp(KeyEventArgs e)

--- a/src/StructuredLogger/ObjectModel/ProjectEvaluation.cs
+++ b/src/StructuredLogger/ObjectModel/ProjectEvaluation.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
             }
         }
 
-        private Dictionary<string, NamedNode> importsMap = new Dictionary<string, NamedNode>();
+        private Dictionary<string, Import> importsMap = new Dictionary<string, Import>();
 
         public void AddImport(TextNode textNode)
         {
@@ -95,5 +95,8 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
             parent.AddChild(textNode);
         }
+
+        public IReadOnlyCollection<Import> GetAllImports()
+            => importsMap.Values;
     }
 }


### PR DESCRIPTION
Here's a new little feature:

![image](https://user-images.githubusercontent.com/7913492/126869848-96d8149a-cea4-420e-8826-002f625bd49a.png)

You can now ctrl-click on an underlined `Import` element to open the file it points to.

An element won't be underlined if it points to different file paths in different evaluations, or if the file it points to is not available (because it never got imported for instance).

This could still be improved (Avalonia version, handling the back key, tooltips, selecting the target file if it's not unique, etc), but I didn't want to change too much at once.
