### PR TITLE
Group Context Menu

### DIFF
--- a/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
@@ -35,6 +35,9 @@ namespace StructuredLogViewer.Controls
         private PreprocessedFileManager preprocessedFileManager;
         private NavigationHelper navigationHelper;
 
+        private MenuItem searchMenuGroup;
+        private MenuItem copyMenuGroup;
+        private MenuItem gotoMenuGroup;
         private MenuItem copyItem;
         private MenuItem copySubtreeItem;
         private MenuItem viewSubtreeTextItem;
@@ -190,6 +193,10 @@ namespace StructuredLogViewer.Controls
             // Build Log
             var contextMenu = new ContextMenu();
             contextMenu.Opened += ContextMenu_Opened;
+            searchMenuGroup = new() { Header = "Search ..." };
+            copyMenuGroup = new() { Header = "Copy ..." };
+            gotoMenuGroup = new() { Header = "Go to ..." };
+
             copyItem = new MenuItem() { Header = "Copy" };
             copySubtreeItem = new MenuItem() { Header = "Copy subtree" };
             viewSubtreeTextItem = new MenuItem() { Header = "View subtree text" };
@@ -198,8 +205,8 @@ namespace StructuredLogViewer.Controls
             excludeNodeByNameFromSearch = new MenuItem() { Header = "Exclude node from search" };
             searchInNodeByNameItem = new MenuItem() { Header = "Search in this node." };
             searchThisNode = new MenuItem() { Header = "Search This Node" };
-            goToTimeLineItem = new MenuItem() { Header = "Go to timeline" };
-            goToTracingItem = new MenuItem() { Header = "Go to tracing" };
+            goToTimeLineItem = new MenuItem() { Header = "Timeline" };
+            goToTracingItem = new MenuItem() { Header = "Tracing" };
             copyChildrenItem = new MenuItem() { Header = "Copy children" };
             sortChildrenItem = new MenuItem() { Header = "Sort children" };
             filterChildrenItem = new MenuItem() { Header = "Filter children (Ctrl+F)" };
@@ -261,25 +268,28 @@ namespace StructuredLogViewer.Controls
             contextMenu.AddItem(viewSourceItem);
             contextMenu.AddItem(viewFullTextItem);
             contextMenu.AddItem(openFileItem);
-            contextMenu.AddItem(preprocessItem);
-            contextMenu.AddItem(searchNuGetItem);
-            contextMenu.AddItem(searchInSubtreeItem);
-            contextMenu.AddItem(searchInNodeByNameItem);
-            contextMenu.AddItem(searchThisNode);
-            contextMenu.AddItem(excludeSubtreeFromSearchItem);
-            contextMenu.AddItem(excludeNodeByNameFromSearch);
-            contextMenu.AddItem(goToTimeLineItem);
-            contextMenu.AddItem(goToTracingItem);
-            contextMenu.AddItem(copyItem);
-            contextMenu.AddItem(copySubtreeItem);
-            contextMenu.AddItem(copyFilePathItem);
-            contextMenu.AddItem(viewSubtreeTextItem);
-            contextMenu.AddItem(copyChildrenItem);
+            gotoMenuGroup.AddItem(preprocessItem);
+            contextMenu.AddItem(searchMenuGroup);
+            searchMenuGroup.AddItem(searchNuGetItem);
+            searchMenuGroup.AddItem(searchInSubtreeItem);
+            searchMenuGroup.AddItem(searchInNodeByNameItem);
+            searchMenuGroup.AddItem(searchThisNode);
+            searchMenuGroup.AddItem(excludeSubtreeFromSearchItem);
+            searchMenuGroup.AddItem(excludeNodeByNameFromSearch);
+            contextMenu.AddItem(gotoMenuGroup);
+            gotoMenuGroup.AddItem(goToTimeLineItem);
+            gotoMenuGroup.AddItem(goToTracingItem);
+            contextMenu.AddItem(copyMenuGroup);
+            copyMenuGroup.AddItem(copyItem);
+            copyMenuGroup.AddItem(copySubtreeItem);
+            copyMenuGroup.AddItem(copyFilePathItem);
+            gotoMenuGroup.AddItem(viewSubtreeTextItem);
+            copyMenuGroup.AddItem(copyChildrenItem);
             contextMenu.AddItem(sortChildrenItem);
             contextMenu.AddItem(filterChildrenItem);
-            contextMenu.AddItem(copyNameItem);
-            contextMenu.AddItem(copyValueItem);
-            contextMenu.AddItem(showTimeItem);
+            copyMenuGroup.AddItem(copyNameItem);
+            copyMenuGroup.AddItem(copyValueItem);
+            gotoMenuGroup.AddItem(showTimeItem);
             contextMenu.AddItem(hideItem);
 
             var treeViewItemStyle = TreeViewExtensions.CreateTreeViewItemStyleWithEvents<BaseNode, TreeViewItem>();
