### PR TITLE
Adjust messaging of compatibility mode

### DIFF
--- a/src/StructuredLogger/BinaryLog.cs
+++ b/src/StructuredLogger/BinaryLog.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
             if (errorByType.Any(i => i != 0))
             {
                 string summary = string.Join(", ", errorByType.Where((count, index) => count > 0).Select((count, index) => $"{((ReaderErrorType)index)}: {count}"));
-                string message = $"{errorByType.Sum()} reading errors encountered ({summary}) - unknown data was skipped in current compatibility mode.";
+                string message = $"Skipped some data unknown to this version of Viewer. {errorByType.Sum()} case{(errorByType.Sum() > 1 ? "s" : string.Empty)} encountered ({summary}).";
 
                 TreeNode node = readerSettings.UnknownDataBehavior switch
                 {
@@ -176,7 +176,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
                     _ => throw new ArgumentOutOfRangeException(nameof(readerSettings.UnknownDataBehavior), readerSettings.UnknownDataBehavior, "Unexpected value")
                 };
 
-                build.AddChildAtBeginning(node);
+                build.AddChild(node);
             }
 
             return build;

--- a/src/StructuredLogger/ReaderSettings.cs
+++ b/src/StructuredLogger/ReaderSettings.cs
@@ -6,7 +6,7 @@
     public class ReaderSettings
     {
         public static ReaderSettings Default { get; } =
-            new() { UnknownDataBehavior = UnknownDataBehavior.Error };
+            new() { UnknownDataBehavior = UnknownDataBehavior.Warning };
 
         /// <summary>
         /// Indication of how the unknown data in future versions of binlogs should be handled.


### PR DESCRIPTION
### Context

Adjusting the messaging, and its perceived severity, when compatibility mode kicks in.
In reality - skipping new event types/ properties - isn't realy an error, just a case of missing visualisation of some newly added diagnostic info.

This is just proposal - any alternative visualisation or wording suggestions are very welcome. I'm not very creative :-)

### Proposed UX

![image](https://github.com/KirillOsenkov/MSBuildStructuredLog/assets/3809076/95d49e90-ae0b-4d9e-85b3-03109dc2eab9)


FYI @ladipro, @rokonec 