### PR TITLE
Add "Buffer" progress bar

### DIFF
--- a/src/StructuredLogViewer.Core/BuildProgress.cs
+++ b/src/StructuredLogViewer.Core/BuildProgress.cs
@@ -8,6 +8,8 @@
 
         public Progress Progress { get; } = new Progress();
 
+        public Progress BufferUsage { get; } = new Progress();
+
         private string progressText;
         public string ProgressText
         {
@@ -29,6 +31,13 @@
             set => SetField(ref this.value, value);
         }
 
+        private double bufferValue;
+        public double BufferValue
+        {
+            get => bufferValue;
+            set => SetField(ref this.bufferValue, value);
+        }
+
         private string msbuildCommandLine;
         public string MSBuildCommandLine
         {
@@ -43,5 +52,7 @@
         }
 
         public bool ShowCommandLine => !string.IsNullOrEmpty(MSBuildCommandLine);
+
+        public bool ShowBufferUsage { get; set; } = false;
     }
 }

--- a/src/StructuredLogViewer.Core/SettingsService.cs
+++ b/src/StructuredLogViewer.Core/SettingsService.cs
@@ -89,9 +89,19 @@ namespace StructuredLogViewer
             RemoveRecentItem(filePath, recentLogsFilePath);
         }
 
+        public static void RemoveAllRecentLogFile()
+        {
+            SaveText(recentLogsFilePath, Enumerable.Empty<string>());
+        }
+
         public static void RemoveRecentProject(string filePath)
         {
             RemoveRecentItem(filePath, recentProjectsFilePath);
+        }
+
+        public static void RemoveAllRecentProject()
+        {
+            SaveText(recentProjectsFilePath, Enumerable.Empty<string>());
         }
 
         private static string GetRecentSearchFilePath(string category = "")

--- a/src/StructuredLogViewer/MainWindow.xaml.cs
+++ b/src/StructuredLogViewer/MainWindow.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Windows;
 using System.Windows.Controls;
@@ -302,9 +303,11 @@ namespace StructuredLogViewer
         private void UpdateRecentItemsMenu(WelcomeScreen welcomeScreen = null)
         {
             welcomeScreen = welcomeScreen ?? new WelcomeScreen();
+
+            RecentItemsSeparator.Visibility = Visibility.Collapsed;
+            RecentProjectsMenu.Items.Clear();
             if (welcomeScreen.ShowRecentProjects)
             {
-                RecentProjectsMenu.Items.Clear();
                 RecentProjectsMenu.Visibility = Visibility.Visible;
                 RecentItemsSeparator.Visibility = Visibility.Visible;
                 foreach (var recentProjectFile in welcomeScreen.RecentProjects)
@@ -313,11 +316,19 @@ namespace StructuredLogViewer
                     menuItem.Click += RecentProjectClick;
                     RecentProjectsMenu.Items.Add(menuItem);
                 }
+
+                var clearHistory = new MenuItem { Header = "Clear Recent Projects" };
+                clearHistory.Click += ClearAllRecentProjectFileClick;
+                RecentProjectsMenu.Items.Add(clearHistory);
+            }
+            else
+            {
+                RecentProjectsMenu.Visibility = Visibility.Collapsed;
             }
 
+            RecentLogsMenu.Items.Clear();
             if (welcomeScreen.ShowRecentLogs)
             {
-                RecentLogsMenu.Items.Clear();
                 RecentLogsMenu.Visibility = Visibility.Visible;
                 RecentItemsSeparator.Visibility = Visibility.Visible;
                 foreach (var recentLog in welcomeScreen.RecentLogs)
@@ -326,6 +337,14 @@ namespace StructuredLogViewer
                     menuItem.Click += RecentLogFileClick;
                     RecentLogsMenu.Items.Add(menuItem);
                 }
+
+                var clearHistory = new MenuItem { Header = "Clear Recent Logs" };
+                clearHistory.Click += ClearAllRecentLogFileClick;
+                RecentLogsMenu.Items.Add(clearHistory);
+            }
+            else
+            {
+                RecentLogsMenu.Visibility = Visibility.Collapsed;
             }
         }
 
