### PR TITLE
Add "will be compiled because" example search to the UI.

### DIFF
--- a/src/StructuredLogViewer.Avalonia/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer.Avalonia/Controls/BuildControl.xaml.cs
@@ -276,6 +276,7 @@ Right-clicking a project node may show the 'Preprocess' option if the version of
             "csc $task",
             "ResolveAssemblyReference $task",
             "$message CompilerServer failed",
+            "will be compiled because",
         };
 
         private static string[] nodeKinds = new[]

--- a/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
@@ -440,6 +440,7 @@ Right-clicking a project node may show the 'Preprocess' option if the version of
             "ResolveAssemblyReference $task",
             "$task $time",
             "$message CompilerServer failed",
+            "will be compiled because",
         };
 
         private static string[] nodeKinds = new[]


### PR DESCRIPTION
This is often the source of rebuilds for native .vcxproj projects.
So having an example handy of how to find these is quite useful.