### PR TITLE
Disable FIPS cryptographic exceptions

### DIFF
--- a/src/StructuredLogViewer/App.config
+++ b/src/StructuredLogViewer/App.config
@@ -15,6 +15,8 @@
     <gcServer enabled="true"/>
     <DisableFXClosureWalk enabled="true"/>
     <generatePublisherEvidence enabled="false"/>
+    <!-- FIPS throw behavior switch can be removed if upgraded to .NET Framework 4.8 -->
+    <AppContextSwitchOverrides value="Switch.System.Security.Cryptography.UseLegacyFipsThrow=false" />
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Build.Framework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>


### PR DESCRIPTION
In .NET Framework 4.7.2 and earlier versions, managed cryptographic provider classes such as System.Security.Cryptography.MD5 throw a System.Security.Cryptography.CryptographicException when the system cryptographic libraries are configured in FIPS mode.

The issue is encountered in the log viewer when needing to write content to a temporary file path e.g. when preprocessing a project node to view the full project XML.

The fix taken here to to turn off the exception throwing behavior via an app runtime switch.

Closes: #701