### PR TITLE
Add Platform/Configuration Adornment, CppAnalyzer QOL improvements

### DIFF
--- a/src/StructuredLogViewer/Controls/TracingControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/TracingControl.xaml.cs
@@ -34,7 +34,7 @@ namespace StructuredLogViewer.Controls
         private bool _showProject = true;
         private bool _showTarget = true;
         private bool _showTask = true;
-        private bool _showCpp = true;
+        private bool _showCpp = false;
         private bool _showNodes = true;
         private bool _groupByNodes = true;
 
@@ -570,7 +570,7 @@ namespace StructuredLogViewer.Controls
                         return ShowTarget;
                     case Microsoft.Build.Logging.StructuredLogger.Task node:
                         // When ShowCpp is enabled, hide the task and show the messages so that only one of them will appear.
-                        if (showCppBlocks && CppAnalyzer.IsCppTask(node.Name))
+                        if (showCppBlocks && node is CppAnalyzer.CppTask cppNode && cppNode.HasTimedBlocks)
                         {
                             return false;
                         }

--- a/src/StructuredLogViewer/themes/Generic.xaml
+++ b/src/StructuredLogViewer/themes/Generic.xaml
@@ -239,14 +239,14 @@
                  Fill="{StaticResource GenericProjectIcon}" />
       <TextBlock Text="{Binding Name}" Margin="0,2,0,0" ToolTip="{Binding ToolTip}" ToolTipService.ShowDuration="60000" />
       <TextBlock
-          Text="{Binding AdormentString}"
+          Text="{Binding AdornmentString}"
           Margin="6,0,0,0"
           Padding="2,0,2,0"
           FontSize="10"
           VerticalAlignment="Center"
           Foreground="{DynamicResource TargetFrameworkForeground}"
           Background="{DynamicResource TargetFrameworkBackground}"
-          Visibility="{Binding AdormentString, Converter={x:Static s:StringEmptinessToVisibilityConverter.Instance}}"/>
+          Visibility="{Binding AdornmentString, Converter={x:Static s:StringEmptinessToVisibilityConverter.Instance}}"/>
       <controls:NodeHyperlinkControl
             Margin="0,2,0,0"
             Text="{Binding TargetsDisplayText}"
@@ -297,14 +297,14 @@
                    ToolTipService.ShowDuration="60000" />-->
       <TextBlock Text="{Binding Name}" Margin="0,2,0,0" ToolTip="{Binding ToolTip}" ToolTipService.ShowDuration="60000" />
       <TextBlock
-          Text="{Binding AdormentString}"
+          Text="{Binding AdornmentString}"
           Margin="6,0,0,0"
           Padding="2,0,2,0"
           FontSize="10"
           VerticalAlignment="Center"
           Foreground="{DynamicResource TargetFrameworkForeground}"
           Background="{DynamicResource TargetFrameworkBackground}"
-          Visibility="{Binding AdormentString, Converter={x:Static s:StringEmptinessToVisibilityConverter.Instance}}"/>
+          Visibility="{Binding AdornmentString, Converter={x:Static s:StringEmptinessToVisibilityConverter.Instance}}"/>
       <TextBlock
           Text="{Binding EvaluationText}"
           Margin="6,2,0,0"

--- a/src/StructuredLogViewer/themes/Generic.xaml
+++ b/src/StructuredLogViewer/themes/Generic.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:l="clr-namespace:Microsoft.Build.Logging.StructuredLogger;assembly=StructuredLogger"
                     xmlns:local="clr-namespace:Microsoft.Build.Logging.StructuredLogger"
@@ -239,14 +239,14 @@
                  Fill="{StaticResource GenericProjectIcon}" />
       <TextBlock Text="{Binding Name}" Margin="0,2,0,0" ToolTip="{Binding ToolTip}" ToolTipService.ShowDuration="60000" />
       <TextBlock
-          Text="{Binding TargetFramework}"
+          Text="{Binding AdormentString}"
           Margin="6,0,0,0"
           Padding="2,0,2,0"
           FontSize="10"
           VerticalAlignment="Center"
           Foreground="{DynamicResource TargetFrameworkForeground}"
           Background="{DynamicResource TargetFrameworkBackground}"
