### PR TITLE
Add Cpp Project Icon

### DIFF
--- a/src/ResourcesGenerator/ResourceCreator.cs
+++ b/src/ResourcesGenerator/ResourceCreator.cs
@@ -77,7 +77,8 @@ namespace ResourcesGenerator
             "EvaluationFinished",
             "CouldNotResolveSdk",
             "ProjectImportSkippedExpressionEvaluatedToEmpty",
-            "SkipTargetBecauseOutputsUpToDate"
+            "SkipTargetBecauseOutputsUpToDate",
+            "MetaprojectGenerated"
         };
 
         public static Dictionary<string, string> Cultures = new Dictionary<string, string>

--- a/src/StructuredLogViewer/themes/Generic.xaml
+++ b/src/StructuredLogViewer/themes/Generic.xaml
@@ -144,7 +144,21 @@
           <GeometryDrawing Brush="#FF414141" Geometry="F1M5.8496,11C6.5296,11,7.0786,10.898,7.4996,10.692L7.4996,9.499C7.0786,9.747 6.6156,9.871 6.1076,9.871 5.5766,9.871 5.1546,9.705 4.8396,9.372 4.5256,9.039 4.3696,8.592 4.3696,8.031 4.3696,7.445 4.5356,6.981 4.8686,6.639 5.2016,6.297 5.6386,6.125 6.1796,6.125 6.6736,6.125 7.1146,6.241 7.4996,6.473L7.4996,5.215C7.1146,5.072 6.6386,5 6.0766,5 5.1656,5 4.4256,5.289 3.8556,5.866 3.2856,6.443 2.9996,7.195 2.9996,8.124 2.9996,8.995 3.2536,9.692 3.7616,10.216 4.2676,10.739 4.9646,11 5.8496,11" />
           <GeometryDrawing Brush="#FFF0EFF1" Geometry="F1M10,8L11,8 11,7 10,7z" />
           <GeometryDrawing Brush="#FFF0EFF1" Geometry="F1M13,7L12,7 12,8 13,8 13,9 12,9 12,10 11,10 11,9 10,9 10,10 9,10 9,9 8,9 8,8 9,8 9,7 8,7 8,6 9,6 9,5 10,5 10,6 11,6 11,5 12,5 12,6 13,6z M7.5,6.473C7.114,6.241 6.674,6.125 6.18,6.125 5.639,6.125 5.201,6.297 4.868,6.639 4.535,6.981 4.369,7.445 4.369,8.031 4.369,8.592 4.525,9.039 4.84,9.372 5.154,9.705 5.576,9.871 6.107,9.871 6.615,9.871 7.079,9.747 7.5,9.499L7.5,10.692C7.079,10.898 6.529,11 5.85,11 4.965,11 4.268,10.739 3.762,10.216 3.254,9.692 3,8.995 3,8.124 3,7.195 3.285,6.443 3.855,5.866 4.426,5.289 5.166,5 6.076,5 6.639,5 7.114,5.072 7.5,5.215z M2,13L14,13 14,3 2,3z" />
-          <GeometryDrawing Brush="#FF378A33" Geometry="F1M14,13L2,13 2,3 14,3z M1,14L15,14 15,2 1,2z" />
+          <GeometryDrawing Brush="#FF1F801F" Geometry="F1M14,13L2,13 2,3 14,3z M1,14L15,14 15,2 1,2z" />
+        </DrawingGroup.Children>
+      </DrawingGroup>
+    </DrawingBrush.Drawing>
+  </DrawingBrush>
+
+<DrawingBrush x:Key="CppProjIcon">
+    <DrawingBrush.Drawing>
+      <DrawingGroup>
+        <DrawingGroup.Children>
+          <GeometryDrawing Brush="#00FFFFFF" Geometry="F1M16,16L0,16 0,0 16,0z" />
+          <GeometryDrawing Brush="#FFF6F6F6" Geometry="F1M0,15L16,15 16,1 0,1z" />
+          <GeometryDrawing Brush="#FFA43FB1" Geometry="F1M14,13L2,13 2,3 14,3z M1,14L15,14 15,2 1,2z" />
+                    <GeometryDrawing Brush="#FFA43FB1" Geometry="F1M8,6V7H6V9H5V7H3V6H5V4H6V6Z" />
+                    <GeometryDrawing Brush="#FFA43FB1" Geometry="F1M13,9v1H11v2H10V10H8V9h2V7h1V9Z" />
         </DrawingGroup.Children>
       </DrawingGroup>
     </DrawingBrush.Drawing>
