### PR TITLE
add new event type BuildCanceled

### DIFF
--- a/src/StructuredLogger/BinaryLogger/BinaryLogRecordKind.cs
+++ b/src/StructuredLogger/BinaryLogger/BinaryLogRecordKind.cs
@@ -36,5 +36,6 @@
         BuildCheckTracing,
         BuildCheckAcquisition,
         BuildSubmissionStarted,
+        BuildCanceled,
     }
 }

--- a/src/StructuredLogger/BinaryLogger/BinaryLogger.cs
+++ b/src/StructuredLogger/BinaryLogger/BinaryLogger.cs
@@ -76,6 +76,8 @@ namespace Microsoft.Build.Logging.StructuredLogger
         // version 23:
         //    - new record kinds: BuildCheckMessageEvent, BuildCheckWarningEvent, BuildCheckErrorEvent,
         //    BuildCheckTracingEvent, BuildCheckAcquisitionEvent, BuildSubmissionStartedEvent
+        // version 24:
+        //    - new record kind: BuildCanceledEvent
 
         // This should be never changed.
         // The minimum version of the binary log reader that can read log of above version.
@@ -83,7 +85,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
         // The current version of the binary log representation.
         // Changes with each update of the binary log format.
-        internal const int FileFormatVersion = 23;
+        internal const int FileFormatVersion = 24;
         // The minimum version of the binary log reader that can read log of above version.
         // This should be changed only when the binary log format is changed in a way that would prevent it from being
         // read by older readers. (changing of the individual BuildEventArgs or adding new is fine - as reader can

--- a/src/StructuredLogger/BinaryLogger/BuildCanceledEventArgs.cs
+++ b/src/StructuredLogger/BinaryLogger/BuildCanceledEventArgs.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+
+namespace StructuredLogger.BinaryLogger
+{
+    /// <summary>
+    /// This class represents the event arguments for build canceled events.
+    /// </summary>
+    internal sealed class BuildCanceledEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
+    {
+
+        /// <summary>
+        /// Constructor which allows the timestamp to be set.
+        /// </summary>
+        /// <param name="message">text message</param>
+        /// <param name="eventTimestamp">Timestamp when the event was created</param>
+        public BuildCanceledEventArgs(
+            string message,
+            DateTime eventTimestamp)
+            : this(message, eventTimestamp, null)
+        {
+        }
+
+        /// <summary>
+        /// Constructor which allows the timestamp to be set.
+        /// </summary>
+        /// <param name="message">text message</param>
+        /// <param name="eventTimestamp">Timestamp when the event was created</param>
+        /// <param name="messageArgs">message arguments</param>
+        public BuildCanceledEventArgs(
+            string message,
+            DateTime eventTimestamp,
+            params object[]? messageArgs)
+            : base(message, null, "MSBuild", eventTimestamp, messageArgs)
+        {
+            if (string.IsNullOrWhiteSpace(message))
+            {
+                throw new ArgumentException("Message cannot be null or consist only white-space characters.");
+            }
+        }
+    }
+}

--- a/src/StructuredLogger/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/StructuredLogger/BinaryLogger/BuildEventArgsReader.cs
@@ -338,6 +338,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 BinaryLogRecordKind.BuildCheckTracing => ReadBuildCheckTracingEventArgs(),
                 BinaryLogRecordKind.BuildCheckAcquisition => ReadBuildCheckAcquisitionEventArgs(),
                 BinaryLogRecordKind.BuildSubmissionStarted => ReadBuildSubmissionStartedEventArgs(),
+                BinaryLogRecordKind.BuildCanceled => ReadBuildCanceledEventArgs(),
                 _ => null,
                 
             };
@@ -707,6 +708,15 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 fields.Message,
                 fields.HelpKeyword,
                 succeeded,
+                fields.Timestamp);
+            SetCommonFields(e, fields);
+            return e;
+        }
+        private BuildEventArgs ReadBuildCanceledEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields();
+            var e = new BuildCanceledEventArgs(
+                fields.Message,
                 fields.Timestamp);
             SetCommonFields(e, fields);
             return e;
@@ -1287,7 +1297,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
         private BuildEventArgs ReadBuildSubmissionStartedEventArgs()
         {
             var fields = ReadBuildEventArgsFields(readImportance: false);
-            var e = new BuildSubmissionStartedEvent();
+            var e = new BuildSubmissionStartedEventArgs();
 
             var globalProperties = ReadStringDictionary();
             var entries = ReadStringList();

--- a/src/StructuredLogger/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/StructuredLogger/BinaryLogger/BuildEventArgsWriter.cs
@@ -183,6 +183,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
                     ProjectFinished
                     BuildStarted
                     BuildFinished
+                    BuildCanceled
                     ProjectEvaluationStarted
                     ProjectEvaluationFinished
                 BuildError
@@ -211,7 +212,8 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 case ProjectFinishedEventArgs projectFinished: return Write(projectFinished);
                 case BuildStartedEventArgs buildStarted: return Write(buildStarted);
                 case BuildFinishedEventArgs buildFinished: return Write(buildFinished);
-                case BuildSubmissionStartedEvent buildSubmissionStarted: return Write(buildSubmissionStarted);
+                case BuildCanceledEventArgs buildCanceled: return Write(buildCanceled);
+                case BuildSubmissionStartedEventArgs buildSubmissionStarted: return Write(buildSubmissionStarted);
                 case ProjectEvaluationStartedEventArgs projectEvaluationStarted: return Write(projectEvaluationStarted);
                 case ProjectEvaluationFinishedEventArgs projectEvaluationFinished: return Write(projectEvaluationFinished);
                 case BuildCheckTracingEventArgs buildCheckTracing: return Write(buildCheckTracing);
@@ -311,6 +313,12 @@ namespace Microsoft.Build.Logging.StructuredLogger
             return BinaryLogRecordKind.BuildFinished;
         }
 