@@ -870,9 +880,9 @@ Recent (");
         private void ContextMenu_Opened(object sender, RoutedEventArgs e)
         {
             var node = treeView.SelectedItem as BaseNode;
-            var visibility = node is NameValueNode ? Visibility.Visible : Visibility.Collapsed;
-            copyNameItem.Visibility = visibility;
-            copyValueItem.Visibility = visibility;
+            var nameValueVisibility = node is NameValueNode ? Visibility.Visible : Visibility.Collapsed;
+            copyNameItem.Visibility = nameValueVisibility;
+            copyValueItem.Visibility = nameValueVisibility;
             viewSourceItem.Visibility = CanView(node) ? Visibility.Visible : Visibility.Collapsed;
             viewFullTextItem.Visibility = HasFullText(node) ? Visibility.Visible : Visibility.Collapsed;
             openFileItem.Visibility = CanOpenFile(node) ? Visibility.Visible : Visibility.Collapsed;
@@ -937,6 +947,15 @@ Recent (");
                 excludeNodeByNameFromSearch.Visibility = Visibility.Collapsed;
                 searchInNodeByNameItem.Visibility = Visibility.Collapsed;
             }
+
+            searchMenuGroup.Visibility = searchMenuGroup.Items.Cast<MenuItem>().Any(p => p.Visibility != Visibility.Collapsed) ?
+                Visibility.Visible : Visibility.Collapsed;
+
+            copyMenuGroup.Visibility = copyMenuGroup.Items.Cast<MenuItem>().Any(p => p.Visibility != Visibility.Collapsed) ?
+                Visibility.Visible : Visibility.Collapsed;
+
+            gotoMenuGroup.Visibility = gotoMenuGroup.Items.Cast<MenuItem>().Any(p => p.Visibility != Visibility.Collapsed) ?
+                Visibility.Visible : Visibility.Collapsed;
         }
 
         private void SharedTreeContextMenu_Opened(object sender, RoutedEventArgs e)

--- a/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
@@ -193,9 +193,9 @@ namespace StructuredLogViewer.Controls
             // Build Log
             var contextMenu = new ContextMenu();
             contextMenu.Opened += ContextMenu_Opened;
-            searchMenuGroup = new() { Header = "Search ..." };
-            copyMenuGroup = new() { Header = "Copy ..." };
-            gotoMenuGroup = new() { Header = "Go to ..." };
+            searchMenuGroup = new() { Header = "Search" };
+            copyMenuGroup = new() { Header = "Copy" };
+            gotoMenuGroup = new() { Header = "Go to" };
 
             copyItem = new MenuItem() { Header = "Copy" };
             copySubtreeItem = new MenuItem() { Header = "Copy subtree" };

--- a/src/StructuredLogViewer/Controls/TracingControl.xaml
+++ b/src/StructuredLogViewer/Controls/TracingControl.xaml
@@ -13,7 +13,7 @@
                 <MenuItem Header="{Binding Path=ShowProjectsText, Mode=OneWay}" IsCheckable="true" IsChecked="{Binding Path=ShowProject , Mode=TwoWay}" StaysOpenOnClick="true"/>
                 <MenuItem Header="{Binding Path=ShowTargetsText, Mode=OneWay}" IsCheckable="true" IsChecked="{Binding Path=ShowTarget , Mode=TwoWay}" StaysOpenOnClick="true"/>
                 <MenuItem Header="{Binding Path=ShowTasksText, Mode=OneWay}" IsCheckable="true" IsChecked="{Binding Path=ShowTask , Mode=TwoWay}" StaysOpenOnClick="true"/>
-                <MenuItem Header="More...">
+                <MenuItem Header="More">
                     <MenuItem Header="{Binding Path=ShowCppText, Mode=OneWay}" IsCheckable="true" IsChecked="{Binding Path=ShowCpp , Mode=TwoWay}" StaysOpenOnClick="true"/>
                     <MenuItem Header="Show P2P on Selection" IsCheckable="true" IsChecked="{Binding Path=ShowProjectReferenceSelection , Mode=TwoWay}" StaysOpenOnClick="true"/>
                     <MenuItem Header="{Binding Path=ShowNodesText, Mode=OneWay}" IsCheckable="true" IsChecked="{Binding Path=ShowNodes , Mode=TwoWay}" StaysOpenOnClick="true"/>

--- a/src/StructuredLogger/Analyzers/CppAnalyzer.cs
+++ b/src/StructuredLogger/Analyzers/CppAnalyzer.cs
@@ -83,7 +83,6 @@ namespace Microsoft.Build.Logging.StructuredLogger
         private bool globalLinkTime = false;
 
         private TimeSpan oneMilliSecond = TimeSpan.FromMilliseconds(1);
-        private static HashSet<string> hashCppTasks = new HashSet<string>() { MultiToolTaskName, CLTaskName, LinkTaskName, LibTaskName };
         private List<CppTimedNode> resultTimedNode = new List<CppTimedNode>();
 
         public CppAnalyzer()

--- a/src/StructuredLogger/ObjectModel/TextNode.cs
+++ b/src/StructuredLogger/ObjectModel/TextNode.cs
@@ -4,7 +4,8 @@
     {
         public string Text { get; set; }
         public string ShortenedText => TextUtilities.ShortenValue(Text);
-        public bool IsTextShortened => Text.Length != TextUtilities.GetShortenLength(Text);
+        public bool IsTextShortened => Text != null && Text.Length != TextUtilities.GetShortenLength(Text);
+
 
         public override string TypeName => nameof(TextNode);
         public override string Title => Text ?? TypeName;

--- a/src/StructuredLogger/ObjectModel/TextNode.cs
+++ b/src/StructuredLogger/ObjectModel/TextNode.cs
@@ -4,7 +4,7 @@
     {
         public string Text { get; set; }
         public string ShortenedText => TextUtilities.ShortenValue(Text);
-        public bool IsTextShortened => Text != ShortenedText;
+        public bool IsTextShortened => Text.Length != TextUtilities.GetShortenLength(Text);
 
         public override string TypeName => nameof(TextNode);
         public override string Title => Text ?? TypeName;

--- a/src/StructuredLogger/TextUtilities.cs
+++ b/src/StructuredLogger/TextUtilities.cs
@@ -287,6 +287,32 @@ namespace Microsoft.Build.Logging.StructuredLogger
         public const int MaxDisplayedValueLength = 260;
         private const string TrimPrompt = "... (Space: view, Ctrl+C: copy)";
 
+        public static int GetShortenLength(string text, int maxChars = MaxDisplayedValueLength)
+        {
+            if (text == null)
+            {
+                return 0;
+            }
+
+            int lineBreak = text.IndexOfFirstLineBreak();
+            if (lineBreak != -1)
+            {
+                if (lineBreak < maxChars)
+                {
+                    return lineBreak;
+                }
+            }
+            else
+            {
+                if (text.Length <= maxChars)
+                {
+                    return text.Length;
+                }
+            }
+
+            return maxChars;
+        }
+
         public static string ShortenValue(string text, string trimPrompt = TrimPrompt, int maxChars = MaxDisplayedValueLength)
         {
             if (text == null)
@@ -294,31 +320,21 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 return text;
             }
 
-            int newLength = maxChars;
-            int lineBreak = text.IndexOfFirstLineBreak();
-            if (lineBreak == -1)
+            int newLength = GetShortenLength(text, maxChars);
+
+            if (text.Length != newLength)
             {
-                if (text.Length <= newLength)
+                var shortText = text.Substring(0, newLength);
+
+                if (maxChars <= newLength && IsWhitespace(text, new Span(newLength, text.Length - newLength)))
                 {
-                    return text;
+                    return shortText + '\u21b5';
                 }
-            }
-            else
-            {
-                if (lineBreak < newLength)
-                {
-                    newLength = lineBreak;
-                }
+
+                return shortText + trimPrompt;
             }
 
-            var shortText = text.Substring(0, newLength);
-
-            if (lineBreak == newLength && IsWhitespace(text, new Span(newLength, text.Length - newLength)))
-            {
-                return shortText + '\u21b5';
-            }
-
-            return shortText + trimPrompt;
+            return text;
         }
 
         public static int IndexOfFirstLineBreak(this string text)

--- a/src/StructuredLogger/TextUtilities.cs
+++ b/src/StructuredLogger/TextUtilities.cs
@@ -326,7 +326,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
             {
                 var shortText = text.Substring(0, newLength);
 
-                if (maxChars <= newLength && IsWhitespace(text, new Span(newLength, text.Length - newLength)))
+                if (newLength <= maxChars && IsWhitespace(text, new Span(newLength, text.Length - newLength)))
                 {
                     return shortText + '\u21b5';
                 }


### PR DESCRIPTION
## Consolidate the Context Menu into groups.
The context menu doubled in length.  This change will group common menus into themes, shortening the context menu without removing functionality.

<details><summary>Before</summary>
<img width="230" alt="image" src="https://github.com/KirillOsenkov/MSBuildStructuredLog/assets/19828377/bfb90e4d-b6ee-4e36-b2b7-a3ce36e7123a">
</details> 
<details><summary>After</summary>
<img width="385" alt="image" src="https://github.com/KirillOsenkov/MSBuildStructuredLog/assets/19828377/abd2b125-4ab1-4a7f-9eb9-0296ea43eb94">
</details> 

## Small optimization in ShortenText
 - Fix an adding the TrimPrompt when not trimmed.