### PR TITLE
DuplicateWrites: Add support for robocopy task detection (from Microsoft.Build.Artifacts)

### DIFF
--- a/src/StructuredLogger/Analyzers/DoubleWritesAnalyzer.cs
+++ b/src/StructuredLogger/Analyzers/DoubleWritesAnalyzer.cs
@@ -42,6 +42,10 @@ namespace Microsoft.Build.Logging.StructuredLogger
             {
                 AnalyzeCopyTask(copyTask);
             }
+            else if (task is RobocopyTask robocopyTask)
+            {
+                AnalyzeCopyTask(robocopyTask);
+            }
             else if (task is CscTask cscTask && cscTask.CompilationWrites.HasValue)
             {
                 AnalyzeCompilationWrites(cscTask.CompilationWrites.Value);

--- a/src/StructuredLogger/Construction/Construction.cs
+++ b/src/StructuredLogger/Construction/Construction.cs
@@ -978,6 +978,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
             Task result = taskName.ToLowerInvariant() switch
             {
                 "copy" => new CopyTask(),
+                "robocopy" => new RobocopyTask(),
                 "csc" => new CscTask(),
                 "vbc" => new VbcTask(),
                 "fsc" => new FscTask(),

--- a/src/StructuredLogger/ObjectModel/Tasks/CopyTask.cs
+++ b/src/StructuredLogger/ObjectModel/Tasks/CopyTask.cs
@@ -9,9 +9,9 @@ namespace Microsoft.Build.Logging.StructuredLogger
         public override string TypeName => nameof(CopyTask);
 
         private IEnumerable<FileCopyOperation> fileCopyOperations;
-        public IEnumerable<FileCopyOperation> FileCopyOperations => fileCopyOperations ?? (fileCopyOperations = GetFileCopyOperations());
+        public IEnumerable<FileCopyOperation> FileCopyOperations => fileCopyOperations ??= GetFileCopyOperations();
 
-        private IEnumerable<FileCopyOperation> GetFileCopyOperations()
+        protected virtual IEnumerable<FileCopyOperation> GetFileCopyOperations()
         {
             if (!HasChildren)
             {
@@ -53,18 +53,11 @@ namespace Microsoft.Build.Logging.StructuredLogger
             return list;
         }
 
-        private static readonly string to = Strings.To;
-        private static readonly string toFile = Strings.ToFile;
-
-        private static FileCopyOperation ParseCopyingFileFrom(Match match, bool copied = true)
+        protected static FileCopyOperation ParseCopyingFileFrom(Match match, bool copied = true) => new FileCopyOperation
         {
-            var result = new FileCopyOperation();
-
-            result.Source = match.Groups["From"].Value;
-            result.Destination = match.Groups["To"].Value;
-            result.Copied = copied;
-
-            return result;
-        }
+            Source = match.Groups["From"].Value,
+            Destination = match.Groups["To"].Value,
+            Copied = copied
+        };
     }
 }

--- a/src/StructuredLogger/ObjectModel/Tasks/RobocopyTask.cs
+++ b/src/StructuredLogger/ObjectModel/Tasks/RobocopyTask.cs
@@ -22,11 +22,28 @@ namespace Microsoft.Build.Logging.StructuredLogger
             {
                 var text = message.Text;
 
-                match = Strings.RobocopyingFileFromRegex.Match(text);
+                match = Strings.RobocopyFileCopiedRegex.Match(text);
                 if (match.Success && match.Groups.Count > 2)
                 {
                     var operation = ParseCopyingFileFrom(match);
                     list.Add(operation);
+                    continue;
+                }
+
+                match = Strings.RobocopyFileSkippedRegex.Match(text);
+                if (match.Success && match.Groups.Count > 2)
+                {
+                    var operation = ParseCopyingFileFrom(match, copied: false);
+                    list.Add(operation);
+                    continue;
+                }
+
+                match = Strings.RobocopyFileFailedRegex.Match(text);
+                if (match.Success && match.Groups.Count > 2)
+                {
+                    var operation = ParseCopyingFileFrom(match, copied: false);
+                    list.Add(operation);
+                    continue;
                 }
             }
 