@@ -376,6 +395,54 @@ namespace StructuredLogViewer
         {
             var menuItem = sender as MenuItem;
             OpenLogFile(Convert.ToString(menuItem.Header));
+        }
+
+        private void ClearProjectFileClick(object sender, RoutedEventArgs e)
+        {
+            SettingsService.RemoveAllRecentProject();
+
+            // Re-draw the welcome screen if it is active
+            // or only update the menu
+            if (this.mainContent.Content is WelcomeScreen)
+            {
+                DisplayWelcomeScreen();
+            }
+            else
+            {
+                UpdateRecentItemsMenu();
+            }
+        }
+
+        private void ClearAllRecentProjectFileClick(object sender, RoutedEventArgs e)
+        {
+            SettingsService.RemoveAllRecentProject();
+
+            // Re-draw the welcome screen if it is active
+            // or only update the menu
+            if (this.mainContent.Content is WelcomeScreen)
+            {
+                DisplayWelcomeScreen();
+            }
+            else
+            {
+                UpdateRecentItemsMenu();
+            }
+        }
+
+        private void ClearAllRecentLogFileClick(object sender, RoutedEventArgs e)
+        {
+            SettingsService.RemoveAllRecentLogFile();
+
+            // Re-draw the welcome screen if it is active
+            // or only update the menu
+            if (this.mainContent.Content is WelcomeScreen)
+            {
+                DisplayWelcomeScreen();
+            }
+            else
+            {
+                UpdateRecentItemsMenu();
+            }
         }
 
         private async void OpenLogFile(string filePath)

--- a/src/StructuredLogViewer/MainWindow.xaml.cs
+++ b/src/StructuredLogViewer/MainWindow.xaml.cs
@@ -466,6 +466,14 @@ namespace StructuredLogViewer
                     progress.Value = update.Ratio;
                 }, DispatcherPriority.Background);
             };
+            progress.BufferUsage.Updated += update =>
+            {
+                Dispatcher.InvokeAsync(() =>
+                {
+                    progress.BufferValue = update.Ratio;
+                }, DispatcherPriority.Background);
+            };
+            progress.ShowBufferUsage = true;
             progress.ProgressText = "Opening " + filePath + "...";
             SetContent(progress);
 
