### PR TITLE
Add support for logging assembly loads logging

### DIFF
--- a/src/StructuredLogger/AssemblyLoadBuildEventArgs2.cs
+++ b/src/StructuredLogger/AssemblyLoadBuildEventArgs2.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
+
+// TODO: remove whole file once AssemblyLoadBuildEventArgs are imported via Microsoft.Build.Framework package
+
+namespace Microsoft.Build.Framework
+{
+    internal enum AssemblyLoadingContext
+    {
+        TaskRun,
+        Evaluation,
+        SdkResolution,
+        LoggerInitialization,
+    }
+
+    internal sealed class AssemblyLoadBuildEventArgs : BuildMessageEventArgs
+    {
+        private const string DefaultAppDomainDescriptor = "[Default]";
+
+        public AssemblyLoadBuildEventArgs()
+        { }
+
+        public AssemblyLoadBuildEventArgs(
+            AssemblyLoadingContext loadingContext,
+            string? loadingInitiator,
+            string? assemblyName,
+            string assemblyPath,
+            Guid mvid,
+            string? customAppDomainDescriptor,
+            MessageImportance importance = MessageImportance.Low)
+            : base(null, null, null, importance, DateTime.UtcNow, assemblyName, assemblyPath, mvid)
+        {
+            LoadingContext = loadingContext;
+            LoadingInitiator = loadingInitiator;
+            AssemblyName = assemblyName;
+            AssemblyPath = assemblyPath;
+            MVID = mvid;
+            AppDomainDescriptor = customAppDomainDescriptor;
+        }
+
+        public AssemblyLoadingContext LoadingContext { get; private set; }
+        public string? LoadingInitiator { get; private set; }
+        public string? AssemblyName { get; private set; }
+        public string? AssemblyPath { get; private set; }
+        public Guid MVID { get; private set; }
+        // Null string indicates that load occurred on Default AppDomain (for both Core and Framework).
+        public string? AppDomainDescriptor { get; private set; }
+
+        public override string Message
+        {
+            get
+            {
+                if (RawMessage == null)
+                {
+                    string? loadingInitiator = LoadingInitiator == null ? null : $" ({LoadingInitiator})";
+                    RawMessage = string.Format("Assembly loaded during {0}{1}: {2} (location: {3}, MVID: {4}, AppDomain: {5})", LoadingContext.ToString(), loadingInitiator, AssemblyName, AssemblyPath, MVID.ToString(), AppDomainDescriptor ?? DefaultAppDomainDescriptor);
+                }
+
+                return RawMessage;
+            }
+        }
+    }
+}

--- a/src/StructuredLogger/BinaryLogger/BinaryLogRecordKind.cs
+++ b/src/StructuredLogger/BinaryLogger/BinaryLogRecordKind.cs
@@ -28,6 +28,7 @@
         NameValueList,
         String,
         TaskParameter,
-        FileUsed
+        FileUsed,
+        AssemblyLoad
     }
 }

--- a/src/StructuredLogger/BinaryLogger/BinaryLogger.cs
+++ b/src/StructuredLogger/BinaryLogger/BinaryLogger.cs
@@ -57,7 +57,9 @@ namespace Microsoft.Build.Logging.StructuredLogger
         //   - TargetSkippedEventArgs: added SkipReason, OriginalBuildEventContext
         // version 15:
         //   - new record kind: FileUsedEventArgs
-        internal const int FileFormatVersion = 15;
+        // version 16:
+        //   - AssemblyLoadBuildEventArgs
+        internal const int FileFormatVersion = 16;
 
         private Stream stream;
         private BinaryWriter binaryWriter;

--- a/src/StructuredLogger/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/StructuredLogger/BinaryLogger/BuildEventArgsWriter.cs
@@ -151,6 +151,7 @@ Build
             TaskCommandLine
             TaskParameter
             UninitializedPropertyRead
+            AssemblyLoaded
         BuildStatus
             TaskStarted
             TaskFinished
@@ -431,6 +432,7 @@ Build
                 case PropertyInitialValueSetEventArgs propertyInitialValueSet: Write(propertyInitialValueSet); break;
                 case CriticalBuildMessageEventArgs criticalBuildMessage: Write(criticalBuildMessage); break;
                 case FileUsedEventArgs fileUsed: Write(fileUsed); break;
+                case AssemblyLoadBuildEventArgs assemblyLoaded: Write(assemblyLoaded); break;
                 default: // actual BuildMessageEventArgs
                     Write(BinaryLogRecordKind.Message);
                     WriteMessageFields(e, writeImportance: true);
@@ -506,6 +508,18 @@ Build
             Write(BinaryLogRecordKind.FileUsed);
             WriteMessageFields(e, writeImportance: false);
             WriteDeduplicatedString(e.FilePath);
+        }
+
+        private void Write(AssemblyLoadBuildEventArgs e)
+        {
+            Write(BinaryLogRecordKind.AssemblyLoad);
+            WriteMessageFields(e, writeMessage: false, writeImportance: false);
+            Write((int)e.LoadingContext);
+            WriteDeduplicatedString(e.LoadingInitiator);
+            WriteDeduplicatedString(e.AssemblyName);
+            WriteDeduplicatedString(e.AssemblyPath);
+            Write(e.MVID);
+            WriteDeduplicatedString(e.AppDomainDescriptor);
         }
 
         private void Write(TaskCommandLineEventArgs e)
@@ -1105,6 +1119,12 @@ Build
         private void Write(bool boolean)
         {
             binaryWriter.Write(boolean);
+        }
+
+        private void Write(Guid guid)
+        {
+            // To avoid allocation (as is done in MSBuild code base) we'd need unsafe code.
+            binaryWriter.Write(guid.ToByteArray());
         }
 
         private void WriteDeduplicatedString(string text)


### PR DESCRIPTION
Related to: https://github.com/dotnet/msbuild/issues/6303
Deature in MSBuild: https://github.com/dotnet/msbuild/pull/8316

### Context

Adding support for showing assembly load events, prduced by the MSBuild.
There is no special treating of the events - they get disaplayed as text message. For sample messages, see the MSBuild PR listed at top.
Sample viewer screenshot:

<img width="914" alt="image" src="https://user-images.githubusercontent.com/3809076/217288820-de4513cb-5d36-4a2e-bf00-ac847cb44709.png">

