### PR TITLE
Reference SkiaSharp.NativeAssets.Linux preview

### DIFF
--- a/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj
+++ b/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <!-- Bump transitive references to preview versions that contain osx-arm64 native assets -->
     <PackageReference Include="SkiaSharp" Version="2.88.0-preview.145" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.0-preview.145" Condition="$(NETCoreSdkRuntimeIdentifier.StartsWith('linux'))"/>
     <PackageReference Include="HarfBuzzSharp" Version="2.8.2-preview.140" />
   </ItemGroup>
 


### PR DESCRIPTION
Otherwise `dotnet restore` adds a reference to the latest non-preview version,
which is too old for the newer managed SkiaSharp library.