### PR TITLE
Fix DisplayDuration display

### DIFF
--- a/src/StructuredLogger.Tests/TextUtilitiesTests.cs
+++ b/src/StructuredLogger.Tests/TextUtilitiesTests.cs
@@ -149,5 +149,21 @@ namespace StructuredLogger.Tests
         {
             var strings = StringsSet.ResourcesCollection;
         }
+
+        [Theory]
+        [InlineData(0, "")]
+        [InlineData(1, "1 ms")]
+        [InlineData(1000, "1.000 s")]
+        [InlineData(60 * 1000, "1:00.000")]
+        [InlineData(60 * 1000 + 40, "1:00.040")]
+        [InlineData(60 * 60 * 1000, "01:00:00")]
+        [InlineData(12 * 60 * 60 * 1000, "12:00:00")]
+        [InlineData(2 * 24 * 60 * 60 * 1000, "2.00:00:00")]
+        [InlineData(2 * 24 * 60 * 60 * 1000 + 40, "2.00:00:00.0400000")]
+        public void TestDisplayDuration(int duration, string expected)
+        {
+            var actual = TextUtilities.DisplayDuration(TimeSpan.FromMilliseconds(duration));
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/src/StructuredLogger/TextUtilities.cs
+++ b/src/StructuredLogger/TextUtilities.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -451,18 +451,15 @@ namespace Microsoft.Build.Logging.StructuredLogger
             {
                 return showZero ? "0 ms" : "";
             }
-
-            if (span.TotalSeconds > 3600)
+            if (span.TotalHours >= 1)
             {
-                return span.ToString(@"h\:mm\:ss");
+                return span.ToString();
             }
-
-            if (span.TotalSeconds > 60)
+            if (span.TotalMinutes >= 1)
             {
                 return span.ToString(@"m\:ss\.fff");
             }
-
-            if (span.TotalMilliseconds > 1000)
+            if (span.TotalSeconds >= 1)
             {
                 return span.ToString(@"s\.fff") + " s";
             }


### PR DESCRIPTION
Fixes #646

`TextUtilities.DisplayDuration` produces invalid output for several different input values. The new tests executed against the old code produce the following test failures:
```
[xUnit.net 00:00:00.19]   Starting:    StructuredLogger.Tests
[xUnit.net 00:00:01.43]     StructuredLogger.Tests.TextUtilitiesTests.TestDisplayDuration(duration: 60000, expected: "1:00.000") [FAIL]
[xUnit.net 00:00:01.43]       Assert.Equal() Failure
[xUnit.net 00:00:01.43]                 ↓ (pos 0)
[xUnit.net 00:00:01.43]       Expected: 1:00.000
[xUnit.net 00:00:01.43]       Actual:   0.000 s
[xUnit.net 00:00:01.43]                 ↑ (pos 0)
[xUnit.net 00:00:01.45]     StructuredLogger.Tests.TextUtilitiesTests.TestDisplayDuration(duration: 172800040, expected: "2.00:00:00.0400000") [FAIL]
[xUnit.net 00:00:01.45]       Assert.Equal() Failure
[xUnit.net 00:00:01.45]                 ↓ (pos 0)
[xUnit.net 00:00:01.45]       Expected: 2.00:00:00.0400000
[xUnit.net 00:00:01.45]       Actual:   0:00:00
[xUnit.net 00:00:01.46]                 ↑ (pos 0)
[xUnit.net 00:00:01.46]     StructuredLogger.Tests.TextUtilitiesTests.TestDisplayDuration(duration: 3600000, expected: "01:00:00") [FAIL]
[xUnit.net 00:00:01.46]       Assert.Equal() Failure
[xUnit.net 00:00:01.46]                  ↓ (pos 1)
[xUnit.net 00:00:01.46]       Expected: 01:00:00
[xUnit.net 00:00:01.46]       Actual:   0:00.000
[xUnit.net 00:00:01.46]                  ↑ (pos 1)
[xUnit.net 00:00:01.46]     StructuredLogger.Tests.TextUtilitiesTests.TestDisplayDuration(duration: 1000, expected: "1.000 s") [FAIL]
[xUnit.net 00:00:01.46]       Assert.Equal() Failure
[xUnit.net 00:00:01.46]                 ↓ (pos 0)
[xUnit.net 00:00:01.46]       Expected: 1.000 s
[xUnit.net 00:00:01.46]       Actual:   0 ms
[xUnit.net 00:00:01.46]                 ↑ (pos 0)
[xUnit.net 00:00:01.46]     StructuredLogger.Tests.TextUtilitiesTests.TestDisplayDuration(duration: 172800000, expected: "2.00:00:00") [FAIL]
[xUnit.net 00:00:01.46]       Assert.Equal() Failure
[xUnit.net 00:00:01.46]                 ↓ (pos 0)
[xUnit.net 00:00:01.46]       Expected: 2.00:00:00
[xUnit.net 00:00:01.46]       Actual:   0:00:00
[xUnit.net 00:00:01.46]                 ↑ (pos 0)
[xUnit.net 00:00:01.46]   Finished:    StructuredLogger.Tests
========== Test run finished: 9 Tests (4 Passed, 5 Failed, 0 Skipped) run in 1,5 sec ==========
```