@@ -215,6 +229,10 @@
         <Setter TargetName="nameText" Property="Foreground" Value="Red" />
         <Setter TargetName="icon" Property="Fill" Value="{DynamicResource ErrorBrush}" />
       </DataTrigger>
+      <DataTrigger Binding="{Binding Name}" Value="DoubleBuild">
+        <Setter TargetName="nameText" Property="Foreground" Value="Red" />
+        <Setter TargetName="icon" Property="Fill" Value="{DynamicResource ErrorBrush}" />
+      </DataTrigger>
     </HierarchicalDataTemplate.Triggers>
   </HierarchicalDataTemplate>
 
@@ -277,6 +295,9 @@
       <DataTrigger Binding="{Binding ProjectFileExtension}" Value=".fsproj">
         <Setter TargetName="icon" Property="Fill" Value="{StaticResource FSProjIcon}" />
       </DataTrigger>
+      <DataTrigger Binding="{Binding ProjectFileExtension}" Value=".vcxproj">
+        <Setter TargetName="icon" Property="Fill" Value="{StaticResource CppProjIcon}" />
+      </DataTrigger>
     </HierarchicalDataTemplate.Triggers>
   </HierarchicalDataTemplate>
 
@@ -324,6 +345,9 @@
       </DataTrigger>
       <DataTrigger Binding="{Binding ProjectFileExtension}" Value=".fsproj">
         <Setter TargetName="icon" Property="Fill" Value="{StaticResource FSProjIcon}" />
+      </DataTrigger>
+      <DataTrigger Binding="{Binding ProjectFileExtension}" Value=".vcxproj">
+        <Setter TargetName="icon" Property="Fill" Value="{StaticResource CppProjIcon}" />
       </DataTrigger>
     </HierarchicalDataTemplate.Triggers>
   </HierarchicalDataTemplate>
@@ -731,6 +755,30 @@
       </DataTrigger>
       <DataTrigger Binding="{Binding ProjectExtension}" Value=".csproj">
         <Setter TargetName="icon" Property="Fill" Value="{StaticResource CSProjIcon}" />
+        <Setter TargetName="icon" Property="Height" Value="16" />
+        <Setter TargetName="icon" Property="Width" Value="16" />
+        <Setter TargetName="icon" Property="StrokeThickness" Value="0" />
+        <Setter TargetName="icon" Property="Margin" Value="2,2,6,2" />
+        <Setter TargetName="text" Property="Margin" Value="0,2,0,0" />
+      </DataTrigger>
+      <DataTrigger Binding="{Binding ProjectExtension}" Value=".vbproj">
+        <Setter TargetName="icon" Property="Fill" Value="{StaticResource VBProjIcon}" />
+        <Setter TargetName="icon" Property="Height" Value="16" />
+        <Setter TargetName="icon" Property="Width" Value="16" />
+        <Setter TargetName="icon" Property="StrokeThickness" Value="0" />
+        <Setter TargetName="icon" Property="Margin" Value="2,2,6,2" />
+        <Setter TargetName="text" Property="Margin" Value="0,2,0,0" />
+      </DataTrigger>
+      <DataTrigger Binding="{Binding ProjectExtension}" Value=".fsproj">
+        <Setter TargetName="icon" Property="Fill" Value="{StaticResource FSProjIcon}" />
+        <Setter TargetName="icon" Property="Height" Value="16" />
+        <Setter TargetName="icon" Property="Width" Value="16" />
+        <Setter TargetName="icon" Property="StrokeThickness" Value="0" />
+        <Setter TargetName="icon" Property="Margin" Value="2,2,6,2" />
+        <Setter TargetName="text" Property="Margin" Value="0,2,0,0" />
+      </DataTrigger>
+      <DataTrigger Binding="{Binding ProjectExtension}" Value=".vcxproj">
+        <Setter TargetName="icon" Property="Fill" Value="{StaticResource CppProjIcon}" />
         <Setter TargetName="icon" Property="Height" Value="16" />
         <Setter TargetName="icon" Property="Width" Value="16" />
         <Setter TargetName="icon" Property="StrokeThickness" Value="0" />