-          Visibility="{Binding TargetFramework, Converter={x:Static s:StringEmptinessToVisibilityConverter.Instance}}"/>
+          Visibility="{Binding AdormentString, Converter={x:Static s:StringEmptinessToVisibilityConverter.Instance}}"/>
       <controls:NodeHyperlinkControl
             Margin="0,2,0,0"
             Text="{Binding TargetsDisplayText}"
@@ -297,14 +297,14 @@
                    ToolTipService.ShowDuration="60000" />-->
       <TextBlock Text="{Binding Name}" Margin="0,2,0,0" ToolTip="{Binding ToolTip}" ToolTipService.ShowDuration="60000" />
       <TextBlock
-          Text="{Binding TargetFramework}"
+          Text="{Binding AdormentString}"
           Margin="6,0,0,0"
           Padding="2,0,2,0"
           FontSize="10"
           VerticalAlignment="Center"
           Foreground="{DynamicResource TargetFrameworkForeground}"
           Background="{DynamicResource TargetFrameworkBackground}"
-          Visibility="{Binding TargetFramework, Converter={x:Static s:StringEmptinessToVisibilityConverter.Instance}}"/>
+          Visibility="{Binding AdormentString, Converter={x:Static s:StringEmptinessToVisibilityConverter.Instance}}"/>
       <TextBlock
           Text="{Binding EvaluationText}"
           Margin="6,2,0,0"

--- a/src/StructuredLogger/Analyzers/BuildAnalyzer.cs
+++ b/src/StructuredLogger/Analyzers/BuildAnalyzer.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using StructuredLogViewer;
-using static Microsoft.Build.Logging.StructuredLogger.CppAnalyzer;
 
 namespace Microsoft.Build.Logging.StructuredLogger
 {
@@ -314,8 +313,6 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 }
             }
         }
-
-
 
         private void AnalyzeTask(Task task)
         {

--- a/src/StructuredLogger/Analyzers/CppAnalyzer.cs
+++ b/src/StructuredLogger/Analyzers/CppAnalyzer.cs
@@ -163,13 +163,13 @@ namespace Microsoft.Build.Logging.StructuredLogger
                                 else
                                 {
                                     // MTT messages only print duration, assume that timestamp of the message is the end.
-                                    // Round 1ms from start time so that the graph fits better.
+                                    // Round 10ms from end time to compensate for the latency in logging and to make the graph look better.
                                     string filename = match.Groups[filenameRegexMatchName].Value;
                                     string msTime = match.Groups[msTimeRegexMatchName].Value;
                                     if (double.TryParse(msTime, out double tryValue) && !string.IsNullOrWhiteSpace(filename))
                                     {
-                                        startTime = message.Timestamp - TimeSpan.FromMilliseconds(tryValue) + oneMilliSecond;
-                                        endTime = message.Timestamp;
+                                        startTime = message.Timestamp - TimeSpan.FromMilliseconds(tryValue);
+                                        endTime = message.Timestamp - TimeSpan.FromMilliseconds(10);
                                         messageText = Path.GetFileName(filename);
                                     }
                                 }

--- a/src/StructuredLogger/Construction/Construction.cs
+++ b/src/StructuredLogger/Construction/Construction.cs
@@ -983,8 +983,12 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 "vbc" => new VbcTask(),
                 "fsc" => new FscTask(),
                 "resolveassemblyreference" => new ResolveAssemblyReferenceTask(),
+                "cl" => new CppAnalyzer.CppTask(),
+                "lib" => new CppAnalyzer.CppTask(),
+                "link" => new CppAnalyzer.CppTask(),
+                "multitooltask" => new CppAnalyzer.CppTask(),
                 _ => new Task(),
-            };
+            };;
 
             result.Name = taskName;
             result.Id = taskId;

--- a/src/StructuredLogger/Construction/Construction.cs
+++ b/src/StructuredLogger/Construction/Construction.cs
@@ -1089,6 +1089,16 @@ namespace Microsoft.Build.Logging.StructuredLogger
                         // renders the badge for all projects, but you can still use this difference to tell what is/isn't an SDK project.
                         project.TargetFramework = kvp.Value;
                     }