--- a/src/StructuredLogger/ObjectModel/Tasks/RobocopyTask.cs
+++ b/src/StructuredLogger/ObjectModel/Tasks/RobocopyTask.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Build.Logging.StructuredLogger
+{
+    public class RobocopyTask : CopyTask
+    {
+        public override string TypeName => nameof(RobocopyTask);
+
+        protected override IEnumerable<FileCopyOperation> GetFileCopyOperations()
+        {
+            if (!HasChildren)
+            {
+                return Enumerable.Empty<FileCopyOperation>();
+            }
+
+            List<FileCopyOperation> list = new List<FileCopyOperation>();
+
+            Match match;
+            foreach (var message in Children.OfType<Message>())
+            {
+                var text = message.Text;
+
+                match = Strings.RobocopyingFileFromRegex.Match(text);
+                if (match.Success && match.Groups.Count > 2)
+                {
+                    var operation = ParseCopyingFileFrom(match);
+                    list.Add(operation);
+                    continue;
+                }
+
+                // TODO: Robocopy with hard links and assess
+
+                //match = Strings.DidNotCopyRegex.Match(text);
+                //if (match.Success && match.Groups.Count > 2)
+                //{
+                //    var operation = ParseCopyingFileFrom(match, copied: false);
+                //    list.Add(operation);
+                //    continue;
+                //}
+
+                //match = Strings.CreatingHardLinkRegex.Match(text);
+                //if (match.Success && match.Groups.Count > 2)
+                //{
+                //    var operation = ParseCopyingFileFrom(match);
+                //    list.Add(operation);
+                //    continue;
+                //}
+            }
+
+            return list;
+        }
+    }
+}

--- a/src/StructuredLogger/ObjectModel/Tasks/RobocopyTask.cs
+++ b/src/StructuredLogger/ObjectModel/Tasks/RobocopyTask.cs
@@ -27,26 +27,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 {
                     var operation = ParseCopyingFileFrom(match);
                     list.Add(operation);
-                    continue;
                 }
-
-                // TODO: Robocopy with hard links and assess
-
-                //match = Strings.DidNotCopyRegex.Match(text);
-                //if (match.Success && match.Groups.Count > 2)
-                //{
-                //    var operation = ParseCopyingFileFrom(match, copied: false);
-                //    list.Add(operation);
-                //    continue;
-                //}
-
-                //match = Strings.CreatingHardLinkRegex.Match(text);
-                //if (match.Success && match.Groups.Count > 2)
-                //{
-                //    var operation = ParseCopyingFileFrom(match);
-                //    list.Add(operation);
-                //    continue;
-                //}
             }
 
             return list;

--- a/src/StructuredLogger/Strings/Strings.cs
+++ b/src/StructuredLogger/Strings/Strings.cs
@@ -78,31 +78,32 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
             TargetDoesNotExistBeforeTargetMessage = CreateRegex(GetString("TargetDoesNotExistBeforeTargetMessage"), 2);
 
-            string copyingFileFrom = GetString("Copy.FileComment");
-            string copyingFileFromEscaped = Escape(copyingFileFrom);
+            string copyingFileFromEscaped = Escape(GetString("Copy.FileComment"));
             CopyingFileFromRegex = new Regex(copyingFileFromEscaped
                 .Replace(@"\{0}", @"(?<From>[^\""]+)")
-                .Replace(@"\{1}", @"(?<To>[^\""]+)")
-                );
-
-            string robocopyingFileFrom = GetString("Robocopy.FileComment");
-            string robocopyingFileFromEscaped = Escape(robocopyingFileFrom);
-            RobocopyingFileFromRegex = new Regex(robocopyingFileFromEscaped
-                .Replace(@"\{0}", @"(?<From>[^\""]+)")
-                .Replace(@"\{1}", @"(?<To>[^\""]+)")
-                );
+                .Replace(@"\{1}", @"(?<To>[^\""]+)"), RegexOptions.Compiled);
 
             CreatingHardLinkRegex = new Regex(Escape(GetString("Copy.HardLinkComment"))
                 .Replace(@"\{0}", @"(?<From>[^\""]+)")
