### PR TITLE
Avalonia Import links

### DIFF
--- a/src/StructuredLogViewer.Avalonia/App.xaml
+++ b/src/StructuredLogViewer.Avalonia/App.xaml
@@ -294,7 +294,7 @@
                            Fill="{StaticResource ImportBrush}" />
                 <TextBlock x:Name="label"
                            Classes="nodeBeforeText"
-                           Text="Import"
+                           Text="Import "
                            Foreground="{Binding IsSelected, Converter={StaticResource LabelColorConverter}, ConverterParameter={StaticResource ImportStroke}}" />
                 <TextBlock x:Name="name"
                            Classes="nodeText"
@@ -315,7 +315,7 @@
                            Fill="{StaticResource NoImportBrush}" />
                 <TextBlock x:Name="label"
                            Classes="nodeBeforeText"
-                           Text="NoImport"
+                           Text="NoImport "
                            Foreground="{Binding IsSelected, Converter={StaticResource LabelColorConverter}, ConverterParameter={StaticResource NoImportStroke}}" />
                 <TextBlock x:Name="name"
                            Classes="nodeText"

--- a/src/StructuredLogViewer.Avalonia/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer.Avalonia/Controls/BuildControl.xaml.cs
@@ -31,6 +31,7 @@ namespace StructuredLogViewer.Avalonia.Controls
         private SourceFileResolver sourceFileResolver;
         private ArchiveFileResolver archiveFile => sourceFileResolver.ArchiveFile;
         private PreprocessedFileManager preprocessedFileManager;
+        private NavigationHelper navigationHelper;
 
         private MenuItem copyItem;
         private MenuItem copySubtreeItem;
@@ -189,6 +190,9 @@ Right-clicking a project node may show the 'Preprocess' option if the version of
 
             preprocessedFileManager = new PreprocessedFileManager(Build, sourceFileResolver);
             preprocessedFileManager.DisplayFile += path => DisplayFile(path);
+
+            navigationHelper = new NavigationHelper(Build, sourceFileResolver);
+            navigationHelper.OpenFileRequested += path => DisplayFile(path);
 
             //PopulateTimeline();
         }
@@ -893,7 +897,7 @@ Recent:
             }
 
             Action preprocess = preprocessedFileManager.GetPreprocessAction(sourceFilePath, PreprocessedFileManager.GetEvaluationKey(evaluation));
-            documentWell.DisplaySource(sourceFilePath, text.Text, lineNumber, column, preprocess);
+            documentWell.DisplaySource(sourceFilePath, text.Text, lineNumber, column, preprocess, navigationHelper);
             return true;
         }
 

--- a/src/StructuredLogViewer.Avalonia/Controls/DocumentWell.xaml.cs
+++ b/src/StructuredLogViewer.Avalonia/Controls/DocumentWell.xaml.cs
@@ -12,7 +12,7 @@ namespace StructuredLogViewer.Avalonia.Controls
     {
         private TabControl tabControl;
         private Button closeButton;
-        
+
         public DocumentWell()
         {
             InitializeComponent();
@@ -52,7 +52,14 @@ namespace StructuredLogViewer.Avalonia.Controls
             IsVisible = false;
         }
 
-        public void DisplaySource(string sourceFilePath, string text, int lineNumber = 0, int column = 0, Action preprocess = null, bool displayPath = true)
+        public void DisplaySource(
+            string sourceFilePath,
+            string text,
+            int lineNumber = 0,
+            int column = 0,
+            Action preprocess = null,
+            NavigationHelper navigationHelper = null,
+            bool displayPath = true)
         {
             var existing = Find(sourceFilePath);
             if (existing != null)
@@ -76,7 +83,7 @@ namespace StructuredLogViewer.Avalonia.Controls
             }
 
             var textViewerControl = new TextViewerControl();
-            textViewerControl.DisplaySource(sourceFilePath, text, lineNumber, column, preprocess);
+            textViewerControl.DisplaySource(sourceFilePath, text, lineNumber, column, preprocess, navigationHelper);
             var tab = new SourceFileTab
             {
                 FilePath = sourceFilePath,

--- a/src/StructuredLogViewer.Avalonia/Controls/DocumentWell.xaml.cs
+++ b/src/StructuredLogViewer.Avalonia/Controls/DocumentWell.xaml.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Linq;
+using Avalonia.Input;
 using Avalonia.Markup.Xaml;
 using Avalonia.Interactivity;
 
@@ -28,6 +29,7 @@ namespace StructuredLogViewer.Avalonia.Controls
             this.RegisterControl(out closeButton, nameof(closeButton));
 
             closeButton.Click += closeButton_Click;
+            tabControl.PointerPressed += TabControlOnPointerPressed;
         }
 
         private void Tabs_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
@@ -99,6 +101,25 @@ namespace StructuredLogViewer.Avalonia.Controls
         private void closeButton_Click(object sender, RoutedEventArgs e)
         {
             Hide();
+        }
+
+        private void TabControlOnPointerPressed(object sender, PointerPressedEventArgs e)
+        {
+            if (e.Handled)
+                return;
+
+            var current = e.Source;
+
+            while (current != null)
+            {
+                if (current is TabItem { DataContext: SourceFileTab sourceFileTab })
+                {
+                    sourceFileTab.Close.Execute(null);
+                    break;
+                }
+
+                current = current.InteractiveParent;
+            }
         }
     }
 }

