### PR TITLE
Breakdown "most expensive tasks" by parent.

### DIFF
--- a/src/StructuredLogger/Analyzers/BuildAnalyzer.cs
+++ b/src/StructuredLogger/Analyzers/BuildAnalyzer.cs
@@ -11,7 +11,8 @@ namespace Microsoft.Build.Logging.StructuredLogger
         private DoubleWritesAnalyzer doubleWritesAnalyzer;
         private ResolveAssemblyReferenceAnalyzer resolveAssemblyReferenceAnalyzer;
         private int index;
-        private Dictionary<string, TimeSpan> taskDurations = new Dictionary<string, TimeSpan>();
+        private Dictionary<string, (TimeSpan TotalDuration, Dictionary<string, TimeSpan> ParentDurations)> taskDurations
+            = new Dictionary<string, (TimeSpan TotalDuration, Dictionary<string, TimeSpan> ParentDurations)>();
         private readonly List<Folder> analyzerReports = new List<Folder>();
 
         public BuildAnalyzer(Build build)
@@ -192,7 +193,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
             }
 
             var durations = taskDurations
-                .OrderByDescending(kvp => kvp.Value)
+                .OrderByDescending(kvp => kvp.Value.TotalDuration)
                 .Where(kvp => // no need to include MSBuild and CallTarget tasks as they are not "terminal leaf" tasks
                     !string.Equals(kvp.Key, "MSBuild", StringComparison.OrdinalIgnoreCase) &&
                     !string.Equals(kvp.Key, "CallTarget", StringComparison.OrdinalIgnoreCase))
@@ -206,11 +207,21 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 var top10Tasks = build.GetOrCreateNodeWithName<Folder>(folderName);
                 foreach (var kvp in durations)
                 {
-                    top10Tasks.AddChild(new Item
+                    var taskItem = new Item
                     {
                         Name = Intern(kvp.Key),
-                        Text = Intern(TextUtilities.DisplayDuration(kvp.Value))
-                    });
+                        Text = Intern(TextUtilities.DisplayDuration(kvp.Value.TotalDuration))
+                    };
+                    var parentDurations = kvp.Value.ParentDurations.OrderByDescending(kv => kv.Value).Take(10);
+                    foreach (var parentDuration in parentDurations)
+                    {
+                        taskItem.AddChild(new Item
+                        {
+                            Name = Intern(parentDuration.Key),
+                            Text = Intern(TextUtilities.DisplayDuration(parentDuration.Value))
+                        });
+                    }
+                    top10Tasks.AddChild(taskItem);
                 }
             }
 
@@ -294,9 +305,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 build.RegisterTask(task);
             }
 
-            taskDurations.TryGetValue(task.Name, out var duration);
-            duration += task.Duration;
-            taskDurations[task.Name] = duration;
+            UpdateTaskDurations(task);
 
             if (task.Name == "ResolveAssemblyReference")
             {
@@ -316,6 +325,25 @@ namespace Microsoft.Build.Logging.StructuredLogger
             }
 
             doubleWritesAnalyzer.AnalyzeTask(task);
+        }
+
+        private void UpdateTaskDurations(Task task)
+        {
+            var parentName =
+                (task.Parent is Task parentTask) ? parentTask.Name :
+                (task.Parent is Target parentTarget) ? parentTarget.Name :
+                "???";
+
+            if (!taskDurations.TryGetValue(task.Name, out var durationTuple))
+            {
+                durationTuple = (TimeSpan.Zero, new Dictionary<string, TimeSpan>());
+            }
+            durationTuple.TotalDuration += task.Duration;
+
+            durationTuple.ParentDurations.TryGetValue(parentName, out var parentDuration);
+            durationTuple.ParentDurations[parentName] = parentDuration + task.Duration;
+
+            taskDurations[task.Name] = durationTuple;
         }
 
         private void AnalyzeTarget(Target target)


### PR DESCRIPTION
Show breakdown of "Top 10 most expensive tasks" by parent.

This addresses https://github.com/KirillOsenkov/MSBuildStructuredLog/issues/284
and shows a more detailed breakdown for other task types.

Sample output:
```
    Exec = 4:44.332
        ValidateAssemblyReferences = 4:42.379
        _GitBaseVersionFallback = 829 ms
        _GitRoot = 277 ms
        _GitCommit = 247 ms
        SetGitExe = 170 ms
        _GitBaseVersionTagExists = 156 ms
        _GitBaseVersionTag = 146 ms
        _EnsureGit = 125 ms
    Csc = 20.976 s
        CoreCompile = 20.976 s
    Copy = 17.290 s
        _CopyOutOfDateSourceItemsToOutputDirectory = 11.071 s
        _CopyFilesMarkedCopyLocal = 5.521 s
        CopyFilesToOutputDirectory = 411 ms
        _CopyAppConfigFile = 135 ms
        CopySQLiteInteropFiles = 74 ms
        CopyRoslynCompilerFilesToOutputDirectory = 68 ms
        _CopyBinDeployableAssemblies = 8 ms
    ResolveAssemblyReference = 8.104 s
        ResolveAssemblyReferences = 8.104 s
    ResolveNuGetPackageAssets = 1.213 s
        ResolveNuGetPackageAssets = 1.213 s
    ResolvePackageFileConflicts = 618 ms
        _HandlePackageFileConflicts = 618 ms
    FindUnderPath = 510 ms
        _CleanGetCurrentAndPriorFileWrites = 508 ms
        IncrementalClean = 2 ms
    WriteLinesToFile = 430 ms
        IncrementalClean = 193 ms
        _GenerateCompileDependencyCache = 118 ms
        AssembleDataPackageManifest = 71 ms
        CreateGeneratedAssemblyInfoInputsCacheFile = 47 ms
        _GitWriteCache =
        _GenerateRuntimeConfigurationFilesInputCache =
        CleanWebpackScripts =
    RestoreTask = 420 ms
        Restore = 420 ms
    RemoveDuplicates = 305 ms
        IncrementalClean = 159 ms
        _CleanGetCurrentAndPriorFileWrites = 90 ms
        Restore = 17 ms
        _GenerateRestoreProjectPathWalk = 15 ms
        _GenerateRestoreProjectPathItems = 15 ms
        _GetAllRestoreProjectPathItems = 6 ms
        _FilterRestoreGraphProjectInputItems =
```