### PR TITLE
Fix selection background color in Avalonia build

### DIFF
--- a/src/StructuredLogViewer.Avalonia/Styles.xaml
+++ b/src/StructuredLogViewer.Avalonia/Styles.xaml
@@ -1,4 +1,4 @@
-﻿<Styles xmlns="https://github.com/avaloniaui"
+<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:structuredLogger="clr-namespace:Microsoft.Build.Logging.StructuredLogger;assembly=StructuredLogger"
         xmlns:converters="clr-namespace:Avalonia.Controls.Converters;assembly=Avalonia.Controls"
@@ -66,7 +66,7 @@
         <Setter Property="Template">
             <ControlTemplate>
                 <StackPanel>
-                    <Border Name="SelectionBorder"
+                    <Border Name="PART_LayoutRoot"
                             Focusable="True"
                             Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"


### PR DESCRIPTION
The selection was black-on-white in the main tree view, which was not ideal when most of the text is black-on-white. This fixes it to inherit colors from the Avalonia base styles:

<img width="1306" alt="image" src="https://github.com/user-attachments/assets/be34ab45-8e8f-4d2b-9084-2257c4870857">

(blue for selection, gray for hover)