-                .Replace(@"\{1}", @"(?<To>[^\""]+)")
-                );
+                .Replace(@"\{1}", @"(?<To>[^\""]+)"), RegexOptions.Compiled);
 
             DidNotCopyRegex = new Regex(Escape(GetString("Copy.DidNotCopyBecauseOfFileMatch"))
                .Replace(@"\{0}", @"(?<From>[^\""]+)")
                .Replace(@"\{1}", @"(?<To>[^\""]+)")
                .Replace(@"\{2}", ".*?")
-               .Replace(@"\{3}", ".*?")
-               );
+               .Replace(@"\{3}", ".*?"), RegexOptions.Compiled);
+
+            RobocopyFileCopiedRegex = new Regex(Escape(RobocopyFileCopiedMessage)
+                .Replace(@"\{0}", @"(?<From>[^\""]+)")
+                .Replace(@"\{1}", @"(?<To>[^\""]+)"), RegexOptions.Compiled );
+
+            RobocopyFileSkippedRegex = new Regex(Escape(RobocopyFileSkippedMessage)
+                .Replace(@"\{0}", @"(?<From>[^\""]+)")
+                .Replace(@"\{1}", @"(?<To>[^\""]+)"), RegexOptions.Compiled);
+
+            RobocopyFileFailedRegex = new Regex(Escape(RobocopyFileFailedMessage)
+                .Replace(@"\{0}", @"(?<From>[^\""]+)")
+                .Replace(@"\{1}", @"(?<To>[^\""]+)"), RegexOptions.Compiled);
 
             ProjectImportSkippedMissingFile = GetString("ProjectImportSkippedMissingFile");
 
@@ -268,7 +269,9 @@ namespace Microsoft.Build.Logging.StructuredLogger
         public static Regex CopyingFileFromRegex { get; set; }
         public static Regex CreatingHardLinkRegex { get; set; }
         public static Regex DidNotCopyRegex { get; set; }
-        public static Regex RobocopyingFileFromRegex { get; set; }
+        public static Regex RobocopyFileCopiedRegex { get; set; }
+        public static Regex RobocopyFileSkippedRegex { get; set; }
+        public static Regex RobocopyFileFailedRegex { get; set; }
         public static Regex TargetDoesNotExistBeforeTargetMessage { get; set; }
         public static Regex TargetAlreadyCompleteSuccessRegex { get; set; }
         public static Regex TargetAlreadyCompleteFailureRegex { get; set; }
@@ -487,6 +490,11 @@ namespace Microsoft.Build.Logging.StructuredLogger
         public static string MSBuildVersionPrefix => "MSBuild version = ";
         public static string MSBuildExecutablePathPrefix => "MSBuild executable path = ";
         public static string Warnings = "Warnings";
+
+        // These aren't localized, see https://github.com/microsoft/MSBuildSdks/blob/543e965191417dee65471ee57a6702289847b49b/src/Artifacts/Tasks/Robocopy.cs#L66-L77
+        private const string RobocopyFileCopiedMessage = "Copied {0} to {1}";
+        private const string RobocopyFileSkippedMessage = "Skipped copying {0} to {1}";
+        private const string RobocopyFileFailedMessage = "Failed to copy {0} to {1}";
 
         public static string GetPropertyName(string message)
         {

--- a/src/StructuredLogger/Strings/Strings.cs
+++ b/src/StructuredLogger/Strings/Strings.cs
@@ -85,6 +85,13 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 .Replace(@"\{1}", @"(?<To>[^\""]+)")
                 );
 
