### PR TITLE
Support for ExtendedCriticalBuildMessageEventArgs

### DIFF
--- a/src/StructuredLogger/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/StructuredLogger/BinaryLogger/BuildEventArgsReader.cs
@@ -877,21 +877,49 @@ namespace Microsoft.Build.Logging.StructuredLogger
         {
             var fields = ReadBuildEventArgsFields(readImportance: true);
 
-            var e = new CriticalBuildMessageEventArgs(
-                fields.Subcategory,
-                fields.Code,
-                fields.File,
-                fields.LineNumber,
-                fields.ColumnNumber,
-                fields.EndLineNumber,
-                fields.EndColumnNumber,
-                fields.Message,
-                fields.HelpKeyword,
-                fields.SenderName,
-                fields.Timestamp,
-                fields.Arguments);
+            BuildEventArgs e;
+            if (fields.Extended == null)
+            {
+                e = new CriticalBuildMessageEventArgs(
+                    fields.Subcategory,
+                    fields.Code,
+                    fields.File,
+                    fields.LineNumber,
+                    fields.ColumnNumber,
+                    fields.EndLineNumber,
+                    fields.EndColumnNumber,
+                    fields.Message,
+                    fields.HelpKeyword,
+                    fields.SenderName,
+                    fields.Timestamp,
+                    fields.Arguments)
+                {
+                    ProjectFile = fields.ProjectFile,
+                };
+            }
+            else
+            {
+                e = new ExtendedCriticalBuildMessageEventArgs(
+                    fields.Extended?.ExtendedType ?? string.Empty,
+                    fields.Subcategory,
+                    fields.Code,
+                    fields.File,
+                    fields.LineNumber,
+                    fields.ColumnNumber,
+                    fields.EndLineNumber,
+                    fields.EndColumnNumber,
+                    fields.Message,
+                    fields.HelpKeyword,
+                    fields.SenderName,
+                    fields.Timestamp,
+                    fields.Arguments)
+                {
+                    ProjectFile = fields.ProjectFile,
+                    ExtendedMetadata = fields.Extended?.ExtendedMetadata,
+                    ExtendedData = fields.Extended?.ExtendedData,
+                };
+            }
             e.BuildEventContext = fields.BuildEventContext;
-            e.ProjectFile = fields.ProjectFile;
             return e;
         }
 

