### PR TITLE
Improve Tracing load times

### DIFF
--- a/src/StructuredLogViewer.Core/Timeline/Lane.cs
+++ b/src/StructuredLogViewer.Core/Timeline/Lane.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 
 namespace StructuredLogViewer
 {
     public class Lane
     {
-        public List<Block> Blocks { get; set; } = new List<Block>();
+        public ConcurrentBag<Block> Blocks { get; set; } = new();
 
         public void Add(Block block)
         {

--- a/src/StructuredLogViewer.Core/Timeline/Timeline.cs
+++ b/src/StructuredLogViewer.Core/Timeline/Timeline.cs
@@ -1,13 +1,15 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Microsoft.Build.Logging.StructuredLogger;
 
 namespace StructuredLogViewer
 {
     public class Timeline
     {
-        public Dictionary<int, Lane> Lanes { get; set; } = new();
+        public ConcurrentDictionary<int, Lane> Lanes { get; set; } = new();
 
         public Timeline(Build build, bool analyzeCpp)
         {
@@ -16,7 +18,7 @@ namespace StructuredLogViewer
 
         private void Populate(Build build, bool analyzeCpp = false)
         {
-            build.VisitAllChildren<NamedNode>(node =>
+            build.ParallelVisitAllChildren<TimedNode>(node =>
             {
                 if (analyzeCpp && node is CppAnalyzer.CppAnalyzerNode cppAnalyzerNode)
                 {
@@ -38,6 +40,8 @@ namespace StructuredLogViewer
                             lane.Add(block);
                         }
                     }
+
+                    return;
                 }
 
                 if (node is not TimedNode timedNode)

--- a/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
@@ -406,7 +406,10 @@ Right-clicking a project node may show the 'Preprocess' option if the version of
         {
             if (this.tracing.Timeline == null)
             {
+                var start = DateTime.Now;
                 var timeline = new Timeline(Build, analyzeCpp: true);
+                var timelineTime = DateTime.Now - start;
+                this.tracing.TimelineTime = timelineTime;
                 this.tracing.BuildControl = this;
                 this.tracing.SetTimeline(timeline, Build.StartTime.Ticks, Build.EndTime.Ticks);
                 this.tracingWatermark.Visibility = Visibility.Hidden;

--- a/src/StructuredLogViewer/Controls/TimelineControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/TimelineControl.xaml.cs
@@ -144,7 +144,7 @@ namespace StructuredLogViewer.Controls
 
         private Panel CreatePanelForLane(Lane lane, double start)
         {
-            var blocks = lane.Blocks;
+            var blocks = lane.Blocks.ToList();
             if (blocks.Count == 0)
             {
                 return null;

--- a/src/StructuredLogViewer/Controls/TracingControl.xaml
+++ b/src/StructuredLogViewer/Controls/TracingControl.xaml
@@ -18,7 +18,7 @@
                     <MenuItem Header="Show P2P on Selection" IsCheckable="true" IsChecked="{Binding Path=ShowProjectReferenceSelection , Mode=TwoWay}" StaysOpenOnClick="true"/>
                     <MenuItem Header="{Binding Path=ShowNodesText, Mode=OneWay}" IsCheckable="true" IsChecked="{Binding Path=ShowNodes , Mode=TwoWay}" StaysOpenOnClick="true"/>
                     <MenuItem Header="Group By Nodes" IsCheckable="true" IsChecked="{Binding Path=GroupByNodes , Mode=TwoWay}" StaysOpenOnClick="true"/>
-                    <!--<MenuItem Header="{Binding Path=LoadStatistics, Mode=OneWay}" IsCheckable="true" IsEnabled="false" />-->
+                    <MenuItem Header="{Binding Path=LoadStatistics, Mode=OneWay}" IsCheckable="true" IsEnabled="false" />
                 </MenuItem>
             </ContextMenu>
         </Grid.ContextMenu>

--- a/src/StructuredLogger/Analyzers/CppAnalyzer.cs
+++ b/src/StructuredLogger/Analyzers/CppAnalyzer.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
             public BaseNode Node;
         }
 
-        public class CppAnalyzerNode : NamedNode
+        public class CppAnalyzerNode : TimedNode
         {
             CppAnalyzer cppAnalyzer;
 

--- a/src/StructuredLogger/ObjectModel/TreeNode.cs
+++ b/src/StructuredLogger/ObjectModel/TreeNode.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Build.Logging.StructuredLogger
 {
@@ -245,7 +246,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
             return default;
         }
 
-        public virtual T FindLastInSubtreeIncludingSelf<T>(Predicate<T> predicate = null)  where T : BaseNode
+        public virtual T FindLastInSubtreeIncludingSelf<T>(Predicate<T> predicate = null) where T : BaseNode
         {
             var child = FindLastDescendant<T>(predicate);
             if (child != null)
@@ -481,6 +482,64 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 });
 
             return foundChildren;
+        }
+
+
+        public void ParallelVisitAllChildren<T>(
+            Action<T> processor,
+            CancellationToken cancellationToken = default,
+            bool takeChildrenSnapshot = false) where T : BaseNode
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            if (this is T typedThis)
+            {
+                processor(typedThis);
+            }
+
+            if (HasChildren)
+            {
+                var list = Children;
+                if (takeChildrenSnapshot)
+                {
+                    list = list.ToArray();
+                }
+
+                void ProcessChild(BaseNode child)
+                {
+                    if (child is TreeNode node)
+                    {
+                        node.ParallelVisitAllChildren(processor, cancellationToken, takeChildrenSnapshot);
+                    }
+                    else if (child is T typedChild)
+                    {
+                        processor(typedChild);
+                    }
+                }
+
+                // A short list is faster on a single thread.
+                // Need more testing to determine the cut off.
+                if (list.Count < Environment.ProcessorCount * 3)
+                {
+                    for (int i = 0; i < list.Count; i++)
+                    {
+                        if (cancellationToken.IsCancellationRequested)
+                        {
+                            return;
+                        }
+
+                        ProcessChild(list[i]);
+                    }
+                }
+                else
+                {
+                    ParallelOptions po = new ParallelOptions() { CancellationToken = cancellationToken };
+                    Parallel.ForEach(list, po, child => ProcessChild(child));
+                }
+            }
         }
 
         public void VisitAllChildren<T>(

--- a/src/StructuredLogger/Search/NodeQueryMatcher.cs
+++ b/src/StructuredLogger/Search/NodeQueryMatcher.cs
@@ -149,19 +149,19 @@ namespace StructuredLogViewer
             {
                 var word = Words[i].Word;
 
-                if (word == "$time" || word == "$duration")
+                if (string.Equals(word, "$time", StringComparison.OrdinalIgnoreCase) || string.Equals(word, "$duration", StringComparison.OrdinalIgnoreCase))
                 {
                     Words.RemoveAt(i);
                     IncludeDuration = true;
                     continue;
                 }
-                else if (word == "$start" || word == "$starttime")
+                else if (string.Equals(word, "$start", StringComparison.OrdinalIgnoreCase) || string.Equals(word, "$starttime", StringComparison.OrdinalIgnoreCase))
                 {
                     Words.RemoveAt(i);
                     IncludeStart = true;
                     continue;
                 }
-                else if (word == "$end" || word == "$endtime")
+                else if (string.Equals(word, "$end", StringComparison.OrdinalIgnoreCase) || string.Equals(word, "$endtime", StringComparison.OrdinalIgnoreCase))
                 {
                     Words.RemoveAt(i);
                     IncludeEnd = true;

--- a/src/StructuredLogger/Search/ProxyNode.cs
+++ b/src/StructuredLogger/Search/ProxyNode.cs
@@ -182,9 +182,9 @@ namespace Microsoft.Build.Logging.StructuredLogger
             {
                 var result = "";
 
-                if (!string.IsNullOrEmpty(project.TargetFramework))
+                if (!string.IsNullOrEmpty(project.AdornmentString))
                 {
-                    result += " " + project.TargetFramework;
+                    result += " " + project.AdornmentString;
                 }
 
                 if (!string.IsNullOrEmpty(project.TargetsDisplayText))

--- a/src/StructuredLogger/Search/ProxyNode.cs
+++ b/src/StructuredLogger/Search/ProxyNode.cs
@@ -236,15 +236,15 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
         private string GetProjectFileExtension()
         {
-            string result = "other";
+            string result = null;
 
-            if (Original is Project project && !string.IsNullOrEmpty(project.ProjectFileExtension))
+            if (Original is Project project)
             {
-                result = project.ProjectFileExtension;
+                result = string.IsNullOrEmpty(project.ProjectFileExtension) ? "other" : project.ProjectFileExtension;
             }
-            else if (Original is ProjectEvaluation evaluation && !string.IsNullOrEmpty(evaluation.ProjectFileExtension))
+            else if (Original is ProjectEvaluation evaluation)
             {
-                result = evaluation.ProjectFileExtension;
+                result = string.IsNullOrEmpty(evaluation.ProjectFileExtension) ? "other" : evaluation.ProjectFileExtension;
             }
 
             return result;


### PR DESCRIPTION
## Switch to OnRender(DrawContext) for Canvas
- Speed up rendering up to 10x faster.
- Simplify TextBlock to reduce creating UI elements.
- Have to redo on_clicks math since TextBlock aren't part of the Canvas Hierarchy.
- Lost mouse over Tooltips ( 😞 ).  Workaround is to double click.
- Load full graph instead of culled subset.  The load times are now fast enough!

## Parallelize Timeline Population (up to 2-3x faster)
- VisitAllChildren itself takes a long time.  There are just a lot of items to go though.
- Move CppAnalysis into one VisitAllChildren, one less loop.

## Misc
- Use case insensitive when parsing $time, $starttime, $endtime
- Search results would show adornment instead of only Framework.
- Fix an issue when mouse zoom would over zoom.