### PR TITLE
Add a main menu link to search syntax wiki

### DIFF
--- a/src/StructuredLogViewer/MainWindow.xaml
+++ b/src/StructuredLogViewer/MainWindow.xaml
@@ -40,7 +40,7 @@
         <MenuItem Header="E_xit" Click="Exit_Click" InputGestureText="Alt+F4" />
       </MenuItem>
       <MenuItem Header="_Help">
-        <MenuItem Header="Search Syntax..." Click="HelpLink3_Click" />
+        <MenuItem Header="Search Syntax" Click="HelpLink3_Click" />
         <MenuItem Header="https://github.com/KirillOsenkov/MSBuildStructuredLog" Click="HelpLink_Click" />
         <MenuItem Header="https://msbuildlog.com" Click="HelpLink2_Click" />
         <Separator />

--- a/src/StructuredLogViewer/MainWindow.xaml
+++ b/src/StructuredLogViewer/MainWindow.xaml
@@ -40,6 +40,7 @@
         <MenuItem Header="E_xit" Click="Exit_Click" InputGestureText="Alt+F4" />
       </MenuItem>
       <MenuItem Header="_Help">
+        <MenuItem Header="Search Syntax..." Click="HelpLink3_Click" />
         <MenuItem Header="https://github.com/KirillOsenkov/MSBuildStructuredLog" Click="HelpLink_Click" />
         <MenuItem Header="https://msbuildlog.com" Click="HelpLink2_Click" />
         <Separator />

--- a/src/StructuredLogViewer/MainWindow.xaml.cs
+++ b/src/StructuredLogViewer/MainWindow.xaml.cs
@@ -1102,6 +1102,11 @@ Use project(.) or project(.csproj) to search all projects (slow)." };
             Process.Start(new ProcessStartInfo("https://msbuildlog.com") { UseShellExecute = true });
         }
 
+        private void HelpLink3_Click(object sender, RoutedEventArgs e)
+        {
+            Process.Start(new ProcessStartInfo("https://github.com/KirillOsenkov/MSBuildStructuredLog/wiki/Search-Syntax") { UseShellExecute = true });
+        }
+
         private void HelpAbout_Click(object sender, RoutedEventArgs e)
         {
             MessageBox.Show(VersionMessage);


### PR DESCRIPTION
I've spent years using binlog viewer almost daily without knowing that it has advanced search syntax.
Adding a link to main menu that points to the wiki to surface this better.
Ideally, the program would pop up some sort of a tip when I'm editing the search field to show advanced command description plus has some minimum highlight of that syntax, but this is not something I can implement here.