### PR TITLE
Fix StructuredLogViewer.Avalonia to work on source-build SDKs

### DIFF
--- a/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj
+++ b/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
-    <RuntimeIdentifiers>win7-x64;ubuntu.14.04-x64;osx.10.12-x64;osx-arm64</RuntimeIdentifiers>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <ApplicationIcon>StructuredLogger.ico</ApplicationIcon>
     <RestoreAdditionalProjectSources Condition="$(PublishNativeAot) == True">
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json;
@@ -41,7 +41,7 @@
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <!-- Bump transitive references to preview versions that contain osx-arm64 native assets -->
     <PackageReference Include="SkiaSharp" Version="2.88.6" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.6" Condition="$(NETCoreSdkRuntimeIdentifier.StartsWith('linux'))" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.6" Condition="$(NETCoreSdkPortableRuntimeIdentifier.StartsWith('linux'))" />
     <PackageReference Include="HarfBuzzSharp" Version="2.8.2-preview.187" />
     <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="7.0.0-*" Condition="$(PublishNativeAot) == True" />
   </ItemGroup>


### PR DESCRIPTION
- Move to .NET 8, since the code uses language features that do not work against .NET 7.0.1xx SDKs.

- Move to recommended portable runtime identifers instead of non-portable/OS-specific ones like ubuntu-14.04, or win7. .NET

- Take a dependency on SkiaSharp.NativeAssets.Linux for any Linux-based OS, even when using a source-build SDK.

Here's more details on the above:

I started trying to use this with a .NET 7 SDK on Fedora:

```
$ dotnet --info
.NET SDK:
 Version:   7.0.116
 Commit:    c19b61c549

Runtime Environment:
 OS Name:     fedora
 OS Version:  39
 OS Platform: Linux
 RID:         fedora.39-x64
 Base Path:   /usr/lib64/dotnet/sdk/7.0.116/

Host:
  Version:      7.0.16
  Architecture: x64
  Commit:       567edafe61

.NET SDKs installed:
  7.0.116 [/usr/lib64/dotnet/sdk]

.NET runtimes installed:
  Microsoft.AspNetCore.App 7.0.16 [/usr/lib64/dotnet/shared/Microsoft.AspNetCore.App]
  Microsoft.NETCore.App 7.0.16 [/usr/lib64/dotnet/shared/Microsoft.NETCore.App]

Other architectures found:
  None

Environment variables:
  DOTNET_ROOT       [/usr/lib64/dotnet]

global.json file:
  MSBuildStructuredLog/global.json

Learn more:
  https://aka.ms/dotnet/info

Download .NET:
  https://aka.ms/dotnet/download
```

And the viewer did not work for me:
  
 ``` 
$ ./run.sh
MSBuildStructuredLog/src/StructuredLogger/BinaryLogger/BinLogReader.cs(389,73): error CS0443: Syntax error; value expected [MSBuildStructuredLog/src/StructuredLogger/StructuredLogger.csproj]
MSBuildStructuredLog/src/StructuredLogger/BinaryLogger/BinLogReader.cs(389,75): error CS1002: ; expected [MSBuildStructuredLog/src/StructuredLogger/StructuredLogger.csproj]
MSBuildStructuredLog/src/StructuredLogger/BinaryLogger/BinLogReader.cs(389,75): error CS1513: } expected [MSBuildStructuredLog/src/StructuredLogger/StructuredLogger.csproj]
```

To get support for these language features, I tried installing and using .NET 8:

```
$ dotnet --info
.NET SDK:
 Version:           8.0.102
 Commit:            b7800db369
 Workload version:  8.0.100-manifests.03fa9662

Runtime Environment:
 OS Name:     fedora
 OS Version:  39
 OS Platform: Linux
 RID:         fedora.39-x64
 Base Path:   /usr/lib64/dotnet/sdk/8.0.102/

.NET workloads installed:
 Workload version: 8.0.100-manifests.03fa9662
There are no installed workloads to display.

Host:
  Version:      8.0.2
  Architecture: x64
  Commit:       1381d5ebd2

.NET SDKs installed:
  8.0.102 [/usr/lib64/dotnet/sdk]

.NET runtimes installed:
  Microsoft.AspNetCore.App 8.0.2 [/usr/lib64/dotnet/shared/Microsoft.AspNetCore.App]
  Microsoft.NETCore.App 8.0.2 [/usr/lib64/dotnet/shared/Microsoft.NETCore.App]

Other architectures found:
  None

Environment variables:
  DOTNET_ROOT       [/usr/lib64/dotnet]

global.json file:
  MSBuildStructuredLog/global.json

Learn more:
  https://aka.ms/dotnet/info

Download .NET:
  https://aka.ms/dotnet/download
```

