### PR TITLE
Change truncation strategy for environment variables

### DIFF
--- a/src/StructuredLogger/BinaryLogger/BinaryLogger.cs
+++ b/src/StructuredLogger/BinaryLogger/BinaryLogger.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
         //   - TargetSkippedEventArgs: added OriginallySucceeded, Condition, EvaluatedCondition
         // version 14:
         //   - TargetSkippedEventArgs: added SkipReason, OriginalBuildEventContext
-        internal const int FileFormatVersion = 14;
+        internal const int FileFormatVersion = 15;
 
         private Stream stream;
         private BinaryWriter binaryWriter;

--- a/src/StructuredLogger/BinaryLogger/BinaryLogger.cs
+++ b/src/StructuredLogger/BinaryLogger/BinaryLogger.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
         //   - TargetSkippedEventArgs: added OriginallySucceeded, Condition, EvaluatedCondition
         // version 14:
         //   - TargetSkippedEventArgs: added SkipReason, OriginalBuildEventContext
-        internal const int FileFormatVersion = 15;
+        internal const int FileFormatVersion = 14;
 
         private Stream stream;
         private BinaryWriter binaryWriter;

--- a/src/StructuredLogger/Construction/Construction.cs
+++ b/src/StructuredLogger/Construction/Construction.cs
@@ -95,23 +95,16 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
                     EnvironmentFolder = Build.GetOrCreateNodeWithName<Folder>(Intern(Strings.Environment));
 
-                    if (args.BuildEnvironment?.ContainsKey("MSBUILDLOGALLENVIRONMENTVARIABLES") == true)
+                    if (args.BuildEnvironment?.Count > 0)
                     {
                         AddProperties(EnvironmentFolder, args.BuildEnvironment);
                     }
-                    else
-                    {
-                        if (args.BuildEnvironment?.Count > 0)
-                        {
-                            AddProperties(EnvironmentFolder, args.BuildEnvironment);
-                        }
 
+                    if (args.BuildEnvironment?.ContainsKey("MSBUILDLOGALLENVIRONMENTVARIABLES") == true)
+                    {
                         EnvironmentFolder.AddChild(new Note
                         {
-                            Text = Intern(
-                                Build.FileFormatVersion >= 15 ?
-                                Strings.TruncatedEnvironment :
-                                Strings.NoEnvironment)
+                            Text = Intern(Strings.TruncatedEnvironment)
                         });
                     }
 

--- a/src/StructuredLogger/Construction/Construction.cs
+++ b/src/StructuredLogger/Construction/Construction.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
                         AddProperties(EnvironmentFolder, args.BuildEnvironment);
                     }
 
-                    if (args.BuildEnvironment?.ContainsKey("MSBUILDLOGALLENVIRONMENTVARIABLES") == true)
+                    if (args.BuildEnvironment?.ContainsKey("MSBUILDLOGALLENVIRONMENTVARIABLES") != true)
                     {
                         EnvironmentFolder.AddChild(new Note
                         {

--- a/src/StructuredLogger/Construction/Construction.cs
+++ b/src/StructuredLogger/Construction/Construction.cs
@@ -100,13 +100,10 @@ namespace Microsoft.Build.Logging.StructuredLogger
                         AddProperties(EnvironmentFolder, args.BuildEnvironment);
                     }
 
-                    if (args.BuildEnvironment?.ContainsKey("MSBUILDLOGALLENVIRONMENTVARIABLES") != true)
+                    EnvironmentFolder.AddChild(new Note
                     {
-                        EnvironmentFolder.AddChild(new Note
-                        {
-                            Text = Intern(Strings.TruncatedEnvironment)
-                        });
-                    }
+                        Text = Intern(Strings.TruncatedEnvironment)
+                    });
 
                     // realize the evaluation folder now so it is ordered before the main solution node
                     _ = EvaluationFolder;

--- a/src/StructuredLogger/Construction/Construction.cs
+++ b/src/StructuredLogger/Construction/Construction.cs
@@ -95,15 +95,23 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
                     EnvironmentFolder = Build.GetOrCreateNodeWithName<Folder>(Intern(Strings.Environment));
 
-                    if (args.BuildEnvironment?.Count > 0)
+                    if (args.BuildEnvironment?.ContainsKey("MSBUILDLOGALLENVIRONMENTVARIABLES") == true)
                     {
                         AddProperties(EnvironmentFolder, args.BuildEnvironment);
                     }
                     else
                     {
+                        if (args.BuildEnvironment?.Count > 0)
+                        {
+                            AddProperties(EnvironmentFolder, args.BuildEnvironment);
+                        }
+
                         EnvironmentFolder.AddChild(new Note
                         {
-                            Text = Intern(Strings.NoEnvironment)
+                            Text = Intern(
+                                Build.FileFormatVersion >= 15 ?
+                                Strings.TruncatedEnvironment :
+                                Strings.NoEnvironment)
                         });
                     }
 

--- a/src/StructuredLogger/Strings/Strings.cs
+++ b/src/StructuredLogger/Strings/Strings.cs
@@ -458,8 +458,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
         public static string Evaluation => "Evaluation";
         public static string Environment => "Environment";
-        public static string TruncatedEnvironment => "List of environment variables here may be truncated. Only those prefixed with \"MSBUILD\", \"DOTNET_\", or \"COMPLUS_\" are logged by default. Define a value for MSBUILDLOGALLENVIRONMENTVARIABLES to log all environment variables.";
-        public static string NoEnvironment => "Define a value for MSBUILDLOGALLENVIRONMENTVARIABLES to log all environment variables. Only those used in evaluating properties are currently logged.";
+        public static string TruncatedEnvironment => "Starting with MSBuild 17.4, only some environment variables are included in the log: the ones read during the build and the ones prefixed with MSBUILD, DOTNET_ or COMPLUS_. Define MSBUILDLOGALLENVIRONMENTVARIABLES to log all environment variables during the build.";
         public static string Imports => "Imports";
         public static string DetailedSummary => "Detailed summary";
         public static string Parameters => "Parameters";

--- a/src/StructuredLogger/Strings/Strings.cs
+++ b/src/StructuredLogger/Strings/Strings.cs
@@ -458,6 +458,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
         public static string Evaluation => "Evaluation";
         public static string Environment => "Environment";
+        public static string TruncatedEnvironment => "List of environment variables here may be truncated. Only those prefixed with \"MSBUILD\", \"DOTNET_\", or \"COMPLUS_\" are logged by default. Define a value for MSBUILDLOGALLENVIRONMENTVARIABLES to log all environment variables.";
         public static string NoEnvironment => "Define a value for MSBUILDLOGALLENVIRONMENTVARIABLES to log all environment variables. Only those used in evaluating properties are currently logged.";
         public static string Imports => "Imports";
         public static string DetailedSummary => "Detailed summary";


### PR DESCRIPTION
This shifts to using MSBUILDLOGALLENVIRONMENTVARIABLES to determine if we logged the full environment or not and gives a useful message if we truncated it.