+
+                    if (string.Equals(kvp.Key, Strings.Platform, StringComparison.OrdinalIgnoreCase))
+                    {
+                        project.Platform = kvp.Value;
+                    }
+
+                    if (string.Equals(kvp.Key, Strings.Configuration, StringComparison.OrdinalIgnoreCase))
+                    {
+                        project.Configuration = kvp.Value;
+                    }
                 }
             }
         }

--- a/src/StructuredLogger/Construction/MessageProcessor.cs
+++ b/src/StructuredLogger/Construction/MessageProcessor.cs
@@ -1,10 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using System.Text;
-using Microsoft.Build.Collections;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Internal;
 
@@ -571,7 +568,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
             else if (nodeToAdd == null)
             {
                 message = Intern(message);
-                if (parent is Task task && CppAnalyzer.IsCppTask(task.Name))
+                if (parent is Task task && task is CppAnalyzer.CppTask)
                 {
                     nodeToAdd = new TimedMessage
                     {

--- a/src/StructuredLogger/ObjectModel/IProjectOrEvaluation.cs
+++ b/src/StructuredLogger/ObjectModel/IProjectOrEvaluation.cs
@@ -1,22 +1,17 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Configuration;
+﻿using System.Collections.Generic;
 
 namespace Microsoft.Build.Logging.StructuredLogger
 {
     public interface IProjectOrEvaluation
     {
-        public string AdornmentString { get; }
+        string TargetFramework { get; set; }
 
-        public string TargetFramework { get; set; }
+        string Platform { get; set; }
 
-        public string Platform { get; set; }
-
-        public string Configuration { get; set; }
+        string Configuration { get; set; }
     }
 
-    public static class IProjectOrEvaluationHelper
+    public static class ProjectOrEvaluationHelper
     {
         private class IProjectOrEvaluationComparer : IEqualityComparer<IProjectOrEvaluation>
         {
@@ -27,18 +22,10 @@ namespace Microsoft.Build.Logging.StructuredLogger
                     && x.Configuration == y.Configuration;
             }
 
-            public int GetHashCode(IProjectOrEvaluation obj)
-            {
-                int hashcode = 123456789;
-                hashcode = hashcode * 987654321 ^ (obj.TargetFramework == null ? 1 : obj.TargetFramework.GetHashCode());
-                hashcode = hashcode * 987654321 ^ (obj.Platform == null ? 1 : obj.Platform.GetHashCode());
-                hashcode = hashcode * 987654321 ^ (obj.Configuration == null ? 1 : obj.Configuration.GetHashCode());
-
-                return hashcode;
-            }
+            public int GetHashCode(IProjectOrEvaluation obj) => (obj.TargetFramework, obj.Platform, obj.Configuration).GetHashCode();
         }
 
-        private const string seperator = ",";
+        private const string separator = ",";
 
         private static IProjectOrEvaluationComparer comparer = new();
 
@@ -51,10 +38,10 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 return value;
             }
 
-            string Adornment = CreateAdornment(proj);
-            AdornmentStringCache.Add(proj, Adornment);
+            string adornment = CreateAdornment(proj);
+            AdornmentStringCache.Add(proj, adornment);
 
-            return Adornment;
+            return adornment;
         }
 
         private static string CreateAdornment(IProjectOrEvaluation proj)
@@ -63,10 +50,10 @@ namespace Microsoft.Build.Logging.StructuredLogger
             bool existsPlatform = !string.IsNullOrEmpty(proj.Platform);
             bool existsConfiguration = !string.IsNullOrEmpty(proj.Configuration);
 
-            if (existsConfiguration && existsPlatform && existsTF) { return string.Join(seperator, proj.Configuration, proj.Platform, proj.TargetFramework); }
-            else if (existsPlatform && existsTF) { return string.Join(seperator, proj.Platform, proj.TargetFramework); }
-            else if (existsConfiguration && existsPlatform) { return string.Join(seperator, proj.Configuration, proj.Platform); }
-            else if (existsConfiguration && existsTF) { return string.Join(seperator, proj.Configuration, proj.TargetFramework); }
+            if (existsConfiguration && existsPlatform && existsTF) { return string.Join(separator, proj.Configuration, proj.Platform, proj.TargetFramework); }
+            else if (existsPlatform && existsTF) { return string.Join(separator, proj.Platform, proj.TargetFramework); }
+            else if (existsConfiguration && existsPlatform) { return string.Join(separator, proj.Configuration, proj.Platform); }
+            else if (existsConfiguration && existsTF) { return string.Join(separator, proj.Configuration, proj.TargetFramework); }
             else if (existsConfiguration) { return proj.Configuration; }
             else if (existsPlatform) { return proj.Platform; }
             else if (existsTF) { return proj.TargetFramework; }

--- a/src/StructuredLogger/ObjectModel/IProjectOrEvaluation.cs
+++ b/src/StructuredLogger/ObjectModel/IProjectOrEvaluation.cs
@@ -1,4 +1,7 @@
-﻿using System.Configuration;
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Configuration;
 
 namespace Microsoft.Build.Logging.StructuredLogger
 {
@@ -15,16 +18,55 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
     public static class IProjectOrEvaluationHelper
     {
-        public static string MakeAdormentString(this IProjectOrEvaluation proj)
+        private class IProjectOrEvaluationComparer : IEqualityComparer<IProjectOrEvaluation>
+        {
+            public bool Equals(IProjectOrEvaluation x, IProjectOrEvaluation y)
+            {
+                return x.TargetFramework == y.TargetFramework
+                    && x.Platform == y.Platform
+                    && x.Configuration == y.Configuration;
+            }
+
+            public int GetHashCode(IProjectOrEvaluation obj)
+            {
+                int hashcode = 123456789;
+                hashcode = hashcode * 987654321 ^ (obj.TargetFramework == null ? 1 : obj.TargetFramework.GetHashCode());
+                hashcode = hashcode * 987654321 ^ (obj.Platform == null ? 1 : obj.Platform.GetHashCode());
+                hashcode = hashcode * 987654321 ^ (obj.Configuration == null ? 1 : obj.Configuration.GetHashCode());
+
+                return hashcode;
+            }
+        }
+
+        private const string seperator = ";";
+
+        private static IProjectOrEvaluationComparer comparer = new();
+
+        private static Dictionary<IProjectOrEvaluation, string> AdormentStringCache = new(comparer);
+
+        public static string GetAdormentString(this IProjectOrEvaluation proj)
+        {
+            if (AdormentStringCache.TryGetValue(proj, out string value))
+            {
+                return value;
+            }
+
+            string adorment = CreateAdorment(proj);
+            AdormentStringCache.Add(proj, adorment);
+
+            return adorment;
+        }
+
+        private static string CreateAdorment(IProjectOrEvaluation proj)
         {
             bool existsTF = !string.IsNullOrEmpty(proj.TargetFramework);
             bool existsPlatform = !string.IsNullOrEmpty(proj.Platform);
             bool existsConfiguration = !string.IsNullOrEmpty(proj.Configuration);
 
-            if (existsConfiguration && existsTF && existsPlatform) { return $"{proj.Configuration};{proj.Platform};{proj.TargetFramework}"; }
-            else if (existsTF && existsPlatform) { return $"{proj.Configuration};{proj.Platform}"; }
-            else if (existsConfiguration && existsPlatform) { return $"{proj.Platform};{proj.TargetFramework}"; }
-            else if (existsConfiguration && existsTF) { return $"{proj.Configuration};{proj.Platform};{proj.TargetFramework}"; }
+            if (existsConfiguration && existsPlatform && existsTF) { return string.Join(seperator, proj.Configuration, proj.Platform, proj.TargetFramework); }
+            else if (existsPlatform && existsTF) { return string.Join(seperator, proj.Platform, proj.TargetFramework); }
+            else if (existsConfiguration && existsPlatform) { return string.Join(seperator, proj.Configuration, proj.Platform); }
+            else if (existsConfiguration && existsTF) { return string.Join(seperator, proj.Configuration, proj.TargetFramework); }
             else if (existsConfiguration) { return proj.Configuration; }
             else if (existsPlatform) { return proj.Platform; }
             else if (existsTF) { return proj.TargetFramework; }

--- a/src/StructuredLogger/ObjectModel/IProjectOrEvaluation.cs
+++ b/src/StructuredLogger/ObjectModel/IProjectOrEvaluation.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
             }
         }
 
-        private const string seperator = ";";
+        private const string seperator = ",";
 
         private static IProjectOrEvaluationComparer comparer = new();
 

--- a/src/StructuredLogger/ObjectModel/IProjectOrEvaluation.cs
+++ b/src/StructuredLogger/ObjectModel/IProjectOrEvaluation.cs
@@ -1,7 +1,35 @@
+﻿using System.Configuration;
+
 namespace Microsoft.Build.Logging.StructuredLogger
 {
     public interface IProjectOrEvaluation
     {
-        string TargetFramework { get; set; }
+        public string AdormentString { get; }
+
+        public string TargetFramework { get; set; }
+
+        public string Platform { get; set; }
+
+        public string Configuration { get; set; }
+    }
+
+    public static class IProjectOrEvaluationHelper
+    {
+        public static string MakeAdormentString(this IProjectOrEvaluation proj)
+        {
+            bool existsTF = !string.IsNullOrEmpty(proj.TargetFramework);
+            bool existsPlatform = !string.IsNullOrEmpty(proj.Platform);
+            bool existsConfiguration = !string.IsNullOrEmpty(proj.Configuration);
+
+            if (existsConfiguration && existsTF && existsPlatform) { return $"{proj.Configuration};{proj.Platform};{proj.TargetFramework}"; }
+            else if (existsTF && existsPlatform) { return $"{proj.Configuration};{proj.Platform}"; }
+            else if (existsConfiguration && existsPlatform) { return $"{proj.Platform};{proj.TargetFramework}"; }
+            else if (existsConfiguration && existsTF) { return $"{proj.Configuration};{proj.Platform};{proj.TargetFramework}"; }
+            else if (existsConfiguration) { return proj.Configuration; }
+            else if (existsPlatform) { return proj.Platform; }
+            else if (existsTF) { return proj.TargetFramework; }
+
+            return string.Empty;
+        }
     }
 }

--- a/src/StructuredLogger/ObjectModel/IProjectOrEvaluation.cs
+++ b/src/StructuredLogger/ObjectModel/IProjectOrEvaluation.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
 {
     public interface IProjectOrEvaluation
     {
-        public string AdormentString { get; }
+        public string AdornmentString { get; }
 
         public string TargetFramework { get; set; }
 
@@ -42,22 +42,22 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
         private static IProjectOrEvaluationComparer comparer = new();
 
-        private static Dictionary<IProjectOrEvaluation, string> AdormentStringCache = new(comparer);
+        private static Dictionary<IProjectOrEvaluation, string> AdornmentStringCache = new(comparer);
 
-        public static string GetAdormentString(this IProjectOrEvaluation proj)
+        public static string GetAdornmentString(this IProjectOrEvaluation proj)
         {
-            if (AdormentStringCache.TryGetValue(proj, out string value))
+            if (AdornmentStringCache.TryGetValue(proj, out string value))
             {
                 return value;
             }
 
-            string adorment = CreateAdorment(proj);
-            AdormentStringCache.Add(proj, adorment);
+            string Adornment = CreateAdornment(proj);
+            AdornmentStringCache.Add(proj, Adornment);
 
-            return adorment;
+            return Adornment;
         }
 
-        private static string CreateAdorment(IProjectOrEvaluation proj)
+        private static string CreateAdornment(IProjectOrEvaluation proj)
         {
             bool existsTF = !string.IsNullOrEmpty(proj.TargetFramework);
             bool existsPlatform = !string.IsNullOrEmpty(proj.Platform);

--- a/src/StructuredLogger/ObjectModel/Project.cs
+++ b/src/StructuredLogger/ObjectModel/Project.cs
@@ -115,9 +115,16 @@ namespace Microsoft.Build.Logging.StructuredLogger
             }
         }
 
+        public string AdormentString => this.MakeAdormentString();
+
         public string TargetFramework { get; set; }
 
+        public string Platform { get; set; }
+
+        public string Configuration { get; set; }
+
         public int EvaluationId { get; set; }
+
         public string EvaluationText { get; set; } = "";
 
         public IDictionary<string, string> GlobalProperties { get; set; } = ImmutableDictionary<string, string>.Empty;

--- a/src/StructuredLogger/ObjectModel/Project.cs
+++ b/src/StructuredLogger/ObjectModel/Project.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
             }
         }
 
-        public string AdormentString => this.GetAdormentString();
+        public string AdornmentString => this.GetAdornmentString();
 
         public string TargetFramework { get; set; }
 

--- a/src/StructuredLogger/ObjectModel/Project.cs
+++ b/src/StructuredLogger/ObjectModel/Project.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
             }
         }
 
