### PR TITLE
Fix the read global properties backcompat issue

### DIFF
--- a/src/StructuredLogger/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/StructuredLogger/BinaryLogger/BuildEventArgsReader.cs
@@ -724,7 +724,12 @@ namespace Microsoft.Build.Logging.StructuredLogger
             if (_fileFormatVersion >= 12)
             {
                 IEnumerable globalProperties = null;
-                if (ReadBoolean())
+                // In newer versions, we store the global properties always, as it handles
+                //  null and empty within WriteProperties already.
+                // This saves a single boolean, but mainly doesn't hide the difference between null and empty
+                //  during write->read roundtrip.
+                if (_fileFormatVersion >= BinaryLogger.ForwardCompatibilityMinimalVersion ||
+                    ReadBoolean())
                 {
                     globalProperties = ReadStringDictionary();
                 }
@@ -778,12 +783,12 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
             if (_fileFormatVersion > 6)
             {
-                if (_fileFormatVersion < BinaryLogger.ForwardCompatibilityMinimalVersion)
+                // See ReadProjectEvaluationFinishedEventArgs for details on why we always store global properties in newer version.
+                if (_fileFormatVersion >= BinaryLogger.ForwardCompatibilityMinimalVersion ||
+                    ReadBoolean())
                 {
-                    // Throw away, but need to advance past it
-                    ReadBoolean();
+                    globalProperties = ReadStringDictionary();
                 }
-                globalProperties = ReadStringDictionary();
             }
 
             var propertyList = ReadPropertyList();


### PR DESCRIPTION
Fixes #740 

### Context

The original PR (#732) was quite loaded - one of the changes was making sure that full roundtrip of writing, reading binlog doesn't loose some minor details that would otherwise prevent full roundtrip equality check.
That change was had buggy conditions, but due to flood of other changes it slipped easily.

### Fix made
For the previous version of logs we keep the old reading behavior of global props - first flag, then - if the flag is true - the dictionary. For new version of logs (yet to be produced) the dictionary is read allways.

### Testing

Manual - the repro binlog, Orchard binlog and couple experimental binlogs of v 18 and above