### PR TITLE
Memory Improvements

### DIFF
--- a/src/StructuredLogViewer/Controls/BuildControl.xaml
+++ b/src/StructuredLogViewer/Controls/BuildControl.xaml
@@ -62,7 +62,6 @@
                             BorderThickness="0"
                             VirtualizingPanel.IsVirtualizing="True"
                             VirtualizingPanel.VirtualizationMode="Recycling"
-                            TreeViewItem.Selected="TreeViewItem_Selected"
                             ItemsSource="{Binding Children}"
                             structuredLogViewer:ScrollViewerHelper.ShiftWheelScrollsHorizontally="True" />
                 </TabItem>

--- a/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
@@ -59,7 +59,7 @@ namespace StructuredLogViewer.Controls
         private ContextMenu sharedTreeContextMenu;
         private ContextMenu filesTreeContextMenu;
 
-        public TreeView ActiveTreeView;
+        private TreeView ActiveTreeView;
 
         private PropertiesAndItemsSearch propertiesAndItemsSearch;
 
@@ -110,10 +110,7 @@ namespace StructuredLogViewer.Controls
             propertiesAndItemsControl.ResultsTreeBuilder = BuildResultTree;
 
             UpdatePropertiesAndItemsWatermark();
-            propertiesAndItemsControl.WatermarkDisplayed += () =>
-            {
-                UpdatePropertiesAndItemsWatermark();
-            };
+            propertiesAndItemsControl.WatermarkDisplayed += UpdatePropertiesAndItemsWatermark;
             propertiesAndItemsControl.RecentItemsCategory = "PropertiesAndItems";
 
             SetProjectContext(null);
@@ -298,6 +295,34 @@ Right-clicking a project node may show the 'Preprocess' option if the version of
             navigationHelper.OpenFileRequested += filePath => DisplayFile(filePath);
 
             centralTabControl.SelectionChanged += CentralTabControl_SelectionChanged;
+        }
+
+        public void Dispose()
+        {
+            searchLogControl.ResultsList.SelectedItemChanged -= ResultsList_SelectionChanged;
+            searchLogControl.WatermarkDisplayed -= UpdatePropertiesAndItemsWatermark;
+            searchLogControl.ExecuteSearch = null;
+            searchLogControl.WatermarkContent = null;
+            searchLogControl.DisplayItems(null);
+            propertiesAndItemsControl.ResultsList.SelectedItemChanged -= ResultsList_SelectionChanged;
+            propertiesAndItemsControl.WatermarkDisplayed -= UpdatePropertiesAndItemsWatermark;
+            propertiesAndItemsContext.Content = null;
+            propertiesAndItemsControl.ExecuteSearch = null;
+            propertiesAndItemsControl.WatermarkContent = null;
+            propertiesAndItemsSearch = null;
+            breadCrumb.ItemsSource = null;
+            filesTree.DisplayItems(null);
+            treeView.SelectedItemChanged -= TreeView_SelectedItemChanged;
+            treeView.ItemsSource = null;
+            centralTabControl.SelectionChanged -= CentralTabControl_SelectionChanged;
+            this.ActiveTreeView = null;
+            this.DataContext = null;
+            preprocessedFileManager = null;
+            navigationHelper = null;
+            projectContext = null;
+            SelectedTreeViewItem = null;
+            BaseNode.ClearSelectedNode();
+            this.Build = null;
         }
 
         private void CentralTabControl_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/src/StructuredLogViewer/Controls/DocumentWell.xaml.cs
