### PR TITLE
TraceView: Add option to show P2P relation when a project is highlighted

### DIFF
--- a/src/StructuredLogViewer/Controls/TracingControl.xaml
+++ b/src/StructuredLogViewer/Controls/TracingControl.xaml
@@ -13,10 +13,13 @@
                 <MenuItem Header="{Binding Path=ShowProjectsText, Mode=OneWay}" IsCheckable="true" IsChecked="{Binding Path=ShowProject , Mode=TwoWay}" StaysOpenOnClick="true"/>
                 <MenuItem Header="{Binding Path=ShowTargetsText, Mode=OneWay}" IsCheckable="true" IsChecked="{Binding Path=ShowTarget , Mode=TwoWay}" StaysOpenOnClick="true"/>
                 <MenuItem Header="{Binding Path=ShowTasksText, Mode=OneWay}" IsCheckable="true" IsChecked="{Binding Path=ShowTask , Mode=TwoWay}" StaysOpenOnClick="true"/>
-                <MenuItem Header="{Binding Path=ShowCppText, Mode=OneWay}" IsCheckable="true" IsChecked="{Binding Path=ShowCpp , Mode=TwoWay}" StaysOpenOnClick="true"/>
-                <MenuItem Header="{Binding Path=ShowNodesText, Mode=OneWay}" IsCheckable="true" IsChecked="{Binding Path=ShowNodes , Mode=TwoWay}" StaysOpenOnClick="true"/>
-                <MenuItem Header="Group By Nodes" IsCheckable="true" IsChecked="{Binding Path=GroupByNodes , Mode=TwoWay}" StaysOpenOnClick="true"/>
-                <!--<MenuItem Header="{Binding Path=LoadStatistics, Mode=OneWay}" IsCheckable="true" IsEnabled="false" />-->
+                <MenuItem Header="More...">
+                    <MenuItem Header="{Binding Path=ShowCppText, Mode=OneWay}" IsCheckable="true" IsChecked="{Binding Path=ShowCpp , Mode=TwoWay}" StaysOpenOnClick="true"/>
+                    <MenuItem Header="Show P2P on Selection" IsCheckable="true" IsChecked="{Binding Path=ShowProjectReferenceSelection , Mode=TwoWay}" StaysOpenOnClick="true"/>
+                    <MenuItem Header="{Binding Path=ShowNodesText, Mode=OneWay}" IsCheckable="true" IsChecked="{Binding Path=ShowNodes , Mode=TwoWay}" StaysOpenOnClick="true"/>
+                    <MenuItem Header="Group By Nodes" IsCheckable="true" IsChecked="{Binding Path=GroupByNodes , Mode=TwoWay}" StaysOpenOnClick="true"/>
+                    <!--<MenuItem Header="{Binding Path=LoadStatistics, Mode=OneWay}" IsCheckable="true" IsEnabled="false" />-->
+                </MenuItem>
             </ContextMenu>
         </Grid.ContextMenu>
         <ScrollViewer x:Name="scrollViewer"

--- a/src/StructuredLogViewer/Controls/TracingControl.xaml
+++ b/src/StructuredLogViewer/Controls/TracingControl.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="StructuredLogViewer.Controls.TracingControl"
+<UserControl x:Class="StructuredLogViewer.Controls.TracingControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -6,42 +6,44 @@
              xmlns:local="clr-namespace:StructuredLogViewer.Controls"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