--- a/src/StructuredLogger/BinaryLogger/ExtendedCriticalBuildMessageEventArgs.cs
+++ b/src/StructuredLogger/BinaryLogger/ExtendedCriticalBuildMessageEventArgs.cs
@@ -1,0 +1,135 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Microsoft.Build.Framework;
+
+/// <summary>
+/// Critical message events arguments including extended data for event enriching.
+/// Extended data are implemented by <see cref="IExtendedBuildEventArgs"/>
+/// </summary>
+public sealed class ExtendedCriticalBuildMessageEventArgs : CriticalBuildMessageEventArgs, IExtendedBuildEventArgs
+{
+    /// <inheritdoc />
+    public string ExtendedType { get; set; }
+
+    /// <inheritdoc />
+    public IDictionary<string, string?>? ExtendedMetadata { get; set; }
+
+    /// <inheritdoc />
+    public string? ExtendedData { get; set; }
+
+    /// <summary>
+    /// This constructor allows all event data to be initialized
+    /// </summary>
+    /// <param name="type">Type of <see cref="IExtendedBuildEventArgs.ExtendedType"/>.</param>
+    /// <param name="subcategory">event subcategory</param>
+    /// <param name="code">event code</param>
+    /// <param name="file">file associated with the event</param>
+    /// <param name="lineNumber">line number (0 if not applicable)</param>
+    /// <param name="columnNumber">column number (0 if not applicable)</param>
+    /// <param name="endLineNumber">end line number (0 if not applicable)</param>
+    /// <param name="endColumnNumber">end column number (0 if not applicable)</param>
+    /// <param name="message">text message</param>
+    /// <param name="helpKeyword">help keyword </param>
+    /// <param name="senderName">name of event sender</param>
+    public ExtendedCriticalBuildMessageEventArgs(
+        string type,
+        string? subcategory,
+        string? code,
+        string? file,
+        int lineNumber,
+        int columnNumber,
+        int endLineNumber,
+        int endColumnNumber,
+        string? message,
+        string? helpKeyword,
+        string? senderName)
+        : this(type, subcategory, code, file, lineNumber, columnNumber, endLineNumber, endColumnNumber, message, helpKeyword, senderName, DateTime.UtcNow)
+    {
+        // do nothing
+    }
+
+    /// <summary>
+    /// This constructor allows timestamp to be set
+    /// </summary>
+    /// <param name="type">Type of <see cref="IExtendedBuildEventArgs.ExtendedType"/>.</param>
+    /// <param name="subcategory">event subcategory</param>
+    /// <param name="code">event code</param>
+    /// <param name="file">file associated with the event</param>
+    /// <param name="lineNumber">line number (0 if not applicable)</param>
+    /// <param name="columnNumber">column number (0 if not applicable)</param>
+    /// <param name="endLineNumber">end line number (0 if not applicable)</param>
+    /// <param name="endColumnNumber">end column number (0 if not applicable)</param>
+    /// <param name="message">text message</param>
+    /// <param name="helpKeyword">help keyword </param>
+    /// <param name="senderName">name of event sender</param>
+    /// <param name="eventTimestamp">custom timestamp for the event</param>
+    public ExtendedCriticalBuildMessageEventArgs(
+        string type,
+        string? subcategory,
+        string? code,
+        string? file,
+        int lineNumber,
+        int columnNumber,
+        int endLineNumber,
+        int endColumnNumber,
+        string? message,
+        string? helpKeyword,
+        string? senderName,
+        DateTime eventTimestamp)
+        : this(type, subcategory, code, file, lineNumber, columnNumber, endLineNumber, endColumnNumber, message, helpKeyword, senderName, eventTimestamp, null!)
+    {
+        // do nothing
+    }
+
+    /// <summary>
+    /// This constructor allows timestamp to be set
+    /// </summary>
+    /// <param name="type">Type of <see cref="IExtendedBuildEventArgs.ExtendedType"/>.</param>
+    /// <param name="subcategory">event subcategory</param>
+    /// <param name="code">event code</param>
+    /// <param name="file">file associated with the event</param>
+    /// <param name="lineNumber">line number (0 if not applicable)</param>
+    /// <param name="columnNumber">column number (0 if not applicable)</param>
+    /// <param name="endLineNumber">end line number (0 if not applicable)</param>
+    /// <param name="endColumnNumber">end column number (0 if not applicable)</param>
+    /// <param name="message">text message</param>
+    /// <param name="helpKeyword">help keyword </param>
+    /// <param name="senderName">name of event sender</param>
+    /// <param name="eventTimestamp">custom timestamp for the event</param>
+    /// <param name="messageArgs">message arguments</param>
+    public ExtendedCriticalBuildMessageEventArgs(
+        string type,
+        string? subcategory,
+        string? code,
+        string? file,
+        int lineNumber,
+        int columnNumber,
+        int endLineNumber,
+        int endColumnNumber,
+        string? message,
+        string? helpKeyword,
+        string? senderName,
+        DateTime eventTimestamp,
+        params object[]? messageArgs)
+        //// Force importance to High. 
+        : base(subcategory, code, file, lineNumber, columnNumber, endLineNumber, endColumnNumber, message, helpKeyword, senderName, eventTimestamp, messageArgs) => ExtendedType = type;
+
+    /// <summary>
+    /// Default constructor. Used for deserialization.
+    /// </summary>
+    internal ExtendedCriticalBuildMessageEventArgs() : this("undefined")
+    {
+        // do nothing
+    }
+
+    /// <summary>
+    /// This constructor specifies only type of extended data.
+    /// </summary>
+    /// <param name="type">Type of <see cref="IExtendedBuildEventArgs.ExtendedType"/>.</param>
+    public ExtendedCriticalBuildMessageEventArgs(string type) => ExtendedType = type;
+}

--- a/src/StructuredLogger/Construction/MessageProcessor.cs
+++ b/src/StructuredLogger/Construction/MessageProcessor.cs
@@ -600,6 +600,8 @@ namespace Microsoft.Build.Logging.StructuredLogger
                     critical.ProjectFile = Intern(criticalArgs.ProjectFile);
                     critical.Subcategory = Intern(criticalArgs.Subcategory);
 
+                    Construction.PopulateWithExtendedData(critical, args);
+
                     nodeToAdd = critical;
                 }
                 else if (parent is Task task && task is CppAnalyzer.CppTask)


### PR DESCRIPTION
Related to https://github.com/dotnet/msbuild/pull/9363

Changes in above ^ PR is not breaking and no new FileVersion is needed

### Changes Made
Add support for parsing and viewing extended data of ExtendedCriticalBuildMessageEventArgs
![image](https://github.com/KirillOsenkov/MSBuildStructuredLog/assets/25249058/6c34dda4-c6a0-48e3-b781-15909555958a)