### PR TITLE
TargetFramework: support TargetFrameworkVersion reading

### DIFF
--- a/src/StructuredLogger/Construction/Construction.cs
+++ b/src/StructuredLogger/Construction/Construction.cs
@@ -1082,6 +1082,13 @@ namespace Microsoft.Build.Logging.StructuredLogger
                             project.TargetFramework = kvp.Value;
                         }
                     }
+                    // If neither of the above are there - look for the old project system
+                    else if (project.TargetFramework is null && string.Equals(kvp.Key, Strings.TargetFrameworkVersion, StringComparison.OrdinalIgnoreCase))
+                    {
+                        // Note this is untranslted, so e.g. "v4.6.2" instead of "net462" - this is intentional as it
+                        // renders the badge for all projects, but you can still use this difference to tell what is/isn't an SDK project.
+                        project.TargetFramework = kvp.Value;
+                    }
                 }
             }
         }

--- a/src/StructuredLogger/Strings/Strings.cs
+++ b/src/StructuredLogger/Strings/Strings.cs
@@ -472,6 +472,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
         public static string EntryTargets => "Entry targets";
         public static string TargetFramework => "TargetFramework";
         public static string TargetFrameworks => "TargetFrameworks";
+        public static string TargetFrameworkVersion => "TargetFrameworkVersion";
         public static string AdditionalProperties => "Additional properties";
         public static string OutputItems => "OutputItems";
         public static string OutputProperties => "OutputProperties";


### PR DESCRIPTION
Discusses a bit in #599 - this adds reading the older `<TargetFrameworkVersion>` project style for version badges. Overall:
| Old | New |
|-----|------|
|<img width="298" alt="image" src="https://user-images.githubusercontent.com/454813/171186657-61b63a67-ef83-42c7-a713-c6e1c48fefef.png">|<img width="283" alt="image" src="https://user-images.githubusercontent.com/454813/171186744-923c8e70-c731-45d7-b82a-d38be4f58ace.png">|