### PR TITLE
Remove some low-hanging fruit allocation

### DIFF
--- a/src/BinlogTool/ListTools.cs
+++ b/src/BinlogTool/ListTools.cs
@@ -48,7 +48,7 @@ namespace BinlogTool
                 return null;
             }
 
-            var sourceCommitId = environment.FindChild<Property>(p => p.Name == "SOURCECOMMITID");
+            var sourceCommitId = environment.FindChild<Property>(static p => p.Name == "SOURCECOMMITID");
             if (sourceCommitId != null)
             {
                 return sourceCommitId.Value;
@@ -83,7 +83,7 @@ namespace BinlogTool
 
             if (task.Name == "Exec")
             {
-                var args = task.FindChild<Property>(p => p.Name == "CommandLineArguments");
+                var args = task.FindChild<Property>(static p => p.Name == "CommandLineArguments");
                 string arguments = null;
 
                 if (args == null)
@@ -91,7 +91,7 @@ namespace BinlogTool
                     var parameters = task.FindChild<Folder>("Parameters");
                     if (parameters != null)
                     {
-                        var command = parameters.FindChild<Property>(p => p.Name == "Command");
+                        var command = parameters.FindChild<Property>(static p => p.Name == "Command");
                         if (command != null)
                         {
                             arguments = command.Value;
@@ -124,7 +124,7 @@ namespace BinlogTool
                 return null;
             }
 
-            var assembly = task.FindChild<Property>(p => p.Name == "Assembly");
+            var assembly = task.FindChild<Property>(static p => p.Name == "Assembly");
             if (assembly == null)
             {
                 return null;
@@ -141,7 +141,7 @@ namespace BinlogTool
                 return null;
             }
 
-            var versionMessage = task.FindChild<Message>(m => m.Text is string message &&
+            var versionMessage = task.FindChild<Message>(static m => m.Text is string message &&
                 message.Length < 200 &&
                 !message.Contains("\n") &&
                 !message.Contains("Leaving it untouched") &&

--- a/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
@@ -2665,7 +2665,7 @@ Recent (");
                 return;
             }
 
-            var statsRoot = Build.FindChild<Folder>(f => f.Name.StartsWith(Strings.Statistics));
+            var statsRoot = Build.FindChild<Folder>(static f => f.Name.StartsWith(Strings.Statistics));
             if (statsRoot != null)
             {
                 return;
@@ -2778,9 +2778,9 @@ Recent (");
 
         private void DisplayTreeStats(Folder statsRoot, BuildStatistics treeStats, BinlogStats recordStats)
         {
-            var buildMessageNode = statsRoot.FindChild<Folder>(n => n.Name.StartsWith("BuildMessage", StringComparison.Ordinal));
-            var taskInputsNode = buildMessageNode.FindChild<Folder>(n => n.Name.StartsWith("Task Input", StringComparison.Ordinal));
-            var taskOutputsNode = buildMessageNode.FindChild<Folder>(n => n.Name.StartsWith("Task Output", StringComparison.Ordinal));
+            var buildMessageNode = statsRoot.FindChild<Folder>(static n => n.Name.StartsWith("BuildMessage", StringComparison.Ordinal));
+            var taskInputsNode = buildMessageNode.FindChild<Folder>(static n => n.Name.StartsWith("Task Input", StringComparison.Ordinal));
+            var taskOutputsNode = buildMessageNode.FindChild<Folder>(static n => n.Name.StartsWith("Task Output", StringComparison.Ordinal));
 
             AddTopTasks(treeStats.TaskParameterMessagesByTask, taskInputsNode);
             AddTopTasks(treeStats.OutputItemMessagesByTask, taskOutputsNode);

--- a/src/StructuredLogger/Analyzers/FileCopyMap.cs
+++ b/src/StructuredLogger/Analyzers/FileCopyMap.cs
@@ -256,7 +256,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 var task = target.FindChild<MSBuildTask>();
                 if (task != null)
                 {
-                    var outputItems = task.FindLastChild<Folder>(f => f.Name == "OutputItems");
+                    var outputItems = task.FindLastChild<Folder>(static f => f.Name == "OutputItems");
                     if (outputItems != null)
                     {
                         var addItem = outputItems.FindChild<AddItem>();
@@ -265,13 +265,13 @@ namespace Microsoft.Build.Logging.StructuredLogger
                             var item = addItem.FindChild<Item>(filePath);
                             if (item != null)
                             {
-                                var metadata = item.FindChild<Metadata>(m => m.Name == "MSBuildSourceProjectFile");
+                                var metadata = item.FindChild<Metadata>(static m => m.Name == "MSBuildSourceProjectFile");
                                 if (metadata != null)
                                 {
                                     var metadataValue = metadata.Value;
                                     resultSet.Add(new SearchResult(metadata));
 
-                                    var referencedProject = task.FindChild<Project>(p => p.Name.Equals(Path.GetFileName(metadataValue), StringComparison.OrdinalIgnoreCase));
+                                    var referencedProject = task.FindChild<Project, string>(static (p, metadataValue) => p.Name.Equals(Path.GetFileName(metadataValue), StringComparison.OrdinalIgnoreCase), metadataValue);
                                     if (referencedProject != null)
                                     {
                                         var getCopyToOutputDirectoryItems = referencedProject.FindTarget("GetCopyToOutputDirectoryItems");
@@ -299,16 +299,16 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 var task = target.FindChild<ResolveAssemblyReferenceTask>();
                 if (task != null)
                 {
-                    var outputItems = task.FindLastChild<Folder>(f => f.Name == "OutputItems");
+                    var outputItems = task.FindLastChild<Folder>(static f => f.Name == "OutputItems");
                     if (outputItems != null)
                     {
-                        var addItem = outputItems.FindChild<AddItem>(a => a.Name == "ReferenceCopyLocalPaths");
+                        var addItem = outputItems.FindChild<AddItem>(static a => a.Name == "ReferenceCopyLocalPaths");
                         if (addItem != null)
                         {
                             var item = addItem.FindChild<Item>(filePath);
                             if (item != null)
                             {
-                                var metadata = item.FindChild<Metadata>(m => m.Name == "MSBuildSourceProjectFile");
+                                var metadata = item.FindChild<Metadata>(static m => m.Name == "MSBuildSourceProjectFile");
                                 if (metadata != null)
                                 {
                                     var metadataValue = metadata.Value;

--- a/src/StructuredLogger/Analyzers/ResolveAssemblyReferenceAnalyzer.cs
+++ b/src/StructuredLogger/Analyzers/ResolveAssemblyReferenceAnalyzer.cs
@@ -23,15 +23,15 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
             currentUsedLocations.Clear();
 
-            var results = rar.FindChild<Folder>(c => c.Name == Strings.Results);
-            var parameters = rar.FindChild<Folder>(c => c.Name == Strings.Parameters);
+            var results = rar.FindChild<Folder>(static c => c.Name == Strings.Results);
+            var parameters = rar.FindChild<Folder>(static c => c.Name == Strings.Parameters);
 
             TotalRARDuration += rar.Duration;
 
             IList<string> searchPaths = null;
             if (parameters != null)
             {
-                var searchPathsNode = parameters.FindChild<NamedNode>(c => c.Name == Strings.SearchPaths);
+                var searchPathsNode = parameters.FindChild<NamedNode>(static c => c.Name == Strings.SearchPaths);
                 if (searchPathsNode != null)
                 {
                     searchPaths = searchPathsNode.Children.Select(c => c.ToString()).ToArray();
@@ -46,7 +46,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 {
                     const string ResolvedFilePathIs = "Resolved file path is \"";
                     string resolvedFilePath = null;
-                    var resolvedFilePathNode = reference.FindChild<Item>(i => i.ToString().StartsWith(ResolvedFilePathIs, StringComparison.Ordinal));
+                    var resolvedFilePathNode = reference.FindChild<Item>(static i => i.ToString().StartsWith(ResolvedFilePathIs, StringComparison.Ordinal));
                     if (resolvedFilePathNode != null)
                     {
                         var text = resolvedFilePathNode.ToString();
@@ -54,7 +54,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
                     }
 
                     const string ReferenceFoundAt = "Reference found at search path location \"";
-                    var foundAtLocation = reference.FindChild<Item>(i => i.ToString().StartsWith(ReferenceFoundAt, StringComparison.Ordinal));
+                    var foundAtLocation = reference.FindChild<Item>(static i => i.ToString().StartsWith(ReferenceFoundAt, StringComparison.Ordinal));
                     if (foundAtLocation != null)
                     {
                         var text = foundAtLocation.ToString();

--- a/src/StructuredLogger/BinaryLogger/BuildEventArgsReader.Viewer.cs
+++ b/src/StructuredLogger/BinaryLogger/BuildEventArgsReader.Viewer.cs
@@ -23,15 +23,15 @@ namespace Microsoft.Build.Logging.StructuredLogger
             public IDictionary<string, string> Dictionary;
         }
 
-        private IDictionary<string, string> CreateDictionary(List<(int keyIndex, int valueIndex)> list)
+        private ArrayDictionary<string, string> CreateDictionary(List<(int keyIndex, int valueIndex)> list)
         {
             var dictionary = new ArrayDictionary<string, string>(list.Count);
             for (int i = 0; i < list.Count; i++)
             {
                 string key = GetStringFromRecord(list[i].keyIndex);
-                string value = GetStringFromRecord(list[i].valueIndex);
                 if (key != null)
                 {
+                    string value = GetStringFromRecord(list[i].valueIndex);
                     dictionary.Add(key, value);
                 }
             }
@@ -191,6 +191,21 @@ namespace Microsoft.Build.Logging.StructuredLogger
         private string GetTaskFinishedMessage(bool succeeded, string taskName)
         {
             return FormatResourceStringIgnoreCodeAndKeyword(succeeded ? "Done executing task \"{0}\"." : "Done executing task \"{0}\" -- FAILED.", taskName);
+        }
+
+        internal static string FormatResourceStringIgnoreCodeAndKeyword(string resource, string arg0)
+        {
+            return string.Format(resource, arg0);
+        }
+
+        internal static string FormatResourceStringIgnoreCodeAndKeyword(string resource, string arg0, string arg1)
+        {
+            return string.Format(resource, arg0, arg1);
+        }
+
+        internal static string FormatResourceStringIgnoreCodeAndKeyword(string resource, string arg0, string arg1, string arg2)
+        {
+            return string.Format(resource, arg0, arg1, arg2);
         }
 
         internal static string FormatResourceStringIgnoreCodeAndKeyword(string resource, params string[] arguments)

--- a/src/StructuredLogger/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/StructuredLogger/BinaryLogger/BuildEventArgsReader.cs
@@ -252,9 +252,11 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 {
                     hasError = true;
 
+                    int localSerializedEventLength = serializedEventLength;
+                    Exception localException = e;
                     string ErrorFactory() =>
                         string.Format("BuildEvent record number {0} (serialized size: {1}) attempted to perform disallowed reads (details: {2}: {3}).",
-                            _recordNumber, serializedEventLength, e.GetType(), e.Message) + (_skipUnknownEvents
+                            _recordNumber, localSerializedEventLength, localException.GetType(), localException.Message) + (_skipUnknownEvents
                             ? " Skipping the record."
                             : string.Empty);
 
@@ -263,9 +265,11 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
                 if (result == null && !hasError)
                 {
+                    int localSerializedEventLength = serializedEventLength;
+                    BinaryLogRecordKind localRecordKind = recordKind;
                     string ErrorFactory() =>
                         string.Format("BuildEvent record number {0} (serialized size: {1}) is of unsupported type: {2}.",
-                            _recordNumber, serializedEventLength, recordKind) + (_skipUnknownEvents
+                            _recordNumber, localSerializedEventLength, localRecordKind) + (_skipUnknownEvents
                             ? " Skipping the record."
                             : string.Empty);
 
@@ -274,9 +278,10 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
                 if (_readStream.BytesCountAllowedToReadRemaining > 0)
                 {
+                    int localSerializedEventLength = serializedEventLength;
                     string ErrorFactory() => string.Format(
-                        "BuildEvent record number {0} was expected to read exactly {1} bytes from the stream, but read {2} instead.", _recordNumber, serializedEventLength,
-                        serializedEventLength - _readStream.BytesCountAllowedToReadRemaining);
+                        "BuildEvent record number {0} was expected to read exactly {1} bytes from the stream, but read {2} instead.", _recordNumber, localSerializedEventLength,
+                        localSerializedEventLength - _readStream.BytesCountAllowedToReadRemaining);
 
                     HandleError(ErrorFactory, _skipUnknownEventParts, ReaderErrorType.UnknownEventData, recordKind);
                 }
@@ -1616,7 +1621,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
             }
         }
 
-        private IEnumerable ReadPropertyList()
+        private IDictionary<string, string> ReadPropertyList()
         {
             var properties = ReadStringDictionary();
             return properties;
@@ -1666,7 +1671,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
             return record;
         }
 
-        private IDictionary<string, string> ReadLegacyStringDictionary()
+        private Dictionary<string, string> ReadLegacyStringDictionary()
         {
             int count = ReadInt32();
             if (count == 0)
@@ -1695,7 +1700,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
             return taskItem;
         }
 
-        private IEnumerable ReadProjectItems()
+        private IList<DictionaryEntry> ReadProjectItems()
         {
             IList<DictionaryEntry> list;
 
@@ -1777,7 +1782,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
             return list;
         }
 
-        private IEnumerable<string> ReadStringList()
+        private string[] ReadStringList()
         {
             var count = ReadInt32();
 
@@ -1790,7 +1795,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
             return list;
         }
 
-        private IEnumerable ReadTaskItemList()
+        private ITaskItem[] ReadTaskItemList()
         {
             int count = ReadInt32();
             if (count == 0)

--- a/src/StructuredLogger/Construction/Construction.cs
+++ b/src/StructuredLogger/Construction/Construction.cs
@@ -365,7 +365,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
             var project = GetProject(args.BuildEventContext.ProjectContextId);
             if (project != null && args.BuildEventContext.TargetId != BuildEventContext.InvalidTargetId)
             {
-                target = project.FindLastChild<Target>(t => t.Id == args.BuildEventContext.TargetId);
+                target = project.FindLastChild<Target, TargetSkippedEventArgs>(static (t, args) => t.Id == args.BuildEventContext.TargetId, args);
             }
 
             if (target == null)
@@ -523,7 +523,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
                         projectEvaluation.ProjectFile = projectFilePath;
 
                         projectEvaluation.Id = evaluationId;
-                        projectEvaluation.EvaluationText = Intern("id:" + evaluationId);
+                        projectEvaluation.EvaluationText = Intern($"id:{evaluationId}");
                         projectEvaluation.NodeId = e.BuildEventContext.NodeId;
                         projectEvaluation.StartTime = e.Timestamp;
                         projectEvaluation.EndTime = e.Timestamp;
@@ -534,7 +534,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
                         var projectFilePath = Intern(projectEvaluationFinished.ProjectFile);
                         var projectName = Intern(Path.GetFileName(projectFilePath));
                         var nodeName = Intern(GetEvaluationProjectName(evaluationId, projectName));
-                        var projectEvaluation = EvaluationFolder.FindLastChild<ProjectEvaluation>(e => e.Id == evaluationId);
+                        var projectEvaluation = EvaluationFolder.FindLastChild<ProjectEvaluation, int>(static (e, evaluationId) => e.Id == evaluationId, evaluationId);
                         if (projectEvaluation == null)
                         {
                             // no matching ProjectEvaluationStarted
@@ -728,7 +728,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
                 result = EvaluationFolder;
 
-                var projectEvaluation = result.FindChild<ProjectEvaluation>(p => p.Id == evaluationId);
+                var projectEvaluation = result.FindChild<ProjectEvaluation, int>(static (p, evaluationId) => p.Id == evaluationId, evaluationId);
                 if (projectEvaluation != null)
                 {
                     result = projectEvaluation;

--- a/src/StructuredLogger/ObjectModel/Build.cs
+++ b/src/StructuredLogger/ObjectModel/Build.cs
@@ -252,7 +252,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 }
 
                 // the evaluation we want is likely to be at the end (recently added)
-                projectEvaluation = evaluation.FindLastChild<ProjectEvaluation>(e => e.Id == id);
+                projectEvaluation = evaluation.FindLastChild<ProjectEvaluation, int>(static (e, id) => e.Id == id, id);
                 if (projectEvaluation != null)
                 {
                     evaluationById[id] = projectEvaluation;

--- a/src/StructuredLogger/ObjectModel/Tasks/CompilationWrites.cs
+++ b/src/StructuredLogger/ObjectModel/Tasks/CompilationWrites.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
         internal static CompilationWrites? TryParse(Task task)
         {
-            var parameters = task.FindChild<Folder>(c => c.Name == Strings.Parameters);
+            var parameters = task.FindChild<Folder>(static c => c.Name == Strings.Parameters);
             if (parameters == null)
             {
                 // Probably localized MSBuild that we don't yet support

--- a/src/StructuredLogger/ObjectModel/TreeNode.cs
+++ b/src/StructuredLogger/ObjectModel/TreeNode.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -219,7 +218,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 return list.FindNode<T>(name);
             }
 
-            return FindChild<T>(c => string.Equals(c.Title, name, StringComparison.OrdinalIgnoreCase));
+            return FindChild<T, string>(static (c, name) => string.Equals(c.Title, name, StringComparison.OrdinalIgnoreCase), name);
         }
 
         public virtual T FindChild<T>(Predicate<T> predicate = null) where T : BaseNode
@@ -231,6 +230,24 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 for (int i = 0; i < count; i++)
                 {
                     if (children[i] is T child && (predicate == null || predicate(child)))
+                    {
+                        return child;
+                    }
+                }
+            }
+
+            return default;
+        }
+
+        public virtual T FindChild<T, TState>(Func<T, TState, bool> predicate, TState state) where T : BaseNode
+        {
+            if (HasChildren)
+            {
+                var children = Children;
+                int count = children.Count;
+                for (int i = 0; i < count; i++)
+                {
+                    if (children[i] is T child && predicate(child, state))
                     {
                         return child;
                     }
@@ -316,9 +333,27 @@ namespace Microsoft.Build.Logging.StructuredLogger
         {
             if (HasChildren)
             {
-                for (int i = Children.Count - 1; i >= 0; i--)
+                IList<BaseNode> children = Children;
+                for (int i = children.Count - 1; i >= 0; i--)
                 {
-                    if (Children[i] is T child && (predicate == null || predicate(child)))
+                    if (children[i] is T child && (predicate == null || predicate(child)))
+                    {
+                        return child;
+                    }
+                }
+            }
+
+            return default;
+        }
+
+        public virtual T FindLastChild<T, TState>(Func<T, TState, bool> predicate, TState state) where T : BaseNode
+        {
+            if (HasChildren)
+            {
+                IList<BaseNode> children = Children;
+                for (int i = children.Count - 1; i >= 0; i--)
+                {
+                    if (children[i] is T child && predicate(child, state))
                     {
                         return child;
                     }

--- a/src/StructuredLogger/Search/ProxyNode.cs
+++ b/src/StructuredLogger/Search/ProxyNode.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 }
             }
 
-            IEnumerable<(string Key, IEnumerable<string> Occurrences)> fieldsWithMatches = null;
+            (string Key, IEnumerable<string> Occurrences)[] fieldsWithMatches = null;
             if (result.FieldsToDisplay != null)
             {
                 fieldsWithMatches = result.FieldsToDisplay.Select(f =>


### PR DESCRIPTION
@KirillOsenkov asked me to look at why the .NET 8 build was slower than the .NET Framework build (answer: https://github.com/KirillOsenkov/MSBuildStructuredLog/pull/819), and why so much time was being taken up in ReadByte (answer: https://github.com/KirillOsenkov/MSBuildStructuredLog/issues/820, https://github.com/dotutils/streamutils/pull/2). But while looking into it, I did an allocation profile and noticed some low-hanging fruit easily avoided, so this addresses those.

- Avoid closures when calling TreeNode.Find{Last}Child. Added an overload that takes state, and made all call sites use `static` to help flag places state was being closed over.
- Avoid closures in BuildEventArgs.Read. The error paths were closing over state used by the success path, resulting in allocation even on success.
- Changed some methods that were returning interfaces to return the strongly-typed collection instead. Consumers that were iterating through them can now automatically avoid going through an enumerator.
- Avoid params allocations for most call sites to FormatResourceStringIgnoreCodeAndKeyword by adding dedicated overloads for 1/2/3 args.
- Avoid an int boxing allocation (on core) when concatening a string with an int.
- Updated TextUtilities to use more modern APIs, e.g. MemoryExtensions.IndexOfAny, IndexOf, ReplaceLineEndings, etc. Some uses were (accidentally?) using Enumerable.Contains.