+        private BinaryLogRecordKind Write(BuildCanceledEventArgs e)
+        {
+            WriteBuildEventArgsFields(e);
+            return BinaryLogRecordKind.BuildCanceled;
+        }
+
         private BinaryLogRecordKind Write(ProjectEvaluationStartedEventArgs e)
         {
             WriteBuildEventArgsFields(e, writeMessage: false);
@@ -336,7 +344,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
             return BinaryLogRecordKind.BuildCheckAcquisition;
         }
 
-        private BinaryLogRecordKind Write(BuildSubmissionStartedEvent e)
+        private BinaryLogRecordKind Write(BuildSubmissionStartedEventArgs e)
         {
             WriteBuildEventArgsFields(e, writeMessage: false);
             Write(e.GlobalProperties);

--- a/src/StructuredLogger/BinaryLogger/BuildSubmissionStartedEventArgs.cs
+++ b/src/StructuredLogger/BinaryLogger/BuildSubmissionStartedEventArgs.cs
@@ -4,7 +4,7 @@ using Microsoft.Build.Framework;
 
 namespace StructuredLogger.BinaryLogger
 {
-    internal class BuildSubmissionStartedEvent()
+    internal class BuildSubmissionStartedEventArgs()
         : BuildStatusEventArgs(message: "", helpKeyword: null, senderName: null, eventTimestamp: DateTime.UtcNow)
     {
         public IDictionary<string, string?> GlobalProperties { get; set; }

--- a/src/StructuredLogger/Construction/Construction.cs
+++ b/src/StructuredLogger/Construction/Construction.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Framework.Profiler;
+using StructuredLogger.BinaryLogger;
 
 namespace Microsoft.Build.Logging.StructuredLogger
 {
@@ -512,7 +513,17 @@ namespace Microsoft.Build.Logging.StructuredLogger
             {
                 lock (syncLock)
                 {
-                    if (e is ProjectEvaluationStartedEventArgs projectEvaluationStarted)
+                    // If the build was canceled we want to show a message in the build log view.
+                    if (e is BuildCanceledEventArgs buildCanceledEventArgs)
+                    {
+                        messageProcessor.Process(new BuildMessageEventArgs(
+                             Intern(buildCanceledEventArgs.Message),
+                        Intern(buildCanceledEventArgs.HelpKeyword),
+                        Intern(buildCanceledEventArgs.SenderName),
+                        MessageImportance.High,
+                        buildCanceledEventArgs.Timestamp));
+                    }
+                    else if (e is ProjectEvaluationStartedEventArgs projectEvaluationStarted)
                     {
                         var evaluationId = projectEvaluationStarted.BuildEventContext.EvaluationId;
                         var projectFilePath = Intern(projectEvaluationStarted.ProjectFile);

--- a/src/StructuredLogger/Construction/Construction.cs
+++ b/src/StructuredLogger/Construction/Construction.cs
@@ -513,17 +513,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
             {
                 lock (syncLock)
                 {
-                    // If the build was canceled we want to show a message in the build log view.
-                    if (e is BuildCanceledEventArgs buildCanceledEventArgs)
-                    {
-                        messageProcessor.Process(new BuildMessageEventArgs(
-                             Intern(buildCanceledEventArgs.Message),
-                        Intern(buildCanceledEventArgs.HelpKeyword),
-                        Intern(buildCanceledEventArgs.SenderName),
-                        MessageImportance.High,
-                        buildCanceledEventArgs.Timestamp));
-                    }
-                    else if (e is ProjectEvaluationStartedEventArgs projectEvaluationStarted)
+                    if (e is ProjectEvaluationStartedEventArgs projectEvaluationStarted)
                     {
                         var evaluationId = projectEvaluationStarted.BuildEventContext.EvaluationId;
                         var projectFilePath = Intern(projectEvaluationStarted.ProjectFile);
@@ -594,6 +584,16 @@ namespace Microsoft.Build.Logging.StructuredLogger
                             AddPropertiesSorted(propertiesFolder, projectEvaluation, projectEvaluationFinished.Properties);
                             AddItems(itemsNode, projectEvaluationFinished.Items);
                         }
+                    } 
+                    else if (e is BuildCanceledEventArgs buildCanceledEventArgs)
+                    {
+                        // If the build was canceled we want to show a message in the build log view.
+                        messageProcessor.Process(new BuildMessageEventArgs(
+                            Intern(buildCanceledEventArgs.Message),
+                            Intern(buildCanceledEventArgs.HelpKeyword),
+                            Intern(buildCanceledEventArgs.SenderName),
+                            MessageImportance.High,
+                            buildCanceledEventArgs.Timestamp));
                     }
                 }
             }


### PR DESCRIPTION
Pair PR to https://github.com/dotnet/msbuild/pull/10755
Adds support for new event type serialized there.

also fixes class name BuildSubmissionStartedEventArgs to be uniform with other EventArgs classes