### PR TITLE
Include generator summary

### DIFF
--- a/src/StructuredLogger/Analyzers/BuildAnalyzer.cs
+++ b/src/StructuredLogger/Analyzers/BuildAnalyzer.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
         private Dictionary<string, (TimeSpan TotalDuration, Dictionary<string, TimeSpan> ParentDurations)> taskDurations
             = new Dictionary<string, (TimeSpan TotalDuration, Dictionary<string, TimeSpan> ParentDurations)>();
         private readonly List<Folder> analyzerReports = new List<Folder>();
+        private readonly List<Folder> generatorReports = new List<Folder>();
 
         public BuildAnalyzer(Build build)
         {
@@ -230,6 +231,12 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 var analyzerReportSummary = build.GetOrCreateNodeWithName<Folder>(Intern($"Analyzer Summary"));
                 CscTaskAnalyzer.CreateMergedReport(analyzerReportSummary, analyzerReports.ToArray());
             }
+
+            if (generatorReports.Count > 0)
+            {
+                var generatorReportSummary = build.GetOrCreateNodeWithName<Folder>(Intern($"Generator Summary"));
+                CscTaskAnalyzer.CreateMergedReport(generatorReportSummary, generatorReports.ToArray());
+            }
         }
 
         private void PostAnalyzeProject(Project project)
@@ -317,10 +324,15 @@ namespace Microsoft.Build.Logging.StructuredLogger
             }
             else if (task.Name == "Csc")
             {
-                var analyzerReport = CscTaskAnalyzer.Analyze(task);
+                var (analyzerReport, generatorReport) = CscTaskAnalyzer.Analyze(task);
                 if (analyzerReport is not null)
                 {
                     analyzerReports.Add(analyzerReport);
+                }
+
+                if (generatorReport is not null)
+                {
+                    generatorReports.Add(generatorReport);
                 }
             }
 

--- a/src/StructuredLogger/Analyzers/CscTaskAnalyzer.cs
+++ b/src/StructuredLogger/Analyzers/CscTaskAnalyzer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -7,9 +7,11 @@ namespace Microsoft.Build.Logging.StructuredLogger
 {
     public class CscTaskAnalyzer
     {
-        public static Folder Analyze(Task task)
+        public static (Folder Analyzers, Folder Generators) Analyze(Task task)
         {
             Folder analyzerReport = null;
+            Folder generatorReport = null;
+            Folder currentReport = null;
             Folder parent = null;
 
             foreach (var message in task.Children.OfType<Message>().ToArray())
@@ -21,12 +23,21 @@ namespace Microsoft.Build.Logging.StructuredLogger
                     analyzerReport.Name = Strings.AnalyzerReport;
                     task.AddChild(analyzerReport);
                     parent = analyzerReport;
+                    currentReport = analyzerReport;
                 }
-                else if (text.Contains(", Version=") && analyzerReport != null)
+                else if (text.StartsWith(Strings.TotalGeneratorExecutionTime, StringComparison.Ordinal))
+                {
+                    generatorReport = new Folder();
+                    generatorReport.Name = Strings.GeneratorReport;
+                    task.AddChild(generatorReport);
+                    parent = generatorReport;
+                    currentReport = generatorReport;
+                }
+                else if (text.Contains(", Version=") && currentReport != null)
                 {
                     var lastAssembly = new Folder();
                     lastAssembly.Name = text;
-                    analyzerReport.AddChild(lastAssembly);
+                    currentReport.AddChild(lastAssembly);
                     parent = lastAssembly;
 
                     // Remove the message since we are already using the same text for the containing folder
@@ -47,7 +58,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 }
             }
 
-            return analyzerReport;
+            return (analyzerReport, generatorReport);
         }
 
         public static void CreateMergedReport(Folder destination, Folder[] analyzerReports)

--- a/src/StructuredLogger/Strings/Strings.cs
+++ b/src/StructuredLogger/Strings/Strings.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using Microsoft.Build.Framework;
@@ -442,6 +442,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
         public static string ToFile => "\" to file \"";
 
         public static string TotalAnalyzerExecutionTime => "Total analyzer execution time:";
+        public static string TotalGeneratorExecutionTime => "Total generator execution time:";
 
         /// <summary>
         /// https://github.com/NuGet/Home/issues/10383
@@ -466,6 +467,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
         public static string Assemblies => "Assemblies";
         public static string TargetOutputs => "TargetOutputs";
         public static string AnalyzerReport => "Analyzer Report";
+        public static string GeneratorReport => "Generator Report";
         public static string Properties => "Properties";
         public static string PropertyReassignmentFolder => "Property reassignment";
         public static string Global => "Global";


### PR DESCRIPTION
Roslyn recently updated their `/reportAnalyzer` support to include
displaying source generator time in addition to analyzer time. This PR
updates the structured logger viewer to display the newly added
generator time in the same fashion that it displays anaylzer time

Roslyn PR: https://github.com/dotnet/roslyn/pull/61661

Here is a screen shot of this change in action 

<img width="590" alt="image" src="https://user-images.githubusercontent.com/146967/177878023-0d977fd6-30de-4034-999c-9bc3541ccf17.png">
