### PR TITLE
Improve CppAnalyzer load time by reducing Regex.Match calls.

### DIFF
--- a/src/StructuredLogViewer/Controls/TracingControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/TracingControl.xaml.cs
@@ -290,7 +290,9 @@ namespace StructuredLogViewer.Controls
                 var keys = sortedKeys.Select(Key => Key.Key).ToList();
 
                 // Get the max number of lanes
-                var length = Math.Max(keys.Count(), keys.Max() + 1);
+                // Note: Max() throws if keys is empty.
+                int keysMax = keys.Any() ? keys.Max() + 1 : 1;
+                var length = Math.Max(keys.Count(), keysMax);
 
                 var blocksCollectionArray = new List<Block>[length];
                 Parallel.ForEach(keys, (key) =>

--- a/src/StructuredLogger/Analyzers/CppAnalyzer.cs
+++ b/src/StructuredLogger/Analyzers/CppAnalyzer.cs
@@ -67,6 +67,12 @@ namespace Microsoft.Build.Logging.StructuredLogger
         private const string startTimeRegexMatchName = "startTime";
         private const string endTimeRegexMatchName = "endTime";
         private const string msTimeRegexMatchName = "msTime";
+        private const string btplusKeyword = @"time(";
+        private const string mttKeyword = " took ";
+        private const string mttCleanUpKeyword = "Cleanup phase took ";
+        private const string mttStartUpKeyword = "will run on ";
+        private const string libKeyword = "Lib: Final Total time =";
+        private const string linkKeyword = "Final: Total time =";
         private bool globalBtplus = false;
         private bool globalLibTime = false;
         private bool globalLinkTime = false;
@@ -137,7 +143,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
                         DateTime startTime = DateTime.MinValue;
                         string messageText = message.Text;
 
-                        if ((usingBTTime && message.Text.StartsWith(@"time(")) || (!usingBTTime && message.Text.Contains(" took ")))
+                        if ((usingBTTime && message.Text.StartsWith(btplusKeyword)) || (!usingBTTime && message.Text.Contains(mttKeyword)))
                         {
                             Match match = usingBTTime ? BTPlus.Match(message.Text) : TaskTime.Match(message.Text);
                             if (match.Success)
@@ -183,7 +189,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
                                 }
                             }
                         }
-                        else if (cppTask.Name == MultiToolTaskName && message.Text.Contains("Cleanup phase took ") || message.Text.Contains("will run on "))
+                        else if (cppTask.Name == MultiToolTaskName && message.Text.Contains(mttCleanUpKeyword) || message.Text.Contains(mttStartUpKeyword))
                         {
                             var match = startupPhase.Match(message.Text);
                             if (match.Success)
@@ -269,7 +275,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
                 foreach (var child in cppTask.Children)
                 {
-                    if (usingLibTime && child is TimedMessage message && message.Text.Contains("Lib: Final Total time ="))
+                    if (usingLibTime && child is TimedMessage message && message.Text.Contains(libKeyword))
                     {
                         DateTime endTime = DateTime.MinValue;
                         DateTime startTime = DateTime.MinValue;
@@ -318,7 +324,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
                 foreach (var child in cppTask.Children)
                 {
-                    if (child is TimedMessage message && message.Text.Contains("Final: Total time ="))
+                    if (child is TimedMessage message && message.Text.Contains(linkKeyword))
                     {
                         DateTime endTime = DateTime.MinValue;
                         DateTime startTime = DateTime.MinValue;

--- a/src/StructuredLogger/Construction/MessageProcessor.cs
+++ b/src/StructuredLogger/Construction/MessageProcessor.cs
@@ -434,7 +434,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
             {
                 parent = GetTarget(args);
 
-                if (Strings.TaskSkippedFalseConditionRegex.IsMatch(message))
+                if (message.Contains(Strings.TaskSkippedFalseCondition) && Strings.TaskSkippedFalseConditionRegex.IsMatch(message))
                 {
                     lowRelevance = true;
                 }
@@ -480,7 +480,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
                     parent = evaluation;
                 }
 
-                if (args is PropertyReassignmentEventArgs || Strings.PropertyReassignmentRegex.IsMatch(message))
+                if (args is PropertyReassignmentEventArgs || (message.Contains(Strings.PropertyReassignment) && Strings.PropertyReassignmentRegex.IsMatch(message)))
                 {
                     TimedNode properties;
                     if (evaluation != null)
@@ -515,7 +515,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
                     parent = construction.EvaluationFolder;
                 }
-                else if (construction.Build.FileFormatVersion < 9 && Strings.PropertyReassignmentRegex.IsMatch(message))
+                else if (construction.Build.FileFormatVersion < 9 && message.Contains(Strings.PropertyReassignment) && Strings.PropertyReassignmentRegex.IsMatch(message))
                 {
                     if (!evaluationMessagesAlreadySeen.Add(message))
                     {


### PR DESCRIPTION
### Improve load times by checking keywords before matching regex.
- String.Contains() is orders of magnitude faster than Regex.Match().  So on critical paths, quickly check if the keyword exists before running the regex.
- CppAnalyzer speed up at least 5x as many messages are misses.
- AddMessage speed up by 10%.