+            string robocopyingFileFrom = GetString("Robocopy.FileComment");
+            string robocopyingFileFromEscaped = Escape(robocopyingFileFrom);
+            RobocopyingFileFromRegex = new Regex(robocopyingFileFromEscaped
+                .Replace(@"\{0}", @"(?<From>[^\""]+)")
+                .Replace(@"\{1}", @"(?<To>[^\""]+)")
+                );
+
             CreatingHardLinkRegex = new Regex(Escape(GetString("Copy.HardLinkComment"))
                 .Replace(@"\{0}", @"(?<From>[^\""]+)")
                 .Replace(@"\{1}", @"(?<To>[^\""]+)")
@@ -261,6 +268,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
         public static Regex CopyingFileFromRegex { get; set; }
         public static Regex CreatingHardLinkRegex { get; set; }
         public static Regex DidNotCopyRegex { get; set; }
+        public static Regex RobocopyingFileFromRegex { get; set; }
         public static Regex TargetDoesNotExistBeforeTargetMessage { get; set; }
         public static Regex TargetAlreadyCompleteSuccessRegex { get; set; }
         public static Regex TargetAlreadyCompleteFailureRegex { get; set; }

--- a/src/StructuredLogger/Strings/Strings.json
+++ b/src/StructuredLogger/Strings/Strings.json
@@ -49,8 +49,7 @@
     "ResolveAssemblyReference.UnifiedDependency": "Unified Dependency \"{0}\".",
     "GetSDKReferenceFiles.ConflictReferenceSameSDK": "There was a conflict between two references with the same file name resolved within the \"{0}\" SDK. Choosing \"{1}\" over \"{2}\" because it was resolved first.",
     "GetSDKReferenceFiles.ConflictRedistDifferentSDK": "There was a conflict between two files from the redist folder files going to the same target path \"{0}\" between the \"{1}\" and \"{2}\" SDKs. Choosing \"{3}\" over \"{4}\" because it was resolved first.",
-    "Copy.FileComment": "Copying file from \"{0}\" to \"{1}\".",
-    "Robocopy.FileComment": "Copied {0} to {1}"
+    "Copy.FileComment": "Copying file from \"{0}\" to \"{1}\"."
   },
   "de-DE": {
     "OutputItemParameterMessagePrefix": "Ausgegebene Elemente: ",

--- a/src/StructuredLogger/Strings/Strings.json
+++ b/src/StructuredLogger/Strings/Strings.json
@@ -49,7 +49,8 @@
     "ResolveAssemblyReference.UnifiedDependency": "Unified Dependency \"{0}\".",
     "GetSDKReferenceFiles.ConflictReferenceSameSDK": "There was a conflict between two references with the same file name resolved within the \"{0}\" SDK. Choosing \"{1}\" over \"{2}\" because it was resolved first.",
     "GetSDKReferenceFiles.ConflictRedistDifferentSDK": "There was a conflict between two files from the redist folder files going to the same target path \"{0}\" between the \"{1}\" and \"{2}\" SDKs. Choosing \"{3}\" over \"{4}\" because it was resolved first.",
-    "Copy.FileComment": "Copying file from \"{0}\" to \"{1}\"."
+    "Copy.FileComment": "Copying file from \"{0}\" to \"{1}\".",
+    "Robocopy.FileComment": "Copied {0} to {1}"
   },
   "de-DE": {
     "OutputItemParameterMessagePrefix": "Ausgegebene Elemente: ",


### PR DESCRIPTION
Overall: adds RoboCopy task support for duplicate file copy detection. This is something very prevalent in some solutions I've been working on and would be a good win if we had it on the dupe detection front.

The task it's detecting is from the Microsoft.Build.Artifacts package which it turns out...isn't actually using Robocopy because...yeah, no clue. Here's the source of the task we're matching: https://github.com/microsoft/MSBuildSdks/blob/543e965191417dee65471ee57a6702289847b49b/src/Artifacts/Tasks/Robocopy.cs