### PR TITLE
[Proposal] Add dumprecords command

### DIFF
--- a/src/BinlogTool/DumpRecords.cs
+++ b/src/BinlogTool/DumpRecords.cs
@@ -55,7 +55,7 @@ namespace BinlogTool
 
             IEnumerable<(BinaryLogRecordKind, long)> records =
                 new BinLogReader().ChunkBinlog(input)
-                    .Select(r => (r.RecordKind, r.Length));
+                    .Select(r => (r.Kind, r.Length));
 
             int totalRecords = 0;
 

--- a/src/BinlogTool/DumpRecords.cs
+++ b/src/BinlogTool/DumpRecords.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Build.Logging.StructuredLogger;
+using Microsoft.Build.Logging;
+using StructuredLogger.Utils;
+
+namespace BinlogTool
+{
+    internal static class DumpRecords
+    {
+        public static void Run(List<string> inputs, bool includeTotal, bool includeRollup, bool includeDetails)
+        {
+            if (!inputs.Any())
+            {
+                // Default - current directory
+                inputs.Add(string.Empty);
+            }
+
+            var inputBinlogs = inputs.SelectMany(input => Searcher.FindBinlogs(input, true)).ToList();
+
+            if (!inputBinlogs.Any())
+            {
+                Log.WriteError("No binlogs found.");
+                return;
+            }
+
+            if (inputBinlogs.Count > 1)
+            {
+                Log.WriteLine(
+                    $"Found {inputBinlogs.Count} binlog files. Will provide overview for all. (found files: {(string.Join(',', inputBinlogs))})");
+            }
+
+            foreach (var inputBinlog in inputBinlogs)
+            {
+                if (inputBinlogs.Count > 1)
+                {
+                    Log.WriteLine();
+                    Log.WriteLine($"Overview for {inputBinlog}");
+                    Log.WriteLine();
+                }
+
+                RunSingle(inputBinlog, includeTotal, includeRollup, includeDetails);
+            }
+        }
+
+        public static void RunSingle(string input, bool includeTotal, bool includeRollup, bool includeDetails)
+        {
+            bool needsGreedyEnumerate = includeRollup && includeDetails;
+
+            IEnumerable<(BinaryLogRecordKind, long)> records =
+                new BinLogReader().ChunkBinlog(input)
+                    .Select(r => (r.RecordKind, r.Length));
+
+            int totalRecords = 0;
+
+            if (needsGreedyEnumerate)
+            {
+                records = records.ToList();
+                totalRecords = records.Count();
+            }
+
+            if (includeRollup)
+            {
+                totalRecords = 0;
+                Log.WriteLine("RecordType, Count, Size[bytes]");
+                Log.WriteLine("==============================");
+                foreach (var group in records.GroupBy(r => r.Item1))
+                {
+                    Log.WriteLine($"{group.Key}, {group.Count()}, {group.Sum(r => r.Item2) / (double)group.Count():0.00}");
+                    totalRecords += group.Count();
+                }
+                Log.WriteLine();
+            }
+
+            if (includeDetails)
+            {
+                totalRecords = 0;
+                Log.WriteLine("RecordType, Size[bytes]");
+                Log.WriteLine("=======================");
+                foreach (var record in records)
+                {
+                    Log.WriteLine($"{record.Item1}, {record.Item2}");
+                    totalRecords++;
+                }
+            }
+
+            if (includeTotal)
+            {
+                Log.WriteLine($"Total records: {totalRecords}");
+                Log.WriteLine();
+            }
+        }
+    }
+}

--- a/src/BinlogTool/Program.cs
+++ b/src/BinlogTool/Program.cs
@@ -194,9 +194,7 @@ namespace BinlogTool
                     }
                 }
 
-                Stopwatch sw = Stopwatch.StartNew();
                 DumpRecords.Run(inputPaths, includeTotal, includeRollup, includeDetails);
-                Console.Error.WriteLine(sw.Elapsed);
                 return 0;
             }
 

--- a/src/BinlogTool/Program.cs
+++ b/src/BinlogTool/Program.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using Microsoft.Build.Logging.StructuredLogger;
 
 namespace BinlogTool
@@ -19,7 +21,8 @@ namespace BinlogTool
     binlogtool reconstruct input.binlog output_path
     binlogtool savestrings input.binlog output.txt
     binlogtool search *.binlog search string
-    binlogtool redact --input:path --recurse --in-place -p:list -p:of -p:secrets -p:to -p:redact");
+    binlogtool redact --input:path --recurse --in-place -p:list -p:of -p:secrets -p:to -p:redact
+    binlogtool dumprecords [[--input:]path] [--include-total] [--include-rollup] [--exclude-details]");
                 return 0;
             }
 
@@ -142,6 +145,58 @@ namespace BinlogTool
                 }
 
                 Redact.Run(inputPaths, redactTokens, inPlace, recurse);