--- a/src/StructuredLogViewer.Avalonia/Controls/ImportLinkHighlighter.cs
+++ b/src/StructuredLogViewer.Avalonia/Controls/ImportLinkHighlighter.cs
@@ -1,0 +1,248 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives.PopupPositioning;
+using Avalonia.Input;
+using Avalonia.Media;
+using AvaloniaEdit;
+using AvaloniaEdit.Document;
+using AvaloniaEdit.Rendering;
+using AvaloniaEdit.Text;
+using Microsoft.Build.Logging.StructuredLogger;
+using FontStyle = Avalonia.Media.FontStyle;
+
+namespace StructuredLogViewer.Avalonia.Controls
+{
+    internal static class ImportLinkHighlighter
+    {
+        private const string ImportElementName = "Import";
+
+        public static void Install(TextEditor textEditor, string filePath, NavigationHelper navigationHelper)
+        {
+            if (navigationHelper == null || string.IsNullOrEmpty(filePath))
+                return;
+
+            var importsByLocation = new Dictionary<TextLocation, HashSet<string>>();
+
+            foreach (var import in navigationHelper.Build.EvaluationFolder.Children.OfType<ProjectEvaluation>().SelectMany(i => i.GetAllImportsTransitive()))
+            {
+                if (!string.Equals(import.ProjectFilePath, filePath, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                if (string.IsNullOrEmpty(import.ImportedProjectFilePath))
+                    continue;
+
+                var location = new TextLocation(import.Line, import.Column);
+
+                if (importsByLocation.TryGetValue(location, out var existingImports))
+                {
+                    existingImports.Add(import.ImportedProjectFilePath);
+                }
+                else
+                {
+                    importsByLocation.Add(location, new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        import.ImportedProjectFilePath
+                    });
+                }
+            }
+
+            if (importsByLocation.Count == 0)
+                return;
+
+            textEditor.TextArea.TextView.ElementGenerators.Add(new ImportLinkGenerator(importsByLocation, navigationHelper));
+        }
+
+        private class ImportLinkGenerator : VisualLineElementGenerator
+        {
+            private readonly Dictionary<TextLocation, HashSet<string>> importsByLocation;
+            private readonly NavigationHelper navigationHelper;
+
+            public ImportLinkGenerator(Dictionary<TextLocation, HashSet<string>> importsByLocation, NavigationHelper navigationHelper)
+            {
+                this.importsByLocation = importsByLocation;
+                this.navigationHelper = navigationHelper;
+            }
+
+            public override int GetFirstInterestedOffset(int startOffset)
+            {
+                var endOffset = CurrentContext.VisualLine.LastDocumentLine.EndOffset;
+                var relevantText = CurrentContext.GetText(startOffset, endOffset - startOffset);
+
+                var index = relevantText.Text.IndexOf("<" + ImportElementName, relevantText.Offset, relevantText.Count, StringComparison.Ordinal);
+                if (index < 0)
+                    return -1;
+
+                var elementStartOffset = index - relevantText.Offset + startOffset;
+                return elementStartOffset + 1;
+            }
+
+            public override VisualLineElement ConstructElement(int offset)
+            {
+                // The offset should point to the "I" in "<Import"
+                var text = CurrentContext.GetText(offset, ImportElementName.Length);
+                if (text.Text.IndexOf(ImportElementName, text.Offset, text.Count, StringComparison.Ordinal) != text.Offset)
+                    return null;
+
+                var location = CurrentContext.Document.GetLocation(offset - 1);
+
+                if (!importsByLocation.TryGetValue(location, out var importedPaths))
+                    return null;
+
+                return new ImportLinkElement(CurrentContext.TextView, CurrentContext.VisualLine, text.Count, importedPaths, navigationHelper);
+            }
+        }
+
+        private class ImportLinkElement : VisualLineText
+        {
+            // private static readonly Cursor handCursor = new(StandardCursorType.Hand);
+
+            private readonly TextView textView;
+            private readonly HashSet<string> importedPaths;
+            private readonly NavigationHelper navigationHelper;
+
+            public ImportLinkElement(TextView textView, VisualLine parentVisualLine, int length, HashSet<string> importedPaths, NavigationHelper navigationHelper)
+                : base(parentVisualLine, length)
+            {
+                this.textView = textView;
+                this.importedPaths = importedPaths;
+                this.navigationHelper = navigationHelper;
+            }
+
+            public override TextRun CreateTextRun(int startVisualColumn, ITextRunConstructionContext context)
+            {
+                // TODO Replace bold with underline when available
+                TextRunProperties.Typeface = new Typeface(TextRunProperties.Typeface.FontFamily, FontStyle.Normal, FontWeight.Bold);
+
+                return base.CreateTextRun(startVisualColumn, context);
+            }
+
+            protected override void OnQueryCursor(PointerEventArgs e)
+            {
+                base.OnQueryCursor(e);
+
+                // TODO The cursor is not returning to the arrow after hovering over the link
+                // See https://github.com/AvaloniaUI/AvaloniaEdit/issues/133
+
+                // if (e.Handled || e.Source is not InputElement inputElement)
+                //     return;
+                //
+                // if ((e.KeyModifiers & KeyModifiers.Control) != 0)
+                // {
+                //     inputElement.Cursor = handCursor;
+                //     e.Handled = true;
+                // }
+                // else
+                // {
+                //     inputElement.Cursor = null;
+                // }
+            }
+
+            protected override void OnPointerPressed(PointerPressedEventArgs e)
+            {
+                if (e.Handled)
+                    return;
+
+                if ((e.KeyModifiers & KeyModifiers.Control) != 0 && e.GetCurrentPoint(null).Properties.IsLeftButtonPressed)
+                {
+                    OpenLink();
+                    e.Handled = true;
+                }
+
+                base.OnPointerPressed(e);
+            }
+
+            protected override VisualLineText CreateInstance(int length)
+            {
+                return new ImportLinkElement(textView, ParentVisualLine, length, importedPaths, navigationHelper);
+            }
+
+            private void OpenLink()
+            {
+                if (importedPaths.Count == 1)
+                {
+                    var filePath = importedPaths.Single();
+
+                    if (navigationHelper.SourceFileResolver.HasFile(filePath))
+                    {
+                        navigationHelper.OpenFile(filePath);
+                        return;
+                    }
+                }
+
+                OpenMenu();
+            }
+
+            private void OpenMenu()
+            {
+                var menu = new ContextMenu
+                {
+                    WindowManagerAddShadowHint = false,
+                    FontFamily = FontFamily.Default,
+                    Cursor = Cursor.Default
+                };
+
+                var commonPathLength = GetCommonPathLength();
+
+                foreach (var filePath in importedPaths.OrderBy(i => i, StringComparer.OrdinalIgnoreCase))
+                {
+                    var menuItem = new MenuItem
+                    {
+                        Header = commonPathLength < 20 ? filePath : "..." + filePath.Substring(commonPathLength),
+                    };
+
+                    if (navigationHelper.SourceFileResolver.HasFile(filePath))
+                    {
+                        menuItem.Click += (_, _) => navigationHelper.OpenFile(filePath);
+                    }
+                    else
+                    {
+                        menuItem.IsEnabled = false;
+                    }
+
+                    menu.AddItem(menuItem);
+                }
+
+                var topLeft = ParentVisualLine.GetVisualPosition(VisualColumn, VisualYPosition.LineTop);
+                var bottomRight = ParentVisualLine.GetVisualPosition(VisualColumn + VisualLength, VisualYPosition.LineBottom);
+
+                menu.PlacementMode = PlacementMode.AnchorAndGravity;
+                menu.PlacementAnchor = PopupAnchor.BottomLeft;
+                menu.PlacementGravity = PopupGravity.BottomRight;
+                menu.PlacementTarget = textView;
+                menu.PlacementRect = new Rect(topLeft - textView.ScrollOffset, bottomRight - textView.ScrollOffset);
+                menu.PlacementConstraintAdjustment = PopupPositionerConstraintAdjustment.FlipY | PopupPositionerConstraintAdjustment.SlideX;
+                menu.Open(textView);
+            }
+
+            private int GetCommonPathLength()
+            {
+                if (importedPaths.Count < 2)
+                    return 0;
+
+                var paths = importedPaths.Select(i => i.ToLowerInvariant()).ToList();
+                var charCountToConsider = paths.Min(i => i.Length);
+
+                var result = 0;
+
+                for (var charIndex = 0; charIndex < charCountToConsider; ++charIndex)
+                {
+                    var currentChar = paths[0][charIndex];
+
+                    for (var pathIndex = 1; pathIndex < paths.Count; ++pathIndex)
+                    {
+                        if (paths[pathIndex][charIndex] != currentChar)
+                            return result;
+                    }
+
+                    if (currentChar is '\\' or '/')
+                        result = charIndex;
+                }
+
+                return result;
+            }
+        }
+    }
+}

--- a/src/StructuredLogViewer.Avalonia/Controls/NavigationHelper.cs
+++ b/src/StructuredLogViewer.Avalonia/Controls/NavigationHelper.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Microsoft.Build.Logging.StructuredLogger;
+
+namespace StructuredLogViewer.Avalonia.Controls
+{
+    public class NavigationHelper
+    {
+        public Build Build { get; }
+        public SourceFileResolver SourceFileResolver { get; }
+
+        public event Action<string> OpenFileRequested;
+
+        public NavigationHelper(Build build, SourceFileResolver sourceFileResolver)
+        {
+            Build = build;
+            SourceFileResolver = sourceFileResolver;
+        }
+
+        public void OpenFile(string filePath)
+        {
+            OpenFileRequested?.Invoke(filePath);
+        }
+    }
+}

--- a/src/StructuredLogViewer.Avalonia/Controls/TextViewerControl.xaml.cs
+++ b/src/StructuredLogViewer.Avalonia/Controls/TextViewerControl.xaml.cs
@@ -86,7 +86,8 @@ namespace StructuredLogViewer.Avalonia.Controls
             string text, 
             int lineNumber = 0, 
             int column = 0, 
-            Action showPreprocessed = null)
+            Action showPreprocessed = null,
+            NavigationHelper navigationHelper = null)
         {
             this.FilePath = sourceFilePath;
             this.Preprocess = showPreprocessed;
@@ -97,6 +98,9 @@ namespace StructuredLogViewer.Avalonia.Controls
 
             SetText(text);
             DisplaySource(lineNumber, column);
+
+            if (IsXml)
+                ImportLinkHighlighter.Install(textEditor, sourceFilePath, navigationHelper);
         }
 
         private void TextAreaMouseRightButtonDown(object sender, PointerEventArgs e)


### PR DESCRIPTION
This is the Avalonia version of #516 and #517:

![image](https://user-images.githubusercontent.com/7913492/127697314-c16c090a-4db0-4312-9924-6b50fdb903a2.png)

There are a few caveats:
 - AvaloniaEdit does not support underline, but there's a [PR for this](https://github.com/AvaloniaUI/AvaloniaEdit/pull/135). I used bold in the meantime.
 - AvaloniaEdit does not handle cursor changes very well ([issue here](https://github.com/AvaloniaUI/AvaloniaEdit/issues/133), probably because of [this](https://github.com/AvaloniaUI/AvaloniaEdit/blob/a3e12d9792d5c51460854b0ea6762908258f8e43/src/AvaloniaEdit/Rendering/TextView.cs#L1642)), so I had to write some clumsy code to work around that.
 - I only tested this on Windows.

I also fixed the display of Import/NoImport nodes in the tree (a space was missing), and made so that tabs can be closed with a middle-click.