### PR TITLE
Add support for improved TaskParameterEventArgs

### DIFF
--- a/src/StructuredLogger/BinaryLog.cs
+++ b/src/StructuredLogger/BinaryLog.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
             if (errorByType.Any(i => i != 0))
             {
-                string summary = string.Join(", ", errorByType.Where((count, index) => count > 0).Select((count, index) => $"{((ReaderErrorType)index)}: {count}"));
+                string summary = string.Join(", ", errorByType.Where((count, index) => count > 0).Select((count, index) => $"{((ReaderErrorType)index)}: {count} cases"));
                 string message = $"Skipped some data unknown to this version of Viewer. {errorByType.Sum()} case{(errorByType.Sum() > 1 ? "s" : string.Empty)} encountered ({summary}).";
 
                 TreeNode node = readerSettings.UnknownDataBehavior switch

--- a/src/StructuredLogger/BinaryLogger/BinaryLogger.cs
+++ b/src/StructuredLogger/BinaryLogger/BinaryLogger.cs
@@ -69,6 +69,8 @@ namespace Microsoft.Build.Logging.StructuredLogger
         //   - GeneratedFileUsedEventArgs exposed for brief period of time (so let's continue with 20)
         // version 20:
         //   - TaskStartedEventArgs: Added TaskAssemblyLocation property
+        // version 21:
+        //   - TaskParameterEventArgs: Added ParameterName and PropertyName properties
 
         // This should be never changed.
         // The minimum version of the binary log reader that can read log of above version.
@@ -76,7 +78,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
         // The current version of the binary log representation.
         // Changes with each update of the binary log format.
-        internal const int FileFormatVersion = 20;
+        internal const int FileFormatVersion = 21;
         // The minimum version of the binary log reader that can read log of above version.
         // This should be changed only when the binary log format is changed in a way that would prevent it from being
         // read by older readers. (changing of the individual BuildEventArgs or adding new is fine - as reader can

--- a/src/StructuredLogger/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/StructuredLogger/BinaryLogger/BuildEventArgsReader.cs
@@ -1149,10 +1149,15 @@ namespace Microsoft.Build.Logging.StructuredLogger
             var kind = (TaskParameterMessageKind)ReadInt32();
             var itemType = ReadDeduplicatedString() ?? "N/A";
             var items = ReadTaskItemList() as IList ?? Array.Empty<ITaskItem>();
+            var (parameterName, propertyName) = _fileFormatVersion >= 21
+                ? (ReadDeduplicatedString(), ReadDeduplicatedString())
+                : (null, null);
 
             var e = ItemGroupLoggingHelper.CreateTaskParameterEventArgs(
                 fields.BuildEventContext,
                 kind,
+                parameterName,
+                propertyName,
                 itemType,
                 items,
                 logItemMetadata: true,

--- a/src/StructuredLogger/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/StructuredLogger/BinaryLogger/BuildEventArgsWriter.cs
@@ -589,6 +589,11 @@ namespace Microsoft.Build.Logging.StructuredLogger
             Write((int)e.Kind);
             WriteDeduplicatedString(e.ItemType);
             WriteTaskItemList(e.Items, e.LogItemMetadata);
+
+            TaskParameterEventArgs2 taskParameters2 = e as TaskParameterEventArgs2;
+            WriteDeduplicatedString(taskParameters2?.ParameterName);
+            WriteDeduplicatedString(taskParameters2?.PropertyName);
+
             if (e.Kind == TaskParameterMessageKind.AddItem
                 || e.Kind == TaskParameterMessageKind.TaskOutput)
             {

--- a/src/StructuredLogger/BinaryLogger/TaskParameterEventArgs2.cs
+++ b/src/StructuredLogger/BinaryLogger/TaskParameterEventArgs2.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections;
+
+namespace Microsoft.Build.Framework
+{
+    public class TaskParameterEventArgs2 : TaskParameterEventArgs
+    {
+        public TaskParameterEventArgs2(
+            TaskParameterMessageKind kind,
+            string parameterName,
+            string propertyName,
+            string itemType,
+            IList items,
+            bool logItemMetadata,
+            DateTime eventTimestamp)
+            : base(kind, itemType, items, logItemMetadata, eventTimestamp)
+        {
+            ParameterName = parameterName;
+            PropertyName = propertyName;
+        }
+
+        // Added in MSBuild 17.11
+        public string ParameterName { get; set; }
+        public string PropertyName { get; set; }
+
+        // the properties in the base class have an internal setter
+        public new int LineNumber { get; set; }
+        public new int ColumnNumber { get; set; }
+    }
+}

--- a/src/StructuredLogger/BinaryLogger/Utilities.cs
+++ b/src/StructuredLogger/BinaryLogger/Utilities.cs
@@ -2,10 +2,8 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using Microsoft.Build.Framework;
-using Microsoft.Build.Logging.StructuredLogger;
 
 namespace Microsoft.Build.BackEnd
 {
@@ -14,6 +12,8 @@ namespace Microsoft.Build.BackEnd
         internal static TaskParameterEventArgs CreateTaskParameterEventArgs(
             BuildEventContext buildEventContext,
             TaskParameterMessageKind messageKind,
+            string parameterName,
+            string propertyName,
             string itemType,
             IList items,
             bool logItemMetadata,
@@ -21,27 +21,18 @@ namespace Microsoft.Build.BackEnd
             int line,
             int column)
         {
-            var args = new TaskParameterEventArgs(
+            var args = new TaskParameterEventArgs2(
                 messageKind,
+                parameterName,
+                propertyName,
                 itemType,
                 items,
                 logItemMetadata,
                 timestamp);
             args.BuildEventContext = buildEventContext;
 
-            if (line != 0)
-            {
-                Reflector.SetLineNumber(args, line);
-            }
-
-            if (column != 0)
-            {
-                Reflector.SetColumnNumber(args, column);
-            }
-
-            // Should probably make these public
-            // args.LineNumber = line;
-            // args.ColumnNumber = column;
+            args.LineNumber = line;
+            args.ColumnNumber = column;
             return args;
         }
     }

--- a/src/StructuredLogger/Reflector.cs
+++ b/src/StructuredLogger/Reflector.cs
@@ -71,18 +71,6 @@ namespace Microsoft.Build.Logging.StructuredLogger
             timeStampSetter(args, timestamp);
         }
 
-        private static Action<BuildMessageEventArgs, int> lineNumberSetter = GetFieldSetter<BuildMessageEventArgs, int>("lineNumber");
-        public static void SetLineNumber(BuildMessageEventArgs args, int lineNumber)
-        {
-            lineNumberSetter(args, lineNumber);
-        }
-
-        private static Action<BuildMessageEventArgs, int> columnNumberSetter = GetFieldSetter<BuildMessageEventArgs, int>("columnNumber");
-        public static void SetColumnNumber(BuildMessageEventArgs args, int columnNumber)
-        {
-            columnNumberSetter(args, columnNumber);
-        }
-
         private static MethodInfo enumerateItemsPerType;
         public static MethodInfo GetEnumerateItemsPerTypeMethod(Type itemDictionary)
         {


### PR DESCRIPTION
https://github.com/dotnet/msbuild/pull/10130 is making MSBuild log `TaskParameterEventArgs` for all task parameters, including all output parameters. This PR adds support for this format change to the viewer.

## Changes

- Bumped the current format version and implemented the corresponding (de)serialization.
- Updated task parameter processing to expect `TaskParameterEventArgs` used for all parameters.
- Updated the presentation of output parameters (up for discussion, details below).

## Testing

- Old binlog with new viewer - no changes.

- New binlog with old viewer - shows the `Skipped some data unknown to this version ...` warning and misplaces output parameters assigned to properties. They are incorrectly displayed under `OutputItems` with `N/A` name.

![image](https://github.com/KirillOsenkov/MSBuildStructuredLog/assets/12206368/1516c91b-5eca-4160-8110-7b81fcd43f29)

This is assumed to be an acceptable break for users who haven't updated to the new version.

- New binlog with new viewer - newly shows the name of the task parameter.

![image](https://github.com/KirillOsenkov/MSBuildStructuredLog/assets/12206368/7847d43d-85bb-4519-a7e2-c325ba9e6c4a)

This is just a quick proof-of-concept as I'm not sure what the best way of presenting this data is or if there's appetite for enriching the UI at all. We could certainly not show the parameter name anywhere for now.