### PR TITLE
Improve launching the TaskRunner

### DIFF
--- a/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
@@ -596,16 +596,20 @@ Recent:
                 return;
             }
 
-            var taskRunner = Path.Combine(Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName), "TaskRunner.exe");
-            if (!File.Exists(taskRunner))
-            {
-                MessageBox.Show("File not found: " + taskRunner);
-                return;
-            }
-
             try
             {
-                Process.Start(taskRunner.QuoteIfNeeded(), $"{logFilePath.QuoteIfNeeded()} {task.Index} pause{(debug ? " debug" : "")}");
+                var directory = Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName);
+                var arguments = $"{logFilePath.QuoteIfNeeded()} {task.Index} pause{(debug ? " debug" : "")}";
+                if (task.GetTargetFrameworkIdentifier() == ".NETFramework")
+                {
+                    var taskRunnerExe = Path.Combine(directory, "TaskRunner.exe");
+                    Process.Start(taskRunnerExe.QuoteIfNeeded(), arguments);
+                }
+                else
+                {
+                    var taskRunnerDll = Path.Combine(directory, "TaskRunner.dll");
+                    Process.Start("dotnet", $"{taskRunnerDll.QuoteIfNeeded()} {arguments}");
+                }
             }
             catch (Exception ex)
             {

--- a/src/StructuredLogger/Construction/MessageProcessor.cs
+++ b/src/StructuredLogger/Construction/MessageProcessor.cs
@@ -555,6 +555,11 @@ namespace Microsoft.Build.Logging.StructuredLogger
                         var version = message.Substring(Strings.MSBuildVersionPrefix.Length);
                         construction.Build.MSBuildVersion = version;
                     }
+                    else if (message.StartsWith(Strings.MSBuildExecutablePathPrefix))
+                    {
+                        var executablePath = message.Substring(Strings.MSBuildExecutablePathPrefix.Length);
+                        construction.Build.MSBuildExecutablePath = executablePath;
+                    }
                 }
             }
 

--- a/src/StructuredLogger/ObjectModel/Build.cs
+++ b/src/StructuredLogger/ObjectModel/Build.cs
@@ -33,6 +33,13 @@ namespace Microsoft.Build.Logging.StructuredLogger
             }
         }
 
+        private string msbuildExecutablePath;
+        public string MSBuildExecutablePath
+        {
+            get => msbuildExecutablePath;
+            set => msbuildExecutablePath = value?.TrimQuotes();
+        }
+
         private Version version;
 
         private void ParseMSBuildVersion()

--- a/src/StructuredLogger/ObjectModel/Task.cs
+++ b/src/StructuredLogger/ObjectModel/Task.cs
@@ -1,4 +1,11 @@
-﻿namespace Microsoft.Build.Logging.StructuredLogger
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+namespace Microsoft.Build.Logging.StructuredLogger
 {
     public class Task : TimedNode, IHasSourceFile, IHasLineNumber
     {
@@ -32,5 +39,39 @@
         public int? LineNumber { get; set; }
 
         public override string ToString() => Title;
+
+        public string GetTargetFrameworkIdentifier()
+        {
+            try
+            {
+                var taskDllPath = FromAssembly;
+                if (!File.Exists(taskDllPath))
+                {
+                    // `FromAssembly` might be an assembly name instead of a file path, e.g. "Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
+                    // Assuming that this assembly is an MSBuild assembly which is in the same directory as the MSBuild executable
+                    var msbuildDirectory = Path.GetDirectoryName(GetNearestParent<Build>()?.MSBuildExecutablePath);
+                    if (msbuildDirectory is not null)
+                    {
+                        var assemblyName = new AssemblyName(FromAssembly);
+                        taskDllPath = Path.Combine(msbuildDirectory, $"{assemblyName.Name}.dll");
+                    }
+                }
+
+                var resolver = new PathAssemblyResolver(Directory.GetFiles(RuntimeEnvironment.GetRuntimeDirectory(), "*.dll"));
+                using var loadContext = new MetadataLoadContext(resolver);
+                var taskAssembly = loadContext.LoadFromAssemblyPath(taskDllPath);
+                var targetFrameworkAttribute = taskAssembly.GetCustomAttributesData().FirstOrDefault(e => e.AttributeType.Name == nameof(TargetFrameworkAttribute));
+                if (targetFrameworkAttribute?.ConstructorArguments.FirstOrDefault().Value is string frameworkNameValue)
+                {
+                    var frameworkName = new FrameworkName(frameworkNameValue);
+                    return frameworkName.Identifier;
+                }
+                throw new InvalidOperationException($"TargetFrameworkAttribute was not found in \"{taskDllPath}\"");
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"Failed to identify the target framework identifier for the task \"{Name}\" from \"{FromAssembly}\"", ex);
+            }
+        }
     }
 }

--- a/src/StructuredLogger/Strings/Strings.cs
+++ b/src/StructuredLogger/Strings/Strings.cs
@@ -476,6 +476,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
         public static string Note => "Note";
         public static string DoubleWrites => "DoubleWrites";
         public static string MSBuildVersionPrefix => "MSBuild version = ";
+        public static string MSBuildExecutablePathPrefix => "MSBuild executable path = ";
         public static string Warnings = "Warnings";
 
         public static string GetPropertyName(string message)

--- a/src/StructuredLogger/StructuredLogger.csproj
+++ b/src/StructuredLogger/StructuredLogger.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MSBuildPackageVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MSBuildPackageVersion)" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">

--- a/src/TaskRunner/TaskRunner.csproj
+++ b/src/TaskRunner/TaskRunner.csproj
@@ -2,9 +2,24 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;net5.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(TargetFramework) == 'net472'">
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
+
+  <PropertyGroup Condition="$(TargetFramework) == 'net5.0'">
+    <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
+    <RollForward>LatestMajor</RollForward>
+    <UseAppHost>false</UseAppHost>
+  </PropertyGroup>
+
+  <Target Name="IgnoreAppConfig" AfterTargets="PrepareForBuild" Condition="$(TargetFrameworkIdentifier) == '.NETCoreApp'">
+    <ItemGroup>
+      <AppConfigWithTargetPath Remove="@(AppConfigWithTargetPath)" />
+    </ItemGroup>
+  </Target>
 
   <ItemGroup>
     <ProjectReference Include="..\StructuredLogger\StructuredLogger.csproj" />


### PR DESCRIPTION
Launch the TaskRunner as .NETFramework (TaskRunner.exe) or .NETCoreApp (dotnet TaskRunner.dll) depending on the task dll target framework identifier.

Fixes #403
Fixes #539

Note that unlike what was hinted in #403, the `TaskRunner.runtimeconfig.json` file is generated at build time and `RollForward` has been set to `LatestMajor` so  that the TaskRunner.dll can run on any installed .NET (Core) runtime. Because "make sure the framework exists from step 2" might turn into a pretty expensive operation.