### PR TITLE
Handle ITaskItem parameter in task runner

### DIFF
--- a/src/TaskRunner/Executor.cs
+++ b/src/TaskRunner/Executor.cs
@@ -146,6 +146,16 @@ namespace TaskRunner
                 {
                     value = taskItems.Select(t => t.ItemSpec).ToArray();
                 }
+                else if (propertyInfo.PropertyType == typeof(ITaskItem))
+                {
+                    var item = taskItems.First();
+                    foreach (var pair in taskItems.Skip(1).Select(e => e.ItemSpec.TrimStart().Split('=')))
+                    {
+                        item.SetMetadata(pair[0], pair[1]);
+                    }
+
+                    value = item;
+                }
                 else
                 {
                     value = taskItems;


### PR DESCRIPTION
Having to convert a `ITaskItem[]` to a `ITaskItem` may happen with MSBuild target batching. For example, this happens with the [Microsoft.SourceLink.GitHub.GetSourceLinkUrl](https://github.com/dotnet/sourcelink/blob/1.1.1/src/SourceLink.GitHub/build/Microsoft.SourceLink.GitHub.targets#L37) task where the `SourceRoot` parameter is somehow translated from what should be a property with metadata to a list of task items.

Without this translation, the following error would occur:
> System.ArgumentException: Object of type 'Microsoft.Build.Framework.ITaskItem[]' cannot be converted to type 'Microsoft.Build.Framework.ITaskItem'.