### PR TITLE
Use correct culture to parse analyzer execution time

### DIFF
--- a/src/StructuredLogger/Analyzers/CscTaskAnalyzer.cs
+++ b/src/StructuredLogger/Analyzers/CscTaskAnalyzer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 
 namespace Microsoft.Build.Logging.StructuredLogger
@@ -136,7 +137,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
                         return (line, TimeSpan.Zero);
                     }
 
-                    if (!double.TryParse(columns[0].Trim(), out var totalTimeSeconds))
+                    if (!double.TryParse(columns[0].Trim(), NumberStyles.Number, CultureInfo.GetCultureInfo(Strings.ResourceSet.Culture), out var totalTimeSeconds))
                     {
                         totalTimeSeconds = 0;
                     }


### PR DESCRIPTION
Fixes #687

The culture found in the log file is now used to parse analyzer execution times.

Before:

![image](https://github.com/KirillOsenkov/MSBuildStructuredLog/assets/20970123/60bd5426-a80a-4bd1-b3df-c93aa4660ae5)

After:

![image](https://github.com/KirillOsenkov/MSBuildStructuredLog/assets/20970123/bacf7b29-6e38-4c4c-832a-a44e003480e9)
