### PR TITLE
Add search menu for Top Expansive

### DIFF
--- a/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
@@ -42,6 +42,7 @@ namespace StructuredLogViewer.Controls
         private MenuItem viewSubtreeTextItem;
         private MenuItem searchInSubtreeItem;
         private MenuItem searchInNodeByNameItem;
+        private MenuItem searchThisNode;
         private MenuItem excludeSubtreeFromSearchItem;
         private MenuItem excludeNodeByNameFromSearch;
         private MenuItem goToTimeLineItem;
@@ -185,6 +186,7 @@ namespace StructuredLogViewer.Controls
             excludeSubtreeFromSearchItem = new MenuItem() { Header = "Exclude subtree from search" };
             excludeNodeByNameFromSearch = new MenuItem() { Header = "Exclude node from search" };
             searchInNodeByNameItem = new MenuItem() { Header = "Search in this node." };
+            searchThisNode = new MenuItem() { Header = "Search This Node" };
             goToTimeLineItem = new MenuItem() { Header = "Go to timeline" };
             goToTracingItem = new MenuItem() { Header = "Go to tracing" };
             copyChildrenItem = new MenuItem() { Header = "Copy children" };
@@ -217,6 +219,7 @@ namespace StructuredLogViewer.Controls
             excludeSubtreeFromSearchItem.Click += (s, a) => ExcludeSubtreeFromSearch();
             excludeNodeByNameFromSearch.Click += (s, a) => ExcludeNodeByNameFromSearch();
             searchInNodeByNameItem.Click += (s, a) => SearchInNodeByName();
+            searchThisNode.Click += (s, a) => SearchThisNode();
             goToTimeLineItem.Click += (s, a) => GoToTimeLine();
             goToTracingItem.Click += (s, a) => GoToTracing();
             copyChildrenItem.Click += (s, a) => CopyChildren();
@@ -243,6 +246,7 @@ namespace StructuredLogViewer.Controls
             contextMenu.AddItem(searchNuGetItem);
             contextMenu.AddItem(searchInSubtreeItem);
             contextMenu.AddItem(searchInNodeByNameItem);
+            contextMenu.AddItem(searchThisNode);
             contextMenu.AddItem(excludeSubtreeFromSearchItem);
             contextMenu.AddItem(excludeNodeByNameFromSearch);
             contextMenu.AddItem(goToTimeLineItem);
@@ -389,6 +393,7 @@ Right-clicking a project node may show the 'Preprocess' option if the version of
             excludeSubtreeFromSearchItem = null;
             excludeNodeByNameFromSearch = null;
             searchInNodeByNameItem = null;
+            searchThisNode = null;
             goToTimeLineItem = null;
             goToTracingItem = null;
             copyChildrenItem = null;
@@ -854,6 +859,16 @@ Recent (");
             runItem.Visibility = canRun;
             debugItem.Visibility = canRun;
             hideItem.Visibility = node is TreeNode ? Visibility.Visible : Visibility.Collapsed;
+
+            if (node is SearchableItem searchItem)
+            {
+                searchThisNode.Visibility = Visibility.Visible;
+                searchThisNode.Header = $"Search {searchItem.SearchText}";
+            }
+            else
+            {
+                searchThisNode.Visibility = Visibility.Collapsed;
+            }
 
             if (node is TimedNode timedNode)
             {
@@ -1565,6 +1580,15 @@ Recent (");
             if (treeView.SelectedItem is TimedNode treeNode)
             {
                 searchLogControl.SearchText += $" under(${treeNode.TypeName} {treeNode.Name})";
+                SelectSearchTab();
+            }
+        }
+
+        public void SearchThisNode()
+        {
+            if (treeView.SelectedItem is SearchableItem searchNode)
+            {
+                searchLogControl.SearchText = searchNode.SearchText;
                 SelectSearchTab();
             }
         }

--- a/src/StructuredLogViewer/Controls/TracingControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/TracingControl.xaml.cs
@@ -741,6 +741,10 @@ namespace StructuredLogViewer.Controls
                         var textBlock = new TextBlock();
                         textBlock.Text = $"{i}s";
 
+                        // Set these to make TextBlock scale like TrueType.
+                        textBlock.SnapsToDevicePixels = true;
+                        TextOptions.SetTextFormattingMode(textBlock, TextFormattingMode.Ideal);
+
                         // add textHeight/2 pixels of front padding
                         Canvas.SetLeft(textBlock, textHeight / 2 + i * OneSecondPixelWidth);
                         canvas.Children.Add(textBlock);

--- a/src/StructuredLogger/Analyzers/BuildAnalyzer.cs
+++ b/src/StructuredLogger/Analyzers/BuildAnalyzer.cs
@@ -231,16 +231,18 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 var top10Tasks = build.GetOrCreateNodeWithName<Folder>(folderName);
                 foreach (var kvp in durations)
                 {
-                    var taskItem = new Item
+                    var taskItem = new SearchableItem
                     {
-                        Text = Intern(kvp.Key) + " = " + Intern($"{TextUtilities.DisplayDuration(kvp.Value.Duration)}, {kvp.Value.Count} calls.")
+                        Text = Intern(kvp.Key) + " = " + Intern($"{TextUtilities.DisplayDuration(kvp.Value.Duration)}, {kvp.Value.Count} calls."),
+                        SearchText = $@"$task ""{kvp.Key}""",
                     };
                     var childNodes = kvp.Value.ChildNodes.OrderByDescending(kv => kv.Value.Duration).Take(10);
                     foreach (var durationNodes in childNodes)
                     {
-                        taskItem.AddChild(new Item
+                        taskItem.AddChild(new SearchableItem
                         {
-                            Text = Intern(durationNodes.Key) + " = " + Intern($"{TextUtilities.DisplayDuration(durationNodes.Value.Duration)}, {durationNodes.Value.Count} calls.")
+                            Text = Intern(durationNodes.Key) + " = " + Intern($"{TextUtilities.DisplayDuration(durationNodes.Value.Duration)}, {durationNodes.Value.Count} calls."),
+                            SearchText = $@"$target ""{durationNodes.Key}""",
                         });
                     }
                     top10Tasks.AddChild(taskItem);

--- a/src/StructuredLogger/ObjectModel/SearchableItem.cs
+++ b/src/StructuredLogger/ObjectModel/SearchableItem.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Build.Logging.StructuredLogger
+{
+    public class SearchableItem : Item
+    {
+        public SearchableItem() : base() { }
+
+        public string SearchText
+        {
+            get { return _searchText ?? this.Text; }
+            set { _searchText = value; }
+        }
+
+        private string _searchText;
+    }
+}


### PR DESCRIPTION
### Add a menu to quickly search in the "Top most expansive tasks"

<img width="287" alt="image" src="https://github.com/KirillOsenkov/MSBuildStructuredLog/assets/19828377/b8c2a01a-30a6-46d6-afe0-5e3e649cdd05">

### Fix type font when scaling
Before:
<img width="151" alt="image" src="https://github.com/KirillOsenkov/MSBuildStructuredLog/assets/19828377/991b080d-a05f-472c-a4f6-da9596792c2f">
After:
<img width="167" alt="image" src="https://github.com/KirillOsenkov/MSBuildStructuredLog/assets/19828377/72d12609-6390-4c9b-8985-b650f38c02f1">