-  <Grid>
-    <Grid.ContextMenu>
-      <ContextMenu>
-        <MenuItem Header="{Binding Path=ShowEvaluationsText, Mode=OneWay}" IsCheckable="true" IsChecked="{Binding Path=ShowEvaluation , Mode=TwoWay}" StaysOpenOnClick="true"/>
-        <MenuItem Header="{Binding Path=ShowProjectsText, Mode=OneWay}" IsCheckable="true" IsChecked="{Binding Path=ShowProject , Mode=TwoWay}" StaysOpenOnClick="true"/>
-        <MenuItem Header="{Binding Path=ShowTargetsText, Mode=OneWay}" IsCheckable="true" IsChecked="{Binding Path=ShowTarget , Mode=TwoWay}" StaysOpenOnClick="true"/>
-        <MenuItem Header="{Binding Path=ShowTasksText, Mode=OneWay}" IsCheckable="true" IsChecked="{Binding Path=ShowTask , Mode=TwoWay}" StaysOpenOnClick="true"/>
-        <MenuItem Header="{Binding Path=ShowCppText, Mode=OneWay}" IsCheckable="true" IsChecked="{Binding Path=ShowCpp , Mode=TwoWay}" StaysOpenOnClick="true"/>
-        <MenuItem Header="{Binding Path=ShowNodesText, Mode=OneWay}" IsCheckable="true" IsChecked="{Binding Path=ShowNodes , Mode=TwoWay}" StaysOpenOnClick="true"/>
-        <MenuItem Header="Group By Nodes" IsCheckable="true" IsChecked="{Binding Path=GroupByNodes , Mode=TwoWay}" StaysOpenOnClick="true"/>
-        <!--<MenuItem Header="{Binding Path=LoadStatistics, Mode=OneWay}" IsCheckable="true" IsEnabled="false" />-->
-      </ContextMenu>
-    </Grid.ContextMenu>
-    <ScrollViewer x:Name="scrollViewer"
+    <Grid>
+        <Grid.ContextMenu>
+            <ContextMenu>
+                <MenuItem Header="{Binding Path=ShowEvaluationsText, Mode=OneWay}" IsCheckable="true" IsChecked="{Binding Path=ShowEvaluation , Mode=TwoWay}" StaysOpenOnClick="true"/>
+                <MenuItem Header="{Binding Path=ShowProjectsText, Mode=OneWay}" IsCheckable="true" IsChecked="{Binding Path=ShowProject , Mode=TwoWay}" StaysOpenOnClick="true"/>
+                <MenuItem Header="{Binding Path=ShowTargetsText, Mode=OneWay}" IsCheckable="true" IsChecked="{Binding Path=ShowTarget , Mode=TwoWay}" StaysOpenOnClick="true"/>
+                <MenuItem Header="{Binding Path=ShowTasksText, Mode=OneWay}" IsCheckable="true" IsChecked="{Binding Path=ShowTask , Mode=TwoWay}" StaysOpenOnClick="true"/>
+                <MenuItem Header="{Binding Path=ShowCppText, Mode=OneWay}" IsCheckable="true" IsChecked="{Binding Path=ShowCpp , Mode=TwoWay}" StaysOpenOnClick="true"/>
+                <MenuItem Header="{Binding Path=ShowNodesText, Mode=OneWay}" IsCheckable="true" IsChecked="{Binding Path=ShowNodes , Mode=TwoWay}" StaysOpenOnClick="true"/>
+                <MenuItem Header="Group By Nodes" IsCheckable="true" IsChecked="{Binding Path=GroupByNodes , Mode=TwoWay}" StaysOpenOnClick="true"/>
+                <!--<MenuItem Header="{Binding Path=LoadStatistics, Mode=OneWay}" IsCheckable="true" IsEnabled="false" />-->
+            </ContextMenu>
+        </Grid.ContextMenu>
+        <ScrollViewer x:Name="scrollViewer"
                 HorizontalScrollBarVisibility="Auto" 
                 VerticalScrollBarVisibility="Auto" Loaded="ScrollViewer_Loaded" Unloaded="ScrollViewer_Unloaded" ScrollChanged="ScrollViewer_ScrollChanged">
-      <Grid x:Name="grid">
-      </Grid>
-    </ScrollViewer>
-    <StackPanel Margin="0,0,30,30"
+            <Grid>
+                <Grid x:Name="overlayGrid" Panel.ZIndex="100" />
+                <Grid x:Name="grid" />
+            </Grid>
+        </ScrollViewer>
+        <StackPanel Margin="0,0,30,30"
                 Background="White"
                 Orientation="Horizontal"
                 ToolTip="Ctrl+MouseWheel to Zoom"
                 HorizontalAlignment="Right"
                 VerticalAlignment="Bottom">
-      <Button x:Name="resetZoomButton"
+            <Button x:Name="resetZoomButton"
               Click="ResetZoom_Click" 
               Padding="2,0,2,0" 
               Visibility="Hidden">100%</Button>
