### PR TITLE
Small fixes

### DIFF
--- a/src/StructuredLogViewer/Controls/TracingControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/TracingControl.xaml.cs
@@ -742,13 +742,14 @@ namespace StructuredLogViewer.Controls
                 }
             }
 
+            // Clear highlight when selection failed.
             if (textblock == null && activeTextBlock != null)
             {
                 if (highlight.Parent is Panel parent)
                 {
                     parent.Children.Remove(highlight);
                 }
-
+                activeTextBlock = null;
                 scrollViewer.ScrollToVerticalOffset(0);
                 scrollViewer.ScrollToHorizontalOffset(0);
             }
@@ -1116,8 +1117,8 @@ namespace StructuredLogViewer.Controls
         private void ScrollToElement(TextField hit)
         {
             Point p = GetTextBlockToOverlayGrid(hit);
-            horizontalOffset = p.X > 20 ? p.X - 20 : p.X;
-            verticalOffset = p.Y > 20 ? p.Y - 20 : p.Y;
+            horizontalOffset = (p.X > 20 ? p.X - 20 : p.X) * scaleTransform.ScaleX;
+            verticalOffset = (p.Y > 20 ? p.Y - 20 : p.Y) * scaleTransform.ScaleY;
 
             horizontalOffset = Math.Max(horizontalOffset, 0);
             verticalOffset = Math.Max(verticalOffset, 0);

--- a/src/StructuredLogger/Analyzers/CppAnalyzer.cs
+++ b/src/StructuredLogger/Analyzers/CppAnalyzer.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
         // time(C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Tools\MSVC\14.24.28218\bin\Hostx86\x86\c1xx.dll)=0.83512s < 985096605139 - 985104956295 > BB [C:\Users\yuehuang\AppData\Local\Temp\123\main36.cpp]
         // time(C:\Program Files(x86)\Microsoft Visual Studio\2019\Preview\VC\Tools\MSVC\14.24.28218\bin\Hostx86\x86\c2.dll)=0.01935s < 985104875296 - 985105068765 > BB[C: \Users\yuehuang\AppData\Local\Temp\123\main47.cpp]
-        const string regexBTPlus = @"^time\(.*(c1xx\.dll|c2\.dll)\)=(?'msTime'([0-9]*\.[0-9]+|[0-9]+))s \< (?'startTime'[\d]*) - (?'endTime'[\d]*) \>\s*(BB)?\s*\[(?'filename'[^\]]*)\]$";
+        const string regexBTPlus = @"^time\(.*(c1\.dll|c1xx\.dll|c2\.dll)\)=(?'msTime'([0-9]*\.[0-9]+|[0-9]+))s \< (?'startTime'[\d]*) - (?'endTime'[\d]*) \>\s*(BB)?\s*\[(?'filename'[^\]]*)\]$";
         readonly Regex BTPlus = new Regex(regexBTPlus, RegexOptions.Multiline);
 
         // Lib: Final Total time = 0.00804s < 5881693617253 - 5881693697673 > PB: 143409152 [D:\test\ConsoleApplication2\x64\Debug\ConsoleApplication2.lib] 
@@ -129,7 +129,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
             // For this view, de-batch them into individual task units.
             if ((cppTask.Name == MultiToolTaskName || cppTask.Name == CLTaskName) && cppTask.HasChildren)
             {
-                bool usingBTTime = globalBtplus;
+                bool usingBTTime = (cppTask.Name == CLTaskName) && globalBtplus;
                 Dictionary<string, CppTimedNode> blocks = new();
                 DateTime taskStartTime = cppTask.StartTime;
                 DateTime taskCleanUpTime = cppTask.EndTime;
@@ -250,7 +250,8 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
                     if (!usingBTTime && child is Property property)
                     {
-                        if (property.Name == Strings.CommandLineArguments && property.Value.Contains("/Bt+"))
+                        if (property.Name == Strings.CommandLineArguments
+                            && (property.Value.Contains("/Bt+") || (property.Value.IndexOf("cl.exe", StringComparison.OrdinalIgnoreCase) >= 0 && globalBtplus)))
                         {
                             usingBTTime = true;
                         }


### PR DESCRIPTION
- Fix GoToTracing to work when zoomed.  
- Fix BT+ to work with .c files.
- Fix BT+ to only apply for cl.  Other tools like midl and fxc should not be affected by Bt+.