+                return 0;
+            }
+
+            if (firstArg == "dumprecords")
+            {
+                bool includeTotal = false;
+                bool includeRollup = false;
+                bool includeDetails = true;
+                List<string> inputPaths = new List<string>();
+
+                foreach (var arg in args.Skip(1))
+                {
+                    if (arg.StartsWith("--input:", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var input = arg.Substring("--input:".Length);
+                        if (string.IsNullOrEmpty(input))
+                        {
+                            Console.Error.WriteLine("Invalid input path");
+                            return -3;
+                        }
+
+                        inputPaths.Add(input);
+                    }
+                    // [--include-total] [--include-rollup] [--exclude-details]
+                    else if (arg.Equals("--include-total", StringComparison.OrdinalIgnoreCase))
+                    {
+                        includeTotal = true;
+                    }
+                    else if (arg.Equals("--include-rollup", StringComparison.OrdinalIgnoreCase))
+                    {
+                        includeRollup = true;
+                    }
+                    else if (arg.Equals("--exclude-details", StringComparison.OrdinalIgnoreCase))
+                    {
+                        includeDetails = false;
+                    }
+                    else if (arg.EndsWith(".binlog", StringComparison.OrdinalIgnoreCase))
+                    {
+                        inputPaths.Add(arg);
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine($"Invalid argument: {arg}");
+                        Console.Error.WriteLine("binlogtool dumprecords [[--input:]path] [--include-total] [--include-rollup] [--exclude-details]");
+                        Console.Error.WriteLine("All arguments are optional (Missing input assumes current working directory. Rollup and total is disabled by default, detail overview is enabled by default. Input(s) arguments can be specified without switch.)");
+                        return -5;
+                    }
+                }
+
+                Stopwatch sw = Stopwatch.StartNew();
+                DumpRecords.Run(inputPaths, includeTotal, includeRollup, includeDetails);
+                Console.Error.WriteLine(sw.Elapsed);
                 return 0;
             }
 

--- a/src/StructuredLogger/BinaryLogger/BinaryLogRecord.cs
+++ b/src/StructuredLogger/BinaryLogger/BinaryLogRecord.cs
@@ -1,9 +1,11 @@
 ﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Logging.StructuredLogger;
 
 namespace Microsoft.Build.Logging
 {
     public class Record
     {
+        public BinaryLogRecordKind Kind;
         public byte[] Bytes;
         public BuildEventArgs Args;
         public long Start;

--- a/src/StructuredLogger/BinaryLogger/BinaryLogRecord.cs
+++ b/src/StructuredLogger/BinaryLogger/BinaryLogRecord.cs
@@ -11,4 +11,6 @@ namespace Microsoft.Build.Logging
         public long Start;
         public long Length;
     }
+
+    public readonly record struct RecordInfo(BinaryLogRecordKind Kind, long Start, long Length);
 }


### PR DESCRIPTION
Fixes #741

### Context
#741 brought a nice idea. I needed something similar for my investigation - just counts, not sizes - so I stitched something for both.

### Samples

Just summary on OrchardCore (runs for about 0.7s on my machine):

```
>binlogtool dumprecords OrchardCore.binlog --include-total --include-rollup --exclude-details

Total records: 1069320

RecordType, Count, Size[bytes]
==============================
Message, 568034, 38.46
NameValueList, 38359, 60.16
BuildStarted, 1, 12.00
ProjectEvaluationStarted, 417, 35.90
ProjectImported, 64414, 55.11
AssemblyLoad, 22, 55.59
PropertyReassignment, 23492, 41.90
ProjectEvaluationFinished, 417, 1912.71
ProjectStarted, 14300, 56.33
TargetStarted, 49962, 38.80
TaskStarted, 23227, 36.90
TaskFinished, 23227, 34.15
TargetFinished, 49962, 52.04
TaskParameter, 145155, 98.90
EnvironmentVariableRead, 792, 37.90
TargetSkipped, 53035, 58.53
ProjectFinished, 14300, 31.30
TaskCommandLine, 198, 40.51
Error, 5, 46.00
BuildFinished, 1, 14.00
```

Details for binlog from new console:

```
>binlogtool dumprecords

RecordType, Size[bytes]
=======================
Message, 50
Message, 50
NameValueList, 9
BuildStarted, 12
Message, 46
Message, 46
Message, 46
Message, 46
Message, 46
ProjectEvaluationStarted, 34
AssemblyLoad, 54
AssemblyLoad, 54
AssemblyLoad, 54
AssemblyLoad, 54
Message, 41
ProjectImported, 45
ProjectImported, 49
Message, 39
...
```

### Limitations

* Summaries won't run on broken binlogs (just the details list) - feels as acceptable limitation (broken binlogs should be less frequent and just a list of records untill the last complete should then suffice)
* The reported sizes for the new format do not include the record type and the offset itself - so there are 2 bytes per each record not reported (but I'd say that's how we want it)

### Breaking changes

* `BinLogReader.WrapperStream` was removed. It was public, but hopefully nobody was using it. If yes - they can easily switch to `TransparentReadStream`.

### Perf

Summary for OrchardCore runs ~0.178 seconds with the new binlogs (offsets included), ~1.967 seconds with old binlogs. Both after warmup runs.
On full details dumping the difference is not so visible, as majority of the time is spend flushing the records (it's ~56 vs ~58 seconds)