-      <Slider x:Name="zoomSlider"
+            <Slider x:Name="zoomSlider"
             MinWidth="100"
             MinHeight="30"
             Minimum="0.1"
             Maximum="4"
             Value="1"
             ValueChanged="zoomSlider_ValueChanged" />
-    </StackPanel>
-  </Grid>
+        </StackPanel>
+    </Grid>
 </UserControl>

--- a/src/StructuredLogger/Analyzers/CppAnalyzer.cs
+++ b/src/StructuredLogger/Analyzers/CppAnalyzer.cs
@@ -180,6 +180,8 @@ namespace Microsoft.Build.Logging.StructuredLogger
                                 {
                                     if (blocks.TryGetValue(filename, out CppTimedNode cppNode))
                                     {
+                                        // note: there is a strange bug where some messages are printed twice.  Don't insert twice into the dictionary.
+
                                         // BT Time prints C1 and C2 as seperate messages, so lets combine to reduce the graph nodes by half.
                                         if (usingBTTime)
                                         {

--- a/src/StructuredLogger/Analyzers/CppAnalyzer.cs
+++ b/src/StructuredLogger/Analyzers/CppAnalyzer.cs
@@ -179,10 +179,13 @@ namespace Microsoft.Build.Logging.StructuredLogger
                                 if (startTime > DateTime.MinValue)
                                 {
                                     // BT Time prints C1 and C2 as seperate messages, so lets combine to reduce the graph nodes by half.
-                                    if (usingBTTime && blocks.TryGetValue(filename, out CppTimedNode cppNode))
+                                    if (blocks.TryGetValue(filename, out CppTimedNode cppNode))
                                     {
-                                        cppNode.StartTime = new DateTime(Math.Min(cppNode.StartTime.Ticks, startTime.Ticks));
-                                        cppNode.EndTime = new DateTime(Math.Max(cppNode.EndTime.Ticks, endTime.Ticks));
+                                        if (usingBTTime)
+                                        {
+                                            cppNode.StartTime = new DateTime(Math.Min(cppNode.StartTime.Ticks, startTime.Ticks));
+                                            cppNode.EndTime = new DateTime(Math.Max(cppNode.EndTime.Ticks, endTime.Ticks));
+                                        }
                                     }
                                     else
                                     {

--- a/src/StructuredLogger/ObjectModel/TreeNode.cs
+++ b/src/StructuredLogger/ObjectModel/TreeNode.cs
@@ -525,5 +525,30 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 }
             }
         }
+
+        // A breadth first search looking for the first node of type T.
+        public IReadOnlyList<T> FindImmediateChildrenOfType<T>()
+        {
+            Queue<BaseNode> searchQueue = new Queue<BaseNode>(Children);
+            List<T> resultNodes = new List<T>();
+
+            while (searchQueue.Count > 0)
+            {
+                var node = searchQueue.Dequeue();
+                if (node is T tNode)
+                {
+                    resultNodes.Add(tNode);
+                }
+                else if (node is TreeNode treeNode && treeNode.HasChildren)
+                {
+                    foreach (BaseNode child in treeNode.Children)
+                    {
+                        searchQueue.Enqueue(child);
+                    }
+                }
+            }
+
+            return resultNodes;
+        }
     }
 }


### PR DESCRIPTION
## Add a feature to show P2P relationship when a project node is selected.
- Remove some common P2P targets to avoid clutter.  ~10% of total targets, but huge visual real estate because they are long running.
- To compensate for the loss of details, extend highlight to show parent and dependent projects.
- Refactor Highlight mechanic to an single overlay Canvas.
- Removed ContentControl() to speed up loading.  Est. ~10% faster.
- Moved some context menu into sub-menu as the menu is starting to get long.
- As part of the refactor, improved hit rate of GoToTimedNode() by reloading all TextBlocks.

Misc.
- Avoid failing to load C++ Analysis when a duplicated message is printed.  Not sure why such message is printed, but best not to fail.

<details><summary>After</summary>
<img src="https://user-images.githubusercontent.com/19828377/200091095-f85ed832-a193-4859-b28d-6983b1339c65.png" />
</details>

<details><summary>Before</summary>
<img src="https://user-images.githubusercontent.com/19828377/200091180-7676d42f-4a7e-4cf4-8e67-e83ac1a9ba38.png" />
</details>