### PR TITLE
Treat Assembly Loads as messages

### DIFF
--- a/src/StructuredLogger/Construction/MessageProcessor.cs
+++ b/src/StructuredLogger/Construction/MessageProcessor.cs
@@ -397,7 +397,11 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 parent = GetTask(args);
                 if (parent is Task task)
                 {
-                    if (task is ResolveAssemblyReferenceTask rar)
+                    if (args is AssemblyLoadBuildEventArgs)
+                    {
+                        nodeToAdd = new Message() { Text = message };
+                    }
+                    else if (task is ResolveAssemblyReferenceTask rar)
                     {
                         if (ProcessRAR(rar, ref parent, message))
                         {

--- a/src/StructuredLogger/Construction/MessageProcessor.cs
+++ b/src/StructuredLogger/Construction/MessageProcessor.cs
@@ -399,7 +399,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 {
                     if (args is AssemblyLoadBuildEventArgs)
                     {
-                        nodeToAdd = new Message() { Text = message };
+                        nodeToAdd = new Message() { Text = Intern(message), IsLowRelevance = lowRelevance };
                     }
                     else if (task is ResolveAssemblyReferenceTask rar)
                     {


### PR DESCRIPTION
### Context

'Assembly loaded' messages were interpreted as Properties on `MSBuild` target.
https://github.com/KirillOsenkov/MSBuildStructuredLog/pull/653#issuecomment-1423025459

### Fix

Special case args by `AssemblyLoadedBuildEventArgs` type before special case handling `MSBuild` target