### PR TITLE
[QOL] Files Search support full path and open .rsp on double click 

### DIFF
--- a/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
@@ -326,7 +326,7 @@ Right-clicking a project node may show the 'Preprocess' option if the version of
             var list = filesTree.ResultsList.ItemsSource as IEnumerable<object>;
             if (list != null)
             {
-                UpdateFileVisibility(list.OfType<NamedNode>(), ArchiveFile.CalculateArchivePath(text));
+                UpdateFileVisibility(list.OfType<NamedNode>(), text.Replace(":", ""));
             }
         }
 

--- a/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
@@ -326,7 +326,7 @@ Right-clicking a project node may show the 'Preprocess' option if the version of
             var list = filesTree.ResultsList.ItemsSource as IEnumerable<object>;
             if (list != null)
             {
-                UpdateFileVisibility(list.OfType<NamedNode>(), text);
+                UpdateFileVisibility(list.OfType<NamedNode>(), ArchiveFile.CalculateArchivePath(text));
             }
         }
 

--- a/src/StructuredLogger/ObjectModel/Message.cs
+++ b/src/StructuredLogger/ObjectModel/Message.cs
@@ -50,6 +50,12 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 return match;
             }
 
+            match = Strings.MessageIncludedResponseFile.Match(Text);
+            if (match.Success)
+            {
+                return match;
+            }
+
             return null;
         }
 
@@ -63,7 +69,10 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 if (match != null && match.Success)
                 {
                     var value = match.Groups["Line"].Value;
-                    return int.Parse(value);
+                    if (int.TryParse(value, out int result))
+                    {
+                        return result;
+                    }
                 }
 
                 return null;

--- a/src/StructuredLogger/Strings/Strings.cs
+++ b/src/StructuredLogger/Strings/Strings.cs
@@ -149,6 +149,10 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 .Replace("{3}", @"(?<File>.*) \((?<Line>\d+),(?<Column>\d+)\)$");
             PropertyReassignmentRegex = new Regex(propertyReassignment, RegexOptions.Compiled | RegexOptions.Singleline);
 
+            // Note: This string is not localized in MSBuild.
+            const string messageIncludeResponseFileString = @$"^Included response file: (?<File>((.:)?[^:\n\r]*?))$";
+            MessageIncludedResponseFile = new Regex(messageIncludeResponseFileString, RegexOptions.Compiled | RegexOptions.Singleline);
+
             string taskFoundFromFactory = GetString("TaskFoundFromFactory")
                 .Replace(@"""{0}""", @"\""(?<task>.+)\""")
                 .Replace(@"""{1}""", @"\""(?<assembly>.+)\""");
@@ -246,6 +250,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
         public static Regex ProjectImportSkippedExpressionEvaluatedToEmptyRegex { get; set; }
         public static Regex ProjectImportSkippedNoMatchesRegex { get; set; }
         public static Regex PropertyReassignmentRegex { get; set; }
+        public static Regex MessageIncludedResponseFile { get; set; }
         public static Regex UnifiedPrimaryReferencePrefix { get; set; }
         public static Regex PrimaryReferencePrefix { get; set; }
         public static Regex DependencyPrefix { get; set; }


### PR DESCRIPTION
- Fix an issue where "Files" tab did not support searching with full path.  Due to rooted path have changed C:\ ==> C\
  
- Open .rsp on double click.
IE, "Included response file: C:\Program Files\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin\amd64\MSBuild.rsp" will now open the file.
