### PR TITLE
Compile as .NET 6, add arm64 support

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -70,7 +70,7 @@
       <OutputFilename ParameterType="System.String" Required="true" />
     </ParameterGroup>
     <Task>
-      <Reference Include="System.Core" />
+      <!--<Reference Include="System.Core" />-->
       <Using Namespace="System" />
       <Using Namespace="System.IO" />
       <Using Namespace="System.Net" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -65,7 +65,7 @@
     <DownloadNuGet OutputFilename="$(NuGetExePath)" Condition="!Exists('$(NuGetExePath)')" />
   </Target>
 
-  <UsingTask TaskName="DownloadNuGet" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+  <UsingTask TaskName="DownloadNuGet" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
     <ParameterGroup>
       <OutputFilename ParameterType="System.String" Required="true" />
     </ParameterGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ install:
   - ps: '& $env:temp\dotnet-install.ps1 -Version "6.0.100-rc.1.21463.6"'
 build_script: 
 - cmd: >-
-    msbuild /r /m /p:Configuration=Release /clp:v=m MSBuildStructuredLog.sln /bl /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+    dotnet msbuild /r /m /p:Configuration=Release /clp:v=m MSBuildStructuredLog.sln /bl /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 
     dotnet cake ./build-macos.cake --settings_skippackageversioncheck=true
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,8 @@ image: Visual Studio 2019
 install:
   - choco upgrade chocolatey # Need at least 0.10.8 to avoid packaging error
   - dotnet tool install --global Cake.Tool --version 1.0.0
+  - ps: Invoke-WebRequest -Uri 'https://dot.net/v1/dotnet-install.ps1' -UseBasicParsing -OutFile "$env:temp\dotnet-install.ps1"
+  - ps: '& $env:temp\dotnet-install.ps1 -Version "6.0.100-rc.1.21463.6"'
 build_script: 
 - cmd: >-
     msbuild /r /m /p:Configuration=Release /clp:v=m MSBuildStructuredLog.sln /bl /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ install:
   - ps: '& $env:temp\dotnet-install.ps1 -Version "6.0.100-rc.1.21463.6"'
 build_script: 
 - cmd: >-
-    dotnet msbuild /r /m /p:Configuration=Release /clp:v=m MSBuildStructuredLog.sln /bl /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+    dotnet msbuild /r /m /p:Configuration=Release /clp:v=m MSBuildStructuredLog.sln /bl /logger:"C:\Program Files\AppVeyor\BuildAgent\dotnetcore\Appveyor.MSBuildLogger.dll"
 
     dotnet cake ./build-macos.cake --settings_skippackageversioncheck=true
 

--- a/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj
+++ b/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
-    <RuntimeIdentifiers>win7-x64;ubuntu.14.04-x64;osx.10.12-x64</RuntimeIdentifiers>
+    <TargetFramework>net6.0</TargetFramework>
+    <RuntimeIdentifiers>win7-x64;ubuntu.14.04-x64;osx.10.12-x64;osx-arm64</RuntimeIdentifiers>
   </PropertyGroup>
   
   <ItemGroup>
@@ -15,7 +15,7 @@
     </AvaloniaResource>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(NETCoreSdkRuntimeIdentifier)' == 'osx-x64'">
+  <ItemGroup Condition="$(NETCoreSdkRuntimeIdentifier.StartsWith('osx'))">
     <Content Include="StructuredLogViewer.icns">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -29,6 +29,8 @@
     <PackageReference Include="Avalonia.Diagnostics" Version="0.10.3" Condition=" '$(Configuration)' == 'Debug' " />
     <PackageReference Include="Avalonia.AvaloniaEdit" Version="0.10.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
+    <PackageReference Include="SkiaSharp" Version="2.88.0-preview.120" />
+    <PackageReference Include="HarfBuzzSharp" Version="2.6.1.9-preview.120" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj
+++ b/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj
@@ -29,8 +29,8 @@
     <PackageReference Include="Avalonia.Diagnostics" Version="0.10.3" Condition=" '$(Configuration)' == 'Debug' " />
     <PackageReference Include="Avalonia.AvaloniaEdit" Version="0.10.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-    <PackageReference Include="SkiaSharp" Version="2.88.0-preview.120" />
-    <PackageReference Include="HarfBuzzSharp" Version="2.6.1.9-preview.120" />
+    <PackageReference Include="SkiaSharp" Version="2.88.0-preview.145" />
+    <PackageReference Include="HarfBuzzSharp" Version="2.8.2-preview.140" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj
+++ b/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Avalonia.Diagnostics" Version="0.10.3" Condition=" '$(Configuration)' == 'Debug' " />
     <PackageReference Include="Avalonia.AvaloniaEdit" Version="0.10.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-    <!-- Bump transtive references to preview versions that contain osx-arm64 native assets -->
+    <!-- Bump transitive references to preview versions that contain osx-arm64 native assets -->
     <PackageReference Include="SkiaSharp" Version="2.88.0-preview.145" />
     <PackageReference Include="HarfBuzzSharp" Version="2.8.2-preview.140" />
   </ItemGroup>

--- a/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj
+++ b/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Avalonia.Diagnostics" Version="0.10.3" Condition=" '$(Configuration)' == 'Debug' " />
     <PackageReference Include="Avalonia.AvaloniaEdit" Version="0.10.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
+    <!-- Bump transtive references to preview versions that contain osx-arm64 native assets -->
     <PackageReference Include="SkiaSharp" Version="2.88.0-preview.145" />
     <PackageReference Include="HarfBuzzSharp" Version="2.8.2-preview.140" />
   </ItemGroup>


### PR DESCRIPTION
Since .NET 6 is right around the corner I thought I'd PR this up. Couple of people run into [the issue](https://github.com/dotnet/runtime/issues/59168) that they only have ARM64 .NET SDK installed on their system which makes the x64 .NET 5 apps not work out of the box due to apphost being x64 and finding only arm64 runtime. This is still [work in progress](https://github.com/dotnet/designs/blob/main/accepted/2021/x64-emulation-on-arm64/x64-emulation.md) from end user perspective on the .NET side.

This PR moves the target to .NET 6 and adds the ARM64 build. This makes the app work natively on Apple Silicon Macs.