### PR TITLE
Quality of Life improvement to Tracing View

### DIFF
--- a/src/StructuredLogViewer/Controls/TracingControl.xaml
+++ b/src/StructuredLogViewer/Controls/TracingControl.xaml
@@ -13,7 +13,7 @@
         <MenuItem Header="{Binding Path=ShowProjectsText, Mode=OneWay}" IsCheckable="true" IsChecked="{Binding Path=ShowProject , Mode=TwoWay}" StaysOpenOnClick="true"/>
         <MenuItem Header="{Binding Path=ShowTargetsText, Mode=OneWay}" IsCheckable="true" IsChecked="{Binding Path=ShowTarget , Mode=TwoWay}" StaysOpenOnClick="true"/>
         <MenuItem Header="{Binding Path=ShowTasksText, Mode=OneWay}" IsCheckable="true" IsChecked="{Binding Path=ShowTask , Mode=TwoWay}" StaysOpenOnClick="true"/>
-        <MenuItem Header="Show Other" IsCheckable="true" IsChecked="{Binding Path=ShowOther , Mode=TwoWay}" StaysOpenOnClick="true"/>
+        <MenuItem Header="{Binding Path=ShowOthersText, Mode=OneWay}" IsCheckable="true" IsChecked="{Binding Path=ShowOther , Mode=TwoWay}" StaysOpenOnClick="true"/>
         <MenuItem Header="{Binding Path=ShowNodesText, Mode=OneWay}" IsCheckable="true" IsChecked="{Binding Path=ShowNodes , Mode=TwoWay}" StaysOpenOnClick="true"/>
         <!--<MenuItem Header="{Binding Path=LoadStatistics, Mode=OneWay}" IsCheckable="true" IsEnabled="false" /> -->
       </ContextMenu>

--- a/src/StructuredLogViewer/Controls/TracingControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/TracingControl.xaml.cs
@@ -277,8 +277,7 @@ namespace StructuredLogViewer.Controls
             Parallel.ForEach(keys, (key) =>
             {
                 var lane = Timeline.Lanes[key];
-                var panel = ComputeVisibleBlocks(lane);
-                blocksCollectionArray[key] = panel;
+                blocksCollectionArray[key] = ComputeVisibleBlocks(lane);
             });
 
             blocksCollection = blocksCollectionArray.Where(p => p != null).ToList();
@@ -402,11 +401,10 @@ namespace StructuredLogViewer.Controls
 
         private void DrawAddNodeDivider()
         {
-            int showMeasurementMod = 0;
-            int totalChild = lanesPanel.Children.Count;
+            int showMeasurementMod = 1;
 
             // Start from second element to account for the top ruler
-            for (int index = 3; index < totalChild; index += 2)
+            for (int index = 3; index < lanesPanel.Children.Count; index += 2)
             {
                 lanesPanel.Children.Insert(index, CreatePanelForNodeDivider(showMeasurementMod % 5 == 0));
                 showMeasurementMod++;

--- a/src/StructuredLogViewer/Controls/TracingControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/TracingControl.xaml.cs
@@ -40,6 +40,7 @@ namespace StructuredLogViewer.Controls
         public int numberOfTargets = 0;
         public int numberOfTasks = 0;
         public int numberOfNodes = 0;
+        public int numberOfOthers = 0;
 
         public string ShowEvaluationsText => $"Show Evaluations ({numberOfEvaluations})";
 
@@ -50,6 +51,8 @@ namespace StructuredLogViewer.Controls
         public string ShowTasksText => $"Show Tasks ({numberOfTasks})";
 
         public string ShowNodesText => $"Show Nodes Divider ({numberOfNodes})";
+
+        public string ShowOthersText => $"Show Others ({numberOfOthers})";
 
         private TimeSpan initTime = TimeSpan.Zero;
         private TimeSpan computeTime = TimeSpan.Zero;
@@ -84,7 +87,7 @@ namespace StructuredLogViewer.Controls
         public bool ShowOther
         {
             get => _showOther;
-            set { _showOther = value; ComputeAndDraw(); }
+            set { _showOther = value; if (this.numberOfOthers > 0) ComputeAndDraw(); }
         }
 
         public bool ShowNodes
@@ -213,6 +216,7 @@ namespace StructuredLogViewer.Controls
                             this.numberOfTasks++;
                             break;
                         default:
+                            this.numberOfOthers++;
                             break;
                     }
                 }
