### PR TITLE
Suggesting target skipped rewording

### DIFF
--- a/src/StructuredLogger/BinaryLogger/BuildEventArgsReader.Viewer.cs
+++ b/src/StructuredLogger/BinaryLogger/BuildEventArgsReader.Viewer.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
                 TargetSkipReason.ConditionWasFalse =>
                     FormatResourceStringIgnoreCodeAndKeyword(
-                        "Target \"{0}\" skipped, due to false condition; ({1}) was evaluated as ({2}).",
+                        "Target \"{0}\" execution and ordering skipped, due to false condition; ({1}) was evaluated as ({2}).",
                         targetName,
                         condition,
                         evaluatedCondition),


### PR DESCRIPTION
### Context

Saw a case of a customer confused by target seemingly not being properly ordered. A simplified repro:

![image](https://github.com/KirillOsenkov/MSBuildStructuredLog/assets/3809076/1ac970a8-b106-464e-acd1-d6e3e1699f74)

```xml
<Project DefaultTargets="Target2">
    <Target Name="Target3" BeforeTargets="Target2">
       <Message Text="Target3 executed" Importance="High" />
    </Target>
  
    <Target Name="Target2" Condition="'A' != 'A'">
       <Message Text="Target2 executed" Importance="High" />
    </Target>
</Project>
```

Basically - since target execution is skipped, the ordering is skipped as well (as it doesn't matter in which order is the target skipped). But when looking on a binlog in can feel confusing why the ordering info doesn't seem to match

### Additional notes

I want this as a base for discussion - whether we want to indicate the case in a binlog somehow at all. And if yes - where.
The current proposal might be too broad (possibly irelevant to many cases as there would be no ordering requested).
I do not have a good idea or strong opinion how to surface the info to users - I just feel it would be helpful to surface it