### PR TITLE
Support `Import` links with several targets

### DIFF
--- a/src/StructuredLogger/ObjectModel/ProjectEvaluation.cs
+++ b/src/StructuredLogger/ObjectModel/ProjectEvaluation.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
             parent.AddChild(textNode);
         }
 
-        public IReadOnlyCollection<Import> GetAllImports()
+        public IEnumerable<Import> GetAllImportsTransitive()
             => importsMap.Values;
     }
 }


### PR DESCRIPTION
Here's an improvement to #516: `Import` elements that evaluated to several files are now underlined, and a menu opens when the element is ctrl-clicked:

![image](https://user-images.githubusercontent.com/7913492/126899805-267ab258-1974-40bc-997a-73b03336cbb7.png)

I realized the element not being underlined is misleading since it suggests nothing was imported. 

I replaced the common part of the file paths with `...`, as the popup menu felt too wide otherwise. Files that were imported but are not available will be included in the menu as disabled items.