-        public string AdormentString => this.MakeAdormentString();
+        public string AdormentString => this.GetAdormentString();
 
         public string TargetFramework { get; set; }
 

--- a/src/StructuredLogger/ObjectModel/ProjectEvaluation.cs
+++ b/src/StructuredLogger/ObjectModel/ProjectEvaluation.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
         public string EvaluationText { get; set; } = "";
 
-        public string AdormentString => this.MakeAdormentString();
+        public string AdormentString => this.GetAdormentString();
 
         public string TargetFramework { get; set; }
 

--- a/src/StructuredLogger/ObjectModel/ProjectEvaluation.cs
+++ b/src/StructuredLogger/ObjectModel/ProjectEvaluation.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
         public string EvaluationText { get; set; } = "";
 
-        public string AdormentString => this.GetAdormentString();
+        public string AdornmentString => this.GetAdornmentString();
 
         public string TargetFramework { get; set; }
 

--- a/src/StructuredLogger/ObjectModel/ProjectEvaluation.cs
+++ b/src/StructuredLogger/ObjectModel/ProjectEvaluation.cs
@@ -17,7 +17,13 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
         public string EvaluationText { get; set; } = "";
 
+        public string AdormentString => this.MakeAdormentString();
+
         public string TargetFramework { get; set; }
