### PR TITLE
Update Nerdbank.GitVersioning package version to 3.5.107

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,7 +19,7 @@
     <LangVersion>latest</LangVersion>
 
     <MSBuildPackageVersion>16.10.0</MSBuildPackageVersion>
-    <NuGetVersionNerdbankGitVersioning>3.4.194</NuGetVersionNerdbankGitVersioning>
+    <NuGetVersionNerdbankGitVersioning>3.5.107</NuGetVersionNerdbankGitVersioning>
   </PropertyGroup>
 
 </Project>

--- a/src/StructuredLogViewer/StructuredLogViewer.csproj
+++ b/src/StructuredLogViewer/StructuredLogViewer.csproj
@@ -79,7 +79,7 @@
   <Target Name="ExtractVersion"
           AfterTargets="CoreBuild"
           Condition="Exists('$(NuspecPath)')"
-          DependsOnTargets="PrepareResources;GenerateAssemblyVersionInfo">
+          DependsOnTargets="PrepareResources;GenerateAssemblyNBGVVersionInfo">
     <PropertyGroup>
       <NupkgPath>$(OutDir)$(NuspecFileName).$(Version).nupkg</NupkgPath>
       <ChocolateyNupkgPath>$(OutDir)$(ChocolateyFileName).$(Version).nupkg</ChocolateyNupkgPath>


### PR DESCRIPTION
In the new version of the package, the build with Git Alternates has been fixed.