@@ -477,7 +485,7 @@ namespace StructuredLogViewer
             {
                 try
                 {
-                    return Serialization.Read(filePath, progress.Progress);
+                    return Serialization.Read(filePath, progress.Progress, progress.BufferUsage);
                 }
                 catch (Exception ex)
                 {

--- a/src/StructuredLogViewer/themes/Generic.xaml
+++ b/src/StructuredLogViewer/themes/Generic.xaml
@@ -1017,6 +1017,8 @@
         <RowDefinition Height="Auto" />
         <RowDefinition Height="Auto" />
         <RowDefinition Height="Auto" />
+        <RowDefinition Height="Auto" />
+        <RowDefinition Height="Auto" />
       </Grid.RowDefinitions>
       <TextBlock x:Name="text"
                  Text="{Binding ProgressText}"
@@ -1024,15 +1026,32 @@
                  Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
                  TextWrapping="Wrap" />
       <ProgressBar Grid.Row="1" 
-                   IsIndeterminate="{Binding IsIndeterminate}" 
+                   IsIndeterminate="{Binding IsIndeterminate}"
                    Value="{Binding Value}"
                    Minimum="0.0"
                    Maximum="1.0"
                    HorizontalAlignment="Center"
-                   Width="200" 
-                   Height="23" 
+                   Width="200"
+                   Height="23"
                    Margin="10" />
-      <StackPanel Grid.Row="2"
+      <TextBlock Grid.Row="2"
+                 Visibility="{Binding ShowBufferUsage, Converter={StaticResource booleanToVisibilityConverter}}" 
+                 Text="Disk ==> Buffer ==> CPU"
+                 HorizontalAlignment="Center"
+                 Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
+                 TextWrapping="Wrap" />
+      <ProgressBar Grid.Row="3"
+                   x:Name="Buffer"
+                   IsIndeterminate="{Binding IsIndeterminate}"
+                   Value="{Binding BufferValue}"
+                   Minimum="0.0"
+                   Maximum="1.0"
+                   HorizontalAlignment="Center"
+                   Width="200"
+                   Height="23"
+                   Margin="10"
+                   Visibility="{Binding ShowBufferUsage, Converter={StaticResource booleanToVisibilityConverter}}" />
+            <StackPanel Grid.Row="4"
                   Margin="40"
                   Visibility="{Binding ShowCommandLine, Converter={StaticResource booleanToVisibilityConverter}}">
         <TextBlock Text="Using command line (press Ctrl+C to copy):"

--- a/src/StructuredLogger/BinaryLog.cs
+++ b/src/StructuredLogger/BinaryLog.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
         public static Build ReadBuild(string filePath) => ReadBuild(filePath, progress: null);
 
-        public static Build ReadBuild(string filePath, Progress progress)
+        public static Build ReadBuild(string filePath, Progress progress, Progress bufferUsage = null)
         {
             using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
@@ -38,7 +38,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
                     projectImportsArchive = File.ReadAllBytes(projectImportsZipFile);
                 }
 
-                var build = ReadBuild(stream, progress, projectImportsArchive);
+                var build = ReadBuild(stream, progress, bufferUsage, projectImportsArchive);
                 build.LogFilePath = filePath;
                 return build;
             }
@@ -49,7 +49,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
         internal const bool ReuseBinlogStrings = false;
 
-        public static Build ReadBuild(Stream stream, Progress progress, byte[] projectImportsArchive = null)
+        public static Build ReadBuild(Stream stream, Progress progress, Progress bufferUsage = null, byte[] projectImportsArchive = null)
         {
             var eventSource = new BinLogReader();
 
@@ -101,7 +101,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
             var sw = Stopwatch.StartNew();
 
-            eventSource.Replay(stream, progress);
+            eventSource.Replay(stream, progress, bufferUsage);
 
             var elapsed = sw.Elapsed;
 

--- a/src/StructuredLogger/BinaryLogger/BinLogReader.cs
+++ b/src/StructuredLogger/BinaryLogger/BinLogReader.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
             Replay(stream, progress: null);
         }
 
-        public void Replay(Stream stream, Progress progress)
+        public void Replay(Stream stream, Progress progress, Progress bufferUsage = null)
         {
             var gzipStream = new GZipStream(stream, CompressionMode.Decompress, leaveOpen: true);
             var bufferedStream = new BufferedStream(gzipStream, 32768);
@@ -71,7 +71,8 @@ namespace Microsoft.Build.Logging.StructuredLogger
             // Use a producer-consumer queue so that IO can happen on one thread
             // while processing can happen on another thread decoupled. The speed
             // up is from 4.65 to 4.15 seconds.
-            var queue = new BlockingCollection<BuildEventArgs>(boundedCapacity: 5000);
+            var maxBoundCapacity = 50000;
+            var queue = new BlockingCollection<BuildEventArgs>(boundedCapacity: maxBoundCapacity);
             var processingTask = System.Threading.Tasks.Task.Run(() =>
             {
                 foreach (var args in queue.GetConsumingEnumerable())
@@ -111,12 +112,17 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
                 queue.Add(instance);
 
-                if (progress != null && recordsRead % 1000 == 0 && stopwatch.ElapsedMilliseconds > 200)
+                if (progress != null && stopwatch.ElapsedMilliseconds > 200)
                 {
                     stopwatch.Restart();
                     var streamPosition = stream.Position;
                     double ratio = (double)streamPosition / streamLength;
                     progress.Report(ratio);
+
+                    if (bufferUsage != null)
+                    {
+                        bufferUsage.Report((double)queue.Count / maxBoundCapacity);
+                    }
                 }
             }
 
@@ -316,10 +322,10 @@ namespace Microsoft.Build.Logging.StructuredLogger
         public override long Length => stream.Length;
 
         private long position;
-        public override long Position 
+        public override long Position
         {
-            get => position; 
-            set => throw new NotImplementedException(); 
+            get => position;
+            set => throw new NotImplementedException();
         }
 
         public override void Flush()

--- a/src/StructuredLogger/Serialization/Serialization.cs
+++ b/src/StructuredLogger/Serialization/Serialization.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
         public static Build Read(string filePath) => Read(filePath, progress: null);
 
-        public static Build Read(string filePath, Progress progress)
+        public static Build Read(string filePath, Progress progress, Progress bufferUsage = null)
         {
             if (filePath.EndsWith(".xml", StringComparison.OrdinalIgnoreCase))
             {
@@ -58,7 +58,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
             {
                 try
                 {
-                    return BinaryLog.ReadBuild(filePath, progress);
+                    return BinaryLog.ReadBuild(filePath, progress, bufferUsage);
                 }
                 catch (Exception)
                 {


### PR DESCRIPTION
## Add a "Buffer" progress bar that will report the BlockingCollection queue length.
![image](https://github.com/KirillOsenkov/MSBuildStructuredLog/assets/19828377/5f13ec2e-fe4d-4638-93fb-0cf3ba0096f7)
 - The progress bar title is a placeholder, please help suggest a good title.

## Add a "Log Processing Statistics" to report the performance of the each type events.
![image](https://github.com/KirillOsenkov/MSBuildStructuredLog/assets/19828377/1ecc3946-8ff9-45a0-81c2-63bebb014ad1)

## Add a menu option to clear recently opened history.
![image](https://github.com/KirillOsenkov/MSBuildStructuredLog/assets/19828377/2a62de2b-b240-4fef-86d9-6273767a6e26)

