### PR TITLE
Search improvements

### DIFF
--- a/src/StructuredLogViewer.Core/SettingsService.cs
+++ b/src/StructuredLogViewer.Core/SettingsService.cs
@@ -104,6 +104,12 @@ namespace StructuredLogViewer
             SaveText(recentProjectsFilePath, Enumerable.Empty<string>());
         }
 
+        public static void RemoveAllRecentSearchText(string recentItemsCategory = "")
+        {
+            var file = GetRecentSearchFilePath(recentItemsCategory);
+            SaveText(file, Enumerable.Empty<string>());
+        }
+
         private static string GetRecentSearchFilePath(string category = "")
         {
             return recentSearchesFilePath.Replace("$", category);

--- a/src/StructuredLogViewer.Core/TypingConcurrentOperation.cs
+++ b/src/StructuredLogViewer.Core/TypingConcurrentOperation.cs
@@ -39,6 +39,11 @@ namespace StructuredLogViewer
 
         public void TextChanged(string searchText, int maxResults)
         {
+            if (searchText.Equals(this.searchText))
+            {
+                return;
+            }
+
             if (ExecuteSearch == null)
             {
                 Reset();

--- a/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
@@ -41,7 +41,9 @@ namespace StructuredLogViewer.Controls
         private MenuItem copySubtreeItem;
         private MenuItem viewSubtreeTextItem;
         private MenuItem searchInSubtreeItem;
+        private MenuItem searchInNodeByNameItem;
         private MenuItem excludeSubtreeFromSearchItem;
+        private MenuItem excludeNodeByNameFromSearch;
         private MenuItem goToTimeLineItem;
         private MenuItem goToTracingItem;
         private MenuItem copyChildrenItem;
@@ -181,6 +183,8 @@ namespace StructuredLogViewer.Controls
             viewSubtreeTextItem = new MenuItem() { Header = "View subtree text" };
             searchInSubtreeItem = new MenuItem() { Header = "Search in subtree" };
             excludeSubtreeFromSearchItem = new MenuItem() { Header = "Exclude subtree from search" };
+            excludeNodeByNameFromSearch = new MenuItem() { Header = "Exclude node from search" };
+            searchInNodeByNameItem = new MenuItem() { Header = "Search in this node." };
             goToTimeLineItem = new MenuItem() { Header = "Go to timeline" };
             goToTracingItem = new MenuItem() { Header = "Go to tracing" };
             copyChildrenItem = new MenuItem() { Header = "Copy children" };
@@ -211,6 +215,8 @@ namespace StructuredLogViewer.Controls
             viewSubtreeTextItem.Click += (s, a) => ViewSubtreeText();
             searchInSubtreeItem.Click += (s, a) => SearchInSubtree();
             excludeSubtreeFromSearchItem.Click += (s, a) => ExcludeSubtreeFromSearch();
+            excludeNodeByNameFromSearch.Click += (s, a) => ExcludeNodeByNameFromSearch();
+            searchInNodeByNameItem.Click += (s, a) => SearchInNodeByName();
             goToTimeLineItem.Click += (s, a) => GoToTimeLine();
             goToTracingItem.Click += (s, a) => GoToTracing();
             copyChildrenItem.Click += (s, a) => CopyChildren();
@@ -236,7 +242,9 @@ namespace StructuredLogViewer.Controls
             contextMenu.AddItem(preprocessItem);
             contextMenu.AddItem(searchNuGetItem);
             contextMenu.AddItem(searchInSubtreeItem);
+            contextMenu.AddItem(searchInNodeByNameItem);
             contextMenu.AddItem(excludeSubtreeFromSearchItem);
+            contextMenu.AddItem(excludeNodeByNameFromSearch);
             contextMenu.AddItem(goToTimeLineItem);
             contextMenu.AddItem(goToTracingItem);
             contextMenu.AddItem(copyItem);
@@ -379,6 +387,8 @@ Right-clicking a project node may show the 'Preprocess' option if the version of
             viewSubtreeTextItem = null;
             searchInSubtreeItem = null;
             excludeSubtreeFromSearchItem = null;
+            excludeNodeByNameFromSearch = null;
+            searchInNodeByNameItem = null;
             goToTimeLineItem = null;
             goToTracingItem = null;
             copyChildrenItem = null;
@@ -617,7 +627,7 @@ Right-clicking a project node may show the 'Preprocess' option if the version of
 
         private void UpdateWatermark()
         {
-            string watermarkText0 = @"Type in the search box to search. Press Ctrl+F to focus the search box. Results (up to 1000) will display here.
+            string watermarkText0 = $@"Type in the search box to search. Press Ctrl+F to focus the search box. Results (up to {Search.DefaultMaxResults}) will display here.
 ";
 
             string watermarkText1 = @"
@@ -647,7 +657,11 @@ Examples:
             if (recentSearches.Any())
             {
                 watermark.Inlines.Add(@"
-Recent:
+Recent (");
+                var clearRecentHyperlink = new Hyperlink(new Run("clear"));
+                clearRecentHyperlink.Click += (s, e) => { SettingsService.RemoveAllRecentSearchText(); UpdateWatermark(); };
+                watermark.Inlines.Add(clearRecentHyperlink);
+                watermark.Inlines.Add(@"):
 ");
 
                 foreach (var recentSearch in recentSearches.Where(s => !searchExamples.Contains(s) && !nodeKinds.Contains(s)))
@@ -704,7 +718,11 @@ Recent:
             if (recentSearches.Any())
             {
                 watermark.Inlines.Add(@"
-Recent:
+Recent (");
+                var clearRecentHyperlink = new Hyperlink(new Run("clear"));
+                clearRecentHyperlink.Click += (s, e) => { SettingsService.RemoveAllRecentSearchText("PropertiesAndItems"); UpdatePropertiesAndItemsWatermark(); };
+                watermark.Inlines.Add(clearRecentHyperlink);
+                watermark.Inlines.Add(@"):
 ");
 
                 foreach (var recentSearch in recentSearches)
@@ -828,11 +846,6 @@ Recent:
             var hasChildren = node is TreeNode t && t.HasChildren;
             copySubtreeItem.Visibility = hasChildren ? Visibility.Visible : Visibility.Collapsed;
             viewSubtreeTextItem.Visibility = copySubtreeItem.Visibility;
-            showTimeItem.Visibility = node is TimedNode ? Visibility.Visible : Visibility.Collapsed;
-            searchInSubtreeItem.Visibility = hasChildren && node is TimedNode ? Visibility.Visible : Visibility.Collapsed;
-            excludeSubtreeFromSearchItem.Visibility = hasChildren && node is TimedNode ? Visibility.Visible : Visibility.Collapsed;
-            goToTimeLineItem.Visibility = node is TimedNode ? Visibility.Visible : Visibility.Collapsed;
-            goToTracingItem.Visibility = node is TimedNode ? Visibility.Visible : Visibility.Collapsed;
             copyChildrenItem.Visibility = copySubtreeItem.Visibility;
             sortChildrenItem.Visibility = copySubtreeItem.Visibility;
             preprocessItem.Visibility = node is IPreprocessable p && preprocessedFileManager.CanPreprocess(p) ? Visibility.Visible : Visibility.Collapsed;
@@ -841,6 +854,37 @@ Recent:
             runItem.Visibility = canRun;
             debugItem.Visibility = canRun;
             hideItem.Visibility = node is TreeNode ? Visibility.Visible : Visibility.Collapsed;
+
+            if (node is TimedNode timedNode)
+            {
+                showTimeItem.Visibility = Visibility.Visible;
+                searchInSubtreeItem.Visibility = hasChildren ? Visibility.Visible : Visibility.Collapsed;
+                excludeSubtreeFromSearchItem.Visibility = hasChildren ? Visibility.Visible : Visibility.Collapsed;
+                goToTimeLineItem.Visibility = Visibility.Visible;
+                goToTracingItem.Visibility = Visibility.Visible;
+                excludeNodeByNameFromSearch.Visibility = hasChildren ? Visibility.Visible : Visibility.Collapsed;
+                searchInNodeByNameItem.Visibility = hasChildren ? Visibility.Visible : Visibility.Collapsed;
+
+                if (excludeNodeByNameFromSearch.Visibility == Visibility.Visible)
+                {
+                    excludeNodeByNameFromSearch.Header = $"Exclude '{timedNode.Name}' from search";
+                }
+
+                if (searchInNodeByNameItem.Visibility == Visibility.Visible)
+                {
+                    searchInNodeByNameItem.Header = $"Search in '{timedNode.Name}'";
+                }
+            }
+            else
+            {
+                showTimeItem.Visibility = Visibility.Collapsed;
+                searchInSubtreeItem.Visibility = Visibility.Collapsed;
+                excludeSubtreeFromSearchItem.Visibility = Visibility.Collapsed;
+                goToTimeLineItem.Visibility = Visibility.Collapsed;
+                goToTracingItem.Visibility = Visibility.Collapsed;
+                excludeNodeByNameFromSearch.Visibility = Visibility.Collapsed;
+                searchInNodeByNameItem.Visibility = Visibility.Collapsed;
+            }
         }
 
         private object FindInFiles(string searchText, int maxResults, CancellationToken cancellationToken)
@@ -1516,11 +1560,29 @@ Recent:
             }
         }
 
+        public void SearchInNodeByName()
+        {
+            if (treeView.SelectedItem is TimedNode treeNode)
+            {
+                searchLogControl.SearchText += $" under(${treeNode.TypeName} {treeNode.Name})";
+                SelectSearchTab();
+            }
+        }
+
         public void ExcludeSubtreeFromSearch()
         {
             if (treeView.SelectedItem is TimedNode treeNode)
             {
                 searchLogControl.SearchText += $" notunder(${treeNode.Index})";
+                SelectSearchTab();
+            }
+        }
+
+        public void ExcludeNodeByNameFromSearch()
+        {
+            if (treeView.SelectedItem is TimedNode treeNode)
+            {
+                searchLogControl.SearchText += $" notunder(${treeNode.TypeName} {treeNode.Name})";
                 SelectSearchTab();
             }
         }

--- a/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
@@ -627,7 +627,7 @@ Right-clicking a project node may show the 'Preprocess' option if the version of
 
         private void UpdateWatermark()
         {
-            string watermarkText0 = $@"Type in the search box to search. Press Ctrl+F to focus the search box. Results (up to {Search.DefaultMaxResults}) will display here.
+            string watermarkText0 = @"Type in the search box to search. Press Ctrl+F to focus the search box. Results (up to 1000) will display here.
 ";
 
             string watermarkText1 = @"

--- a/src/StructuredLogViewer/Controls/SearchAndResultsControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/SearchAndResultsControl.xaml.cs
@@ -64,7 +64,7 @@ namespace StructuredLogViewer.Controls
 
         private void searchTextBox_TextChanged(object sender, TextChangedEventArgs e)
         {
-            var searchText = searchTextBox.Text;
+            var searchText = searchTextBox.Text.Trim();
             TextChanged?.Invoke(searchText);
 
             if (string.IsNullOrWhiteSpace(searchText) || searchText.Length < 3)


### PR DESCRIPTION
### Add menu item to search in this node by name.
  - For example, a project will add  under($Project StructuredLogViewer.Core.csproj)
<img width="325" alt="image" src="https://github.com/KirillOsenkov/MSBuildStructuredLog/assets/19828377/696e18b1-1907-45d6-bea5-8bfb9713fd0e">


### Add "Clear" link to clear recent searches.
<img width="263" alt="image" src="https://github.com/KirillOsenkov/MSBuildStructuredLog/assets/19828377/a5e41b27-b0f3-46e2-8643-8625bb211798">

### Trim search text to skip searching when typing a "space"