### PR TITLE
Add ToolTips and ClickDrag to TraceView

### DIFF
--- a/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
@@ -982,8 +982,18 @@ Recent:
             var node = breadCrumb.SelectedItem as TreeNode;
             if (node != null)
             {
-                SelectItem(node);
-                treeView.Focus();
+                if (this.centralTabControl.SelectedIndex == 0)
+                {
+                    SelectItem(node);
+                    treeView.Focus();
+                }
+                else if (this.centralTabControl.SelectedIndex == 2)
+                {
+                    if (node is TimedNode tnode) {
+                        tracing.GoToTimedNode(tnode);
+                    }
+                }
+
                 e.Handled = true;
             }
 

--- a/src/StructuredLogViewer/Controls/TimelineControl.xaml
+++ b/src/StructuredLogViewer/Controls/TimelineControl.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="StructuredLogViewer.Controls.TimelineControl"
+<UserControl x:Class="StructuredLogViewer.Controls.TimelineControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -14,7 +14,6 @@
       </Grid>
     </ScrollViewer>
     <StackPanel Margin="0,0,30,30"
-                Background="White"
                 Orientation="Horizontal"
                 ToolTip="Ctrl+MouseWheel to Zoom"
                 HorizontalAlignment="Right"

--- a/src/StructuredLogViewer/Controls/TracingControl.xaml
+++ b/src/StructuredLogViewer/Controls/TracingControl.xaml
@@ -35,7 +35,6 @@
             </Grid>
         </ScrollViewer>
         <StackPanel Margin="0,0,30,30"
-                Background="White"
                 Orientation="Horizontal"
                 ToolTip="Ctrl+MouseWheel to Zoom"
                 HorizontalAlignment="Right"

--- a/src/StructuredLogViewer/Controls/TracingControl.xaml
+++ b/src/StructuredLogViewer/Controls/TracingControl.xaml
@@ -27,7 +27,11 @@
                 VerticalScrollBarVisibility="Auto" Loaded="ScrollViewer_Loaded" Unloaded="ScrollViewer_Unloaded" ScrollChanged="ScrollViewer_ScrollChanged">
             <Grid>
                 <Grid x:Name="overlayGrid" Panel.ZIndex="100" />
-                <Grid x:Name="grid" />
+                <!-- Note: This grid needs to be transparent so that Mouse Move and Down will register on the empty background. -->
+                <Grid x:Name="grid"
+                      Background="Transparent"
+                      MouseLeftButtonDown="Grid_MouseLeftButtonDown"
+                      MouseMove="Grid_MouseMove" />
             </Grid>
         </ScrollViewer>
         <StackPanel Margin="0,0,30,30"

--- a/src/StructuredLogViewer/Controls/TracingControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/TracingControl.xaml.cs
@@ -1124,8 +1124,17 @@ namespace StructuredLogViewer.Controls
             scrollViewer.ScrollToVerticalOffset(verticalOffset);
         }
 
+        private bool IsMouseMoving;
+        private Point initial;
+
         private void Canvas_MouseUp(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
+            if (IsMouseMoving)
+            {
+                IsMouseMoving = false;
+                return;
+            }
+
             if (sender is FastCanvas canvas)
             {
                 var mousePos = e.GetPosition(canvas);
@@ -1141,8 +1150,34 @@ namespace StructuredLogViewer.Controls
                         lastClickTimestamp = Timestamp;
                         var activePoint = canvas.TranslatePoint(point, overlayCanvas);
                         HighlightTextBlock(textBlock, activePoint);
+                        BuildControl.UpdateBreadcrumb(block.Node);
                     }
                 }
+            }
+        }
+
+        private void Grid_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            initial = Mouse.GetPosition(this);
+        }
+
+        private void Grid_MouseMove(object sender, MouseEventArgs e)
+        {
+            // Handle the case where mouse up isn't sent when released outside of client space.
+            if (e.LeftButton == MouseButtonState.Released)
+            {
+                IsMouseMoving = false;
+                return;
+            }
+
+            var newPosition = e.GetPosition(this);
+            var vect = Point.Subtract(initial, newPosition);
+            if (IsMouseMoving || vect.Length > 5)
+            {
+                IsMouseMoving = true;
+                scrollViewer.ScrollToHorizontalOffset(scrollViewer.HorizontalOffset + vect.X);
+                scrollViewer.ScrollToVerticalOffset(scrollViewer.VerticalOffset + vect.Y);
+                initial = newPosition;
             }
         }
 


### PR DESCRIPTION
- Add back Tooltips when hovering over items.
- Add update Breadcrumbs to reflect the selections, selecting the breadcrumb will go to the selected node of the active viewer.  Previously it would go to the log view.
- Add click and drag on the graph to scroll. (similar to online maps)
- Misc: remove the white background in ZoomSlider as it doesn't match dark theme.