+++ b/src/StructuredLogViewer/Controls/DocumentWell.xaml.cs
@@ -12,13 +12,10 @@ namespace StructuredLogViewer.Controls
 {
     public partial class DocumentWell : UserControl
     {
-        private ICollectionView tabsView;
-
         public DocumentWell()
         {
             InitializeComponent();
             tabControl.ItemsSource = Tabs;
-            tabsView = CollectionViewSource.GetDefaultView(Tabs);
             Tabs.CollectionChanged += Tabs_CollectionChanged;
 
             var existingStyle = Application.Current.FindResource(typeof(TabItem));
@@ -26,6 +23,13 @@ namespace StructuredLogViewer.Controls
             style.Setters.Add(new EventSetter(MouseDownEvent, (MouseButtonEventHandler)OnMouseDownEvent));
 
             tabControl.ItemContainerStyle = style;
+        }
+
+        public void Dispose()
+        {
+            tabControl.ItemContainerStyle = null;
+            Tabs.CollectionChanged -= Tabs_CollectionChanged;
+            tabControl.ItemsSource = null;
         }
 
         private void OnMouseDownEvent(object sender, MouseButtonEventArgs args)

--- a/src/StructuredLogViewer/Controls/ProjectGraphControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/ProjectGraphControl.xaml.cs
@@ -12,6 +12,12 @@ namespace StructuredLogViewer.Controls
             InitializeComponent();
         }
 
+        public void Dispose()
+        {
+            Panel.Children.Clear();
+            BuildControl = null;
+        }
+
         public BuildControl BuildControl { get; set; }
 
         public void SetGraph(Graph graph)

--- a/src/StructuredLogViewer/Controls/SearchAndResultsControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/SearchAndResultsControl.xaml.cs
@@ -14,12 +14,21 @@ namespace StructuredLogViewer.Controls
         public SearchAndResultsControl()
         {
             InitializeComponent();
-            typingConcurrentOperation.DisplayResults += (r, moreAvailable, cancellationToken) => DisplaySearchResults(r, moreAvailable, cancellationToken);
+            typingConcurrentOperation.DisplayResults += DisplaySearchResults;
             typingConcurrentOperation.SearchComplete += TypingConcurrentOperation_SearchComplete;
 
             VirtualizingPanel.SetIsVirtualizing(resultsList, SettingsService.EnableTreeViewVirtualization);
 
             this.Unloaded += SearchAndResultsControl_Unloaded;
+        }
+
+        public void Dispose()
+        {
+            this.Unloaded -= SearchAndResultsControl_Unloaded;
+            typingConcurrentOperation.DisplayResults -= DisplaySearchResults;
+            typingConcurrentOperation.SearchComplete -= TypingConcurrentOperation_SearchComplete;
+            this.clearSearchButton.Click -= clearSearchButton_Click;
+            this.resultsList.ItemsSource = null;
         }
 
         private void SearchAndResultsControl_Unloaded(object sender, RoutedEventArgs e)

--- a/src/StructuredLogViewer/Controls/TimelineControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/TimelineControl.xaml.cs
@@ -20,6 +20,17 @@ namespace StructuredLogViewer.Controls
             grid.LayoutTransform = scaleTransform;
         }
 
+        public void Dispose()
+        {
+            PreviewMouseWheel -= TimelineControl_MouseWheel;
+            grid.Children.Clear();
+            this.Timeline = null;
+            BuildControl = null;
+            TextBlocks.Clear();
+            activeTextBlock = null;
+            highlight = null;
+        }
+
         private double scaleFactor = 1;
         private double horizontalOffset = 0;
         private double verticalOffset = 0;

--- a/src/StructuredLogViewer/MainWindow.xaml.cs
+++ b/src/StructuredLogViewer/MainWindow.xaml.cs
@@ -133,6 +133,9 @@ namespace StructuredLogViewer
 
         private void DisplayWelcomeScreen(string message = "")
         {
+            // Dispose of current build.
+            DisplayBuild(null);
+
             this.projectFilePath = null;
             this.logFilePath = null;
             this.currentBuild = null;
@@ -629,6 +632,11 @@ namespace StructuredLogViewer
 
         private void DisplayBuild(Build build)
         {
+            if (currentBuild != null && currentBuild is BuildControl)
+            {
+                currentBuild.Dispose();
+            }
+
             currentBuild = build != null ? new BuildControl(build, logFilePath) : null;
             SetContent(currentBuild);
 

--- a/src/StructuredLogger/ObjectModel/BaseNode.cs
+++ b/src/StructuredLogger/ObjectModel/BaseNode.cs
@@ -35,6 +35,11 @@ namespace Microsoft.Build.Logging.StructuredLogger
         /// </summary>
         private static BaseNode selectedNode = null;
 
+        public static void ClearSelectedNode()
+        {
+            selectedNode = null;
+        }
+
         public bool IsSelected
         {
             get => selectedNode == this;


### PR DESCRIPTION
### Free object when going back WelcomeScreen.
 - StructuredLogger.Build and children are freed.
 - I tried to free BuildControl but there were still some lingering object from WPF.
### Improve AddProperties to avoid sparse lists.
 - Casting to IEnumerable during sort removed access to the size.
### Removed UpdatedGraph() as the trace graph is fully rendered on load.