@@ -487,6 +491,11 @@ namespace StructuredLogViewer.Controls
             return time / TimeToPixel;
         }
 
+        private static double ConvertPixelToTime(double pixel)
+        {
+            return pixel * TimeToPixel;
+        }
+
         public void GoToTimedNode(TimedNode node)
         {
             TextBlock textblock = null;
@@ -513,8 +522,12 @@ namespace StructuredLogViewer.Controls
 
         private List<Block> ComputeVisibleBlocks(Lane lane)
         {
+            double pixelDuration = ConvertPixelToTime(1);
             var blocks = lane.Blocks.Where(b =>
             {
+                if (b.Duration.Ticks < pixelDuration)
+                    return false;
+
                 switch (b.Node)
                 {
                     case ProjectEvaluation:

--- a/src/StructuredLogViewer/Controls/TracingControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/TracingControl.xaml.cs
@@ -568,18 +568,30 @@ namespace StructuredLogViewer.Controls
             }
 
             endpoints.Sort();
+            List<long> indentList = new List<long>(5);
 
-            int level = 0;
             foreach (var endpoint in endpoints)
             {
                 if (endpoint.IsStart)
                 {
-                    level++;
-                    endpoint.Block.Indent = level;
-                }
-                else
-                {
-                    level--;
+                    int i = 0;
+                    while (i < indentList.Count)
+                    {
+                        if (indentList[i] <= endpoint.Timestamp)
+                        {
+                            endpoint.Block.Indent = i;
+                            indentList[i] = endpoint.Block.EndTime.Ticks;
+                            break;
+                        }
+
+                        i++;
+                    }
+
+                    if (i == indentList.Count)
+                    {
+                        endpoint.Block.Indent = i;
+                        indentList.Add(endpoint.Block.EndTime.Ticks);
+                    }
                 }
             }
 
@@ -627,7 +639,7 @@ namespace StructuredLogViewer.Controls
                 textBlock.Text = $"{block.Text} ({TextUtilities.DisplayDuration(block.Duration)})";
                 textBlock.Background = ChooseBackground(block);
 
-                double indentOffset = textHeight * (block.Indent - 1);
+                double indentOffset = textHeight * block.Indent;
 
                 double left = ConvertTimeToPixel(block.Start - globalStart);
                 double duration = ConvertTimeToPixel(block.End - block.Start);

--- a/src/StructuredLogViewer/Controls/TracingControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/TracingControl.xaml.cs
@@ -262,10 +262,16 @@ namespace StructuredLogViewer.Controls
         private void ComputeTimeline()
         {
             var start = Timestamp;
-            var keys = Timeline.Lanes.Keys.ToList();
-            keys.Sort();
+            // Sort by the start time of each lane
+            var keys1 = Timeline.Lanes.Where(p => p.Value.Blocks.Any()).ToDictionary(key => key.Key, p => p.Value.Blocks.Min(p => p.StartTime.Ticks)).ToList();
+            keys1.Sort((l, r) =>
+            {
+                return l.Value.CompareTo(r.Value);
+            });
+            var keys = keys1.Select(Key => Key.Key).ToList();
 
-            var length = Math.Max(keys.Count(), keys.Last() + 1);
+            // Get the max number of lanes
+            var length = Math.Max(keys.Count(), keys.Max() + 1);
 
             var blocksCollectionArray = new List<Block>[length];
             Parallel.ForEach(keys, (key) =>

--- a/src/StructuredLogViewer/Controls/TracingControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/TracingControl.xaml.cs
@@ -222,7 +222,7 @@ namespace StructuredLogViewer.Controls
                     this.numberOfNodes++;
                 }
 
-                if (this._showEvaluation && totalItems > 10000)
+                if (this._showProject && totalItems > 10000)
                 {
                     this._showEvaluation = true;
                     this._showProject = false;


### PR DESCRIPTION
- Fix the strange stacking of text.  The previous indent logic assumes that the parent node is always bigger than the child indent.  However, due to 1) strange timing between nodes, and 2) yielding, the nodes could be created in any side or order.
![image](https://user-images.githubusercontent.com/19828377/171333847-f26bb9ac-1d39-478d-95f8-68d9d87a61d7.png) ![image](https://user-images.githubusercontent.com/19828377/171333881-6d14eaf3-eec0-4dbd-afd0-d7b2e9f50c82.png)
- Add Other text and counter.  Add check to avoid redraw if nothing has changed.
- Fix an spacing issue when drawing the ruler.
- Sort lanes based on start time instead of node number itself.
