### PR TITLE
Add newer version info in file version error

### DIFF
--- a/src/StructuredLogViewer/MainWindow.xaml.cs
+++ b/src/StructuredLogViewer/MainWindow.xaml.cs
@@ -211,6 +211,7 @@ namespace StructuredLogViewer
                 {
                     var versionText = result.Version.ToString();
                     message = "After restarting the app you will be on version " + versionText;
+                    BinaryLogger.IsNewerVersionAvailable = true;
                     FileAssociations.EnsureAssociationsSet(versionText);
                 }
                 else

--- a/src/StructuredLogger/BinaryLogger/BinaryLogger.cs
+++ b/src/StructuredLogger/BinaryLogger/BinaryLogger.cs
@@ -61,6 +61,8 @@ namespace Microsoft.Build.Logging.StructuredLogger
         //   - AssemblyLoadBuildEventArgs
         internal const int FileFormatVersion = 16;
 
+        public static bool IsNewerVersionAvailable { get; set; }
+
         private Stream stream;
         private BinaryWriter binaryWriter;
         private BuildEventArgsWriter eventArgsWriter;


### PR DESCRIPTION
## Context

https://github.com/dotnet/msbuild/pull/8316#issuecomment-1446279894

When opening log with new version, first attempt fails and app needs to be restarted to run the updated bits. This situation might not be clear to unexperienced user from the error message.

## Change

Propagating info about available update into the logic layer, so that this can be appended to version not supported error.
For simplicity the propagation of info is done via a bit ugly way. Alternatively we can pass some optional version info holder into `Serialization.Read` to keep the current encapsulation - I'm open to suggestions here.

## Testing

Manual tests via manipulating latest known file format and update check:

```
System.NotSupportedException: Unsupported log file format. Latest supported version is 16, the log file has version 15. Update available - restart this instance to automatically use newer version.
   at Microsoft.Build.Logging.StructuredLogger.BinLogReader.EnsureFileFormatVersionKnown(Int32 fileFormatVersion) in C:\src\binlog-viewer\src\StructuredLogger\BinaryLogger\BinLogReader.cs:line 153
   at Microsoft.Build.Logging.StructuredLogger.BinLogReader.Replay(Stream stream, Progress progress) in C:\src\binlog-viewer\src\StructuredLogger\BinaryLogger\BinLogReader.cs:line 69
   at Microsoft.Build.Logging.StructuredLogger.BinaryLog.ReadBuild(Stream stream, Progress progress, Byte[] projectImportsArchive) in C:\src\binlog-viewer\src\StructuredLogger\BinaryLog.cs:line 104
   at Microsoft.Build.Logging.StructuredLogger.BinaryLog.ReadBuild(String filePath, Progress progress) in C:\src\binlog-viewer\src\StructuredLogger\BinaryLog.cs:line 41
   at Microsoft.Build.Logging.StructuredLogger.Serialization.Read(String filePath, Progress progress) in C:\src\binlog-viewer\src\StructuredLogger\Serialization\Serialization.cs:line 71
   at StructuredLogViewer.MainWindow.<>c__DisplayClass29_0.<OpenLogFile>b__3() in C:\src\binlog-viewer\src\StructuredLogViewer\MainWindow.xaml.cs:line 413
```

<img width="550" alt="image" src="https://user-images.githubusercontent.com/3809076/221854107-2d3ff755-65ee-480b-9c30-e642915c77e6.png">

