### PR TITLE
Fix use of server GC for .NET 8 build

### DIFF
--- a/src/StructuredLogViewer/StructuredLogViewer.csproj
+++ b/src/StructuredLogViewer/StructuredLogViewer.csproj
@@ -13,6 +13,7 @@
     <Product>MSBuild Structured Log Viewer</Product>
     <AssemblyTitle>MSBuild Structured Log Viewer</AssemblyTitle>
     <ApplicationManifest>app.manifest</ApplicationManifest>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net472'">


### PR DESCRIPTION
Here's what top-level CPU consumption looks like in a run with the netfx build up until it's done reading the input:
<img width="1454" alt="image" src="https://github.com/user-attachments/assets/d4e82014-66d6-48c4-b887-8b94b9625e91">
It's using server GC, thanks to:
https://github.com/KirillOsenkov/MSBuildStructuredLog/blob/2744686ed557d48d386dd529d824c68ae0c5b5dd/src/StructuredLogViewer/App.config#L15

Here's what it looks like on core before this change:
<img width="1448" alt="image" src="https://github.com/user-attachments/assets/2258b981-d8de-4280-9724-5c0ff5d3d47f">
It doesn't respect that app.config, hence using workstation GC. Note it's flat, pegging only a single core, rather than utilizing more, due to being bottlenecked on GC.

Now with the one-line fix:
<img width="1424" alt="image" src="https://github.com/user-attachments/assets/d9f90202-1f99-4ba1-8613-792be22b6ac2">