--- a/src/StructuredLogger/ObjectModel/Message.cs
+++ b/src/StructuredLogger/ObjectModel/Message.cs
@@ -56,6 +56,12 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 return match;
             }
 
+            match = Strings.MessageMetaprojectGenerated.Match(Text);
+            if (match.Success)
+            {
+                return match;
+            }
+
             return null;
         }
 

--- a/src/StructuredLogger/Search/ProxyNode.cs
+++ b/src/StructuredLogger/Search/ProxyNode.cs
@@ -236,20 +236,15 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
         private string GetProjectFileExtension()
         {
-            string result = null;
+            string result = "other";
 
-            if (Original is Project project)
+            if (Original is Project project && !string.IsNullOrEmpty(project.ProjectFileExtension))
             {
                 result = project.ProjectFileExtension;
             }
-            else if (Original is ProjectEvaluation evaluation)
+            else if (Original is ProjectEvaluation evaluation && !string.IsNullOrEmpty(evaluation.ProjectFileExtension))
             {
                 result = evaluation.ProjectFileExtension;
-            }
-
-            if (result != null && result != ".sln" && result != ".csproj")
-            {
-                result = "other";
             }
 
             return result;

--- a/src/StructuredLogger/Strings/Strings.cs
+++ b/src/StructuredLogger/Strings/Strings.cs
@@ -153,6 +153,11 @@ namespace Microsoft.Build.Logging.StructuredLogger
             const string messageIncludeResponseFileString = @$"^Included response file: (?<File>((.:)?[^:\n\r]*?))$";
             MessageIncludedResponseFile = new Regex(messageIncludeResponseFileString, RegexOptions.Compiled | RegexOptions.Singleline);
 
+            MetaprojectGenerated = GetString("MetaprojectGenerated");
+            string messageMetaprojectGeneratedString = MetaprojectGenerated.Replace(@"{0}", @"(?<File>((.:)?[^:\n\r]*?))");
+
+            MessageMetaprojectGenerated = new Regex(messageMetaprojectGeneratedString, RegexOptions.Compiled | RegexOptions.Singleline);
+
             string taskFoundFromFactory = GetString("TaskFoundFromFactory")
                 .Replace(@"""{0}""", @"\""(?<task>.+)\""")
                 .Replace(@"""{1}""", @"\""(?<assembly>.+)\""");
@@ -251,6 +256,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
         public static Regex ProjectImportSkippedNoMatchesRegex { get; set; }
         public static Regex PropertyReassignmentRegex { get; set; }
         public static Regex MessageIncludedResponseFile { get; set; }
+        public static Regex MessageMetaprojectGenerated { get; set; }
         public static Regex UnifiedPrimaryReferencePrefix { get; set; }
         public static Regex PrimaryReferencePrefix { get; set; }
         public static Regex DependencyPrefix { get; set; }
@@ -301,6 +307,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
         public static string ProjectImportSkippedInvalidFile { get; set; }
         public static string ProjectImportSkippedEmptyFile { get; set; }
         public static string TaskSkippedFalseCondition { get; set; }
+        public static string MetaprojectGenerated { get; set; }
 
         public static Match UsingTask(string message)
         {

--- a/src/StructuredLogger/Strings/Strings.json
+++ b/src/StructuredLogger/Strings/Strings.json
@@ -1,5 +1,6 @@
 {
   "en-US": {
+    "MetaprojectGenerated": "Metaproject \"{0}\" generated.",
     "OutputItemParameterMessagePrefix": "Output Item(s): ",
     "General.ProjectUndefineProperties": "Removing Properties for project \"{0}\":",
     "ProjectImportSkippedEmptyFile": "Project \"{0}\" was not imported by \"{1}\" at ({2},{3}), due to the file being empty.",
@@ -52,6 +53,7 @@
     "Copy.FileComment": "Copying file from \"{0}\" to \"{1}\"."
   },
   "de-DE": {
+    "MetaprojectGenerated": "Das Metaprojekt \"{0}\" wurde generiert.",
     "OutputItemParameterMessagePrefix": "Ausgegebene Elemente: ",
     "General.ProjectUndefineProperties": "Eigenschaften für Projekt \"{0}\" werden entfernt:",
     "ProjectImportSkippedEmptyFile": "Das Projekt \"{0}\" wurde von \"{1}\" nicht in ({2},{3}) importiert, da die Datei leer war.",
@@ -104,6 +106,7 @@
     "Copy.FileComment": "Die Datei wird von \"{0}\" in \"{1}\" kopiert."
   },
   "it-IT": {
+    "MetaprojectGenerated": "Il metaprogetto \"{0}\" è stato generato.",
     "OutputItemParameterMessagePrefix": "Elementi di output: ",
     "General.ProjectUndefineProperties": "Rimozione delle proprietà per il progetto \"{0}\":",
     "ProjectImportSkippedEmptyFile": "Il progetto \"{0}\" non è stato importato da \"{1}\" a ({2},{3}) perché il file è vuoto.",
@@ -156,6 +159,7 @@
     "Copy.FileComment": "Copia del file da \"{0}\" a \"{1}\"."
   },
   "es-ES": {
+    "MetaprojectGenerated": "Se generó el metaproyecto \"{0}\".",
     "OutputItemParameterMessagePrefix": "Elementos de salida: ",
     "General.ProjectUndefineProperties": "Quitando propiedades del proyecto \"{0}\":",
     "ProjectImportSkippedEmptyFile": "\"{1}\" no importó el proyecto \"{0}\" en ({2},{3}) porque el archivo estaba vacío.",
@@ -208,6 +212,7 @@
     "Copy.FileComment": "Copiando el archivo de \"{0}\" en \"{1}\"."
   },
   "fr-FR": {
+    "MetaprojectGenerated": "Le métaprojet \"{0}\" a été généré.",
     "OutputItemParameterMessagePrefix": "Élément(s) en sortie : ",
     "General.ProjectUndefineProperties": "Suppression des propriétés du projet \"{0}\" :",
     "ProjectImportSkippedEmptyFile": "Le projet \"{0}\" n’a pas été importé par \"{1}\" sur ({2},{3}), car le fichier est vide.",
@@ -260,6 +265,7 @@
     "Copy.FileComment": "Copie du fichier de \"{0}\" vers \"{1}\"."
   },
   "cs-CZ": {
+    "MetaprojectGenerated": "Metaprojekt {0} byl vygenerován.",
     "OutputItemParameterMessagePrefix": "Výstupní položky: ",
     "General.ProjectUndefineProperties": "Odstraňování vlastností projektu {0}:",
     "ProjectImportSkippedEmptyFile": "{1} neimportoval projekt {0} v ({2},{3}), protože soubor je prázdný.",
@@ -312,6 +318,7 @@
     "Copy.FileComment": "Probíhá kopírování souboru z umístění {0} do umístění {1}."
   },
   "ja-JP": {
+    "MetaprojectGenerated": "メタプロジェクト \"{0}\" が生成されました。",
     "OutputItemParameterMessagePrefix": "出力項目: ",
     "General.ProjectUndefineProperties": "プロジェクト \"{0}\" のプロパティの削除:",
     "ProjectImportSkippedEmptyFile": "ファイルが空であるため、プロジェクト \"{0}\" は \"{1}\" によって ({2},{3}) でインポートされませんでした。",
@@ -364,6 +371,7 @@
     "Copy.FileComment": "\"{0}\" から \"{1}\" へファイルをコピーしています。"
   },
   "ko-KR": {
+    "MetaprojectGenerated": "메타프로젝트 \"{0}\"이(가) 생성되었습니다.",
     "OutputItemParameterMessagePrefix": "출력 항목: ",
     "General.ProjectUndefineProperties": "\"{0}\" 프로젝트에 대한 속성 제거:",
     "ProjectImportSkippedEmptyFile": "파일이 비어 있어 ({2},{3})의 \"{1}\"이(가) \"{0}\" 프로젝트를 가져오지 않았습니다.",
@@ -416,6 +424,7 @@
     "Copy.FileComment": "\"{0}\"에서 \"{1}\"(으)로 파일을 복사하고 있습니다."
   },
   "ru-RU": {
+    "MetaprojectGenerated": "Создан метапроект \"{0}\".",
     "OutputItemParameterMessagePrefix": "Выходных элементов: ",
     "General.ProjectUndefineProperties": "Удаление свойств для проекта \"{0}\":",
     "ProjectImportSkippedEmptyFile": "Проект \"{0}\" не был импортирован \"{1}\" в ({2},{3}), так как файл пуст.",
@@ -468,6 +477,7 @@
     "Copy.FileComment": "Копирование файла из \"{0}\" в \"{1}\"."
   },
   "pl-PL": {
+    "MetaprojectGenerated": "Wygenerowano metaprojekt „{0}”.",
     "OutputItemParameterMessagePrefix": "Elementy wyjściowe: ",
     "General.ProjectUndefineProperties": "Usuwanie właściwości projektu {0}:",
     "ProjectImportSkippedEmptyFile": "Projekt „{0}” nie został zaimportowany przez projekt „{1}” o ({2},{3}), ponieważ plik był pusty.",
@@ -520,6 +530,7 @@
     "Copy.FileComment": "Kopiowanie pliku z „{0}” do „{1}”."
   },
   "pt-BR": {
+    "MetaprojectGenerated": "Metaprojeto \"{0}\" gerado.",
     "OutputItemParameterMessagePrefix": "Itens de Saída(s): ",
     "General.ProjectUndefineProperties": "Removendo Propriedades do projeto \"{0}\":",
     "ProjectImportSkippedEmptyFile": "O projeto \"{0}\" não foi importado por \"{1}\" em ({2},{3}), devido ao arquivo estar vazio.",
@@ -572,6 +583,7 @@
     "Copy.FileComment": "Copiando o arquivo de \"{0}\" para \"{1}\"."
   },
   "tr-TR": {
+    "MetaprojectGenerated": "\"{0}\" meta projesi oluşturuldu.",
     "OutputItemParameterMessagePrefix": "Çıkış Öğeleri: ",
     "General.ProjectUndefineProperties": "\"{0}\" projesinin Özellikleri kaldırılıyor:",
     "ProjectImportSkippedEmptyFile": "\"{0}\" adlı proje, dosyanın boş olması nedeniyle ({2},{3}) konumundaki \"{1}\" tarafından içeri aktarılmadı.",
@@ -624,6 +636,7 @@
     "Copy.FileComment": "Dosya \"{0}\" konumundan \"{1}\" konumuna kopyalanıyor."
   },
   "zh-Hans": {
+    "MetaprojectGenerated": "已生成元项目“{0}”。",
     "OutputItemParameterMessagePrefix": "输出项: ",
     "General.ProjectUndefineProperties": "移除项目“{0}”的属性:",
     "ProjectImportSkippedEmptyFile": "由于文件为空，项目“{0}”不由 ({2}、{3}) 处的“{1}”导入。",


### PR DESCRIPTION
Add double click on Meta Project message that will open the metaproject file.
Fix missing vb and fs project icons from search results.
Add Cpp Project Icon.
![image](https://user-images.githubusercontent.com/19828377/218631794-5f10fb1a-b42a-4af2-a88e-3417e7fa1428.png)