But the application still did not work for me:  
  
```  
$ ./run.sh

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:05.80
You must install or update .NET to run this application.

App: MSBuildStructuredLog/bin/StructuredLogViewer.Avalonia/Debug/net7.0/StructuredLogViewer.Avalonia
Architecture: x64
Framework: 'Microsoft.NETCore.App', version '7.0.0' (x64)
.NET location: /usr/lib64/dotnet

The following frameworks were found:
  8.0.2 at [/usr/lib64/dotnet/shared/Microsoft.NETCore.App]

Learn more:
https://aka.ms/dotnet/app-launch-failed

To install missing framework, download:
https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=7.0.0&arch=x64&rid=fedora.39-x64&os=fedora.39
```

So I moved the project to .NET 8:

```diff
diff --git a/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj b/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj
index 2fad35d..4d81780 100644
--- a/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj
+++ b/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj
@@ -2,7 +2,7 @@

   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>^M
     <RuntimeIdentifiers>win7-x64;ubuntu.14.04-x64;osx.10.12-x64;osx-arm64</RuntimeIdentifiers>
     <ApplicationIcon>StructuredLogger.ico</ApplicationIcon>
     <RestoreAdditionalProjectSources Condition="$(PublishNativeAot) == True">
```

Trying to run the application again led to:

```
$ ./run.sh
/usr/lib64/dotnet/sdk/8.0.102/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets(90,5): error NETSDK1083: The specified RuntimeIdentifier 'win7-x64' is not recognized. See https://aka.ms/netsdk1083 for more information. [MSBuildStructuredLog/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj]
/usr/lib64/dotnet/sdk/8.0.102/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets(90,5): error NETSDK1083: The specified RuntimeIdentifier 'ubuntu.14.04-x64' is not recognized. See https://aka.ms/netsdk1083 for more information. [MSBuildStructuredLog/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj]
/usr/lib64/dotnet/sdk/8.0.102/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets(90,5): error NETSDK1083: The specified RuntimeIdentifier 'osx.10.12-x64' is not recognized. See https://aka.ms/netsdk1083 for more information. [MSBuildStructuredLog/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj]

Build FAILED.

/usr/lib64/dotnet/sdk/8.0.102/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets(90,5): error NETSDK1083: The specified RuntimeIdentifier 'win7-x64' is not recognized. See https://aka.ms/netsdk1083 for more information. [MSBuildStructuredLog/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj]
/usr/lib64/dotnet/sdk/8.0.102/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets(90,5): error NETSDK1083: The specified RuntimeIdentifier 'ubuntu.14.04-x64' is not recognized. See https://aka.ms/netsdk1083 for more information. [MSBuildStructuredLog/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj]
/usr/lib64/dotnet/sdk/8.0.102/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets(90,5): error NETSDK1083: The specified RuntimeIdentifier 'osx.10.12-x64' is not recognized. See https://aka.ms/netsdk1083 for more information. [MSBuildStructuredLog/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj]
    0 Warning(s)
    3 Error(s)

Time Elapsed 00:00:00.44

The build failed. Fix the build errors and run again.
```

So I fixed that that by moving to the portable RIDs:

```diff
diff --git a/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj b/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj
index 2fad35d..776706a 100644
--- a/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj
+++ b/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
-    <RuntimeIdentifiers>win7-x64;ubuntu.14.04-x64;osx.10.12-x64;osx-arm64</RuntimeIdentifiers>
+    <TargetFramework>net8.0</TargetFramework>^M
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;osx-arm64</RuntimeIdentifiers>^M
     <ApplicationIcon>StructuredLogger.ico</ApplicationIcon>
     <RestoreAdditionalProjectSources Condition="$(PublishNativeAot) == True">
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json;
```

