### PR TITLE
Reintroduce removed public API

### DIFF
--- a/src/StructuredLogger/BinaryLog.cs
+++ b/src/StructuredLogger/BinaryLog.cs
@@ -27,7 +27,9 @@ namespace Microsoft.Build.Logging.StructuredLogger
             return reader.ReadRecords(binlogBytes);
         }
 
-        public static Build ReadBuild(string filePath, ReaderSettings readerSettings = null)
+        public static Build ReadBuild(string filePath) => ReadBuild(filePath, progress: null);
+        public static Build ReadBuild(string filePath, Progress progress) => ReadBuild(filePath, progress, readerSettings: null);
+        public static Build ReadBuild(string filePath, ReaderSettings readerSettings)
             => ReadBuild(filePath, progress: null, readerSettings);
 
         public static Build ReadBuild(string filePath, Progress progress, ReaderSettings readerSettings)
@@ -50,7 +52,8 @@ namespace Microsoft.Build.Logging.StructuredLogger
         public static Build ReadBuild(Stream stream, byte[] projectImportsArchive = null)
             => ReadBuild(stream, progress: null, projectImportsArchive: projectImportsArchive);
 
-        //UnknownDataBehavior
+        public static Build ReadBuild(Stream stream, Progress progress, byte[] projectImportsArchive = null)
+            => ReadBuild(stream, progress, projectImportsArchive, readerSettings: null);
 
         public static Build ReadBuild(
             Stream stream,

--- a/src/StructuredLogger/Serialization/Serialization.cs
+++ b/src/StructuredLogger/Serialization/Serialization.cs
@@ -49,6 +49,8 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
         public static Build Read(string filePath) => Read(filePath, progress: null, readerSettings: ReaderSettings.Default);
 
+        public static Build Read(string filePath, Progress progress) => Read(filePath, progress, readerSettings: ReaderSettings.Default);
+
         public static Build Read(string filePath, Progress progress, ReaderSettings readerSettings)
         {
             if (filePath.EndsWith(".xml", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
Fixes #746

### Context

Reintroducing removed `BinaryLog` and `Serialization` public methods.
There are other breaking changes in publicly exposed types/calls in the binlogtool - but I'd expect that to be rather used via CLI rather then API (so leaving as is now)