+
+        public string Platform { get; set; }
+
+        public string Configuration { get; set; }
 
         public double RelativeDuration { get; set; }
 

--- a/src/StructuredLogger/Search/ProxyNode.cs
+++ b/src/StructuredLogger/Search/ProxyNode.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
             }
             else if (node is Project project)
             {
-                return $"{project.Name} {project.AdormentString} {project.TargetsDisplayText}";
+                return $"{project.Name} {project.AdornmentString} {project.TargetsDisplayText}";
             }
             else if (node is ProjectEvaluation evaluation)
             {

--- a/src/StructuredLogger/Search/ProxyNode.cs
+++ b/src/StructuredLogger/Search/ProxyNode.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using StructuredLogViewer;
@@ -34,7 +34,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
             }
             else if (node is Project project)
             {
-                return $"{project.Name} {project.TargetFramework}{project.TargetsDisplayText}";
+                return $"{project.Name} {project.AdormentString} {project.TargetsDisplayText}";
             }
             else if (node is ProjectEvaluation evaluation)
             {

--- a/src/StructuredLogger/Strings/Strings.cs
+++ b/src/StructuredLogger/Strings/Strings.cs
@@ -473,6 +473,8 @@ namespace Microsoft.Build.Logging.StructuredLogger
         public static string Global => "Global";
         public static string EntryTargets => "Entry targets";
         public static string TargetFramework => "TargetFramework";
+        public static string Platform => "Platform";
+        public static string Configuration => "Configuration";
         public static string TargetFrameworks => "TargetFrameworks";
         public static string TargetFrameworkVersion => "TargetFrameworkVersion";
         public static string AdditionalProperties => "Additional properties";


### PR DESCRIPTION
### Add Platform/Configuration Adornment
Add platform and configuration into the existing TargetFramework property for project nodes.  Platform and Configuration are the primary properties and is often a cause of issue when solution are incorrectly batched.
<details>
<summary>Screen Shot</summary>
<img src="https://user-images.githubusercontent.com/19828377/191128957-35fcaeb1-7271-4983-93fe-6c60504eda7f.png" />
<img src="https://user-images.githubusercontent.com/19828377/191129689-949365d6-a458-4750-b743-a2ed4cdb4a86.png" />

</details>

### CppAnalyzer QOL improvements
- Turned off Cpp Details by default.
- Fix an issue where not all Cpp Details are active for all task.  Now each task has a boolean to indicate when it is present.  IE. CL.exe can be have details but Linker doesn't.
- Merge C1/C2 messages from BT Time, cutting the number of nodes in half.
- Align the Compile Time to the right (previously center).  The start time is unknown but the end time is almost guarantee to be correct.
- Add more rounding to MTT messages to make the graph fit better.