Then I tried to run that:

```
$ ./run.sh 

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:01.08
Unhandled exception. System.TypeInitializationException: The type initializer for 'SkiaSharp.SKObject' threw an exception.
 ---> System.InvalidOperationException: The version of the native libSkiaSharp library (88.0) is incompatible with this version of SkiaSharp. Supported versions of the native libSkiaSharp library are in the range [88.1, 89.0).
   at SkiaSharp.SkiaSharpVersion.CheckNativeLibraryCompatible(Version minSupported, Version current, Boolean throwIfIncompatible)
   at SkiaSharp.SkiaSharpVersion.CheckNativeLibraryCompatible(Boolean throwIfIncompatible)
   at SkiaSharp.SKObject..cctor()
   --- End of inner exception stack trace ---
   at SkiaSharp.SKObject..ctor(IntPtr handle, Boolean owns)
   at SkiaSharp.GRGlInterface..ctor(IntPtr h, Boolean owns)
   at SkiaSharp.GRGlInterface.GetObject(IntPtr handle)
   at SkiaSharp.GRGlInterface.CreateOpenGl(GRGlGetProcedureAddressDelegate get)
   at Avalonia.Skia.GlSkiaGpu..ctor(IPlatformOpenGlInterface openGl, Nullable`1 maxResourceBytes) in /_/src/Skia/Avalonia.Skia/Gpu/OpenGl/GlSkiaGpu.cs:line 24
   at Avalonia.Skia.PlatformRenderInterface..ctor(ISkiaGpu skiaGpu, Nullable`1 maxResourceBytes) in /_/src/Skia/Avalonia.Skia/PlatformRenderInterface.cs:line 37
   at Avalonia.Skia.SkiaPlatform.Initialize(SkiaOptions options) in /_/src/Skia/Avalonia.Skia/SkiaPlatform.cs:line 20
   at Avalonia.SkiaApplicationExtensions.<>c__0`1.<UseSkia>b__0_0() in /_/src/Skia/Avalonia.Skia/SkiaApplicationExtensions.cs:line 20
   at Avalonia.Controls.AppBuilderBase`1.Setup() in /_/src/Avalonia.Controls/AppBuilderBase.cs:line 304
   at Avalonia.Controls.AppBuilderBase`1.SetupWithLifetime(IApplicationLifetime lifetime) in /_/src/Avalonia.Controls/AppBuilderBase.cs:line 179
   at Avalonia.ClassicDesktopStyleApplicationLifetimeExtensions.StartWithClassicDesktopLifetime[T](T builder, String[] args, ShutdownMode shutdownMode) in /_/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs:line 208
   at StructuredLogViewer.Avalonia.Program.Main(String[] args) in MSBuildStructuredLog/src/StructuredLogViewer.Avalonia/Program.cs:line 9
```

It looked like the SkiaSharp native dependency wasn't being added. I think this is because the non-portable SDK's RuntimeIdentifier isn't Linux. So I switched the conditional to compare with the portable RID:

```diff
diff --git a/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj b/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj
index 2fad35d..12a0277 100644
--- a/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj
+++ b/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
-    <RuntimeIdentifiers>win7-x64;ubuntu.14.04-x64;osx.10.12-x64;osx-arm64</RuntimeIdentifiers>
+    <TargetFramework>net8.0</TargetFramework>^M
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;osx-arm64</RuntimeIdentifiers>^M
     <ApplicationIcon>StructuredLogger.ico</ApplicationIcon>
     <RestoreAdditionalProjectSources Condition="$(PublishNativeAot) == True">
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json;
@@ -41,7 +41,7 @@
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <!-- Bump transitive references to preview versions that contain osx-arm64 native assets -->
     <PackageReference Include="SkiaSharp" Version="2.88.6" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.6" Condition="$(NETCoreSdkRuntimeIdentifier.StartsWith('linux'))" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.6" Condition="$(NETCoreSdkPortableRuntimeIdentifier.StartsWith('linux'))" />^M
     <PackageReference Include="HarfBuzzSharp" Version="2.8.2-preview.187" />
     <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="7.0.0-*" Condition="$(PublishNativeAot) == True" />
   </ItemGroup>
  
```

And then `./run.sh` worked :tada: 