### PR TITLE
Add secrets search and bump DotUtils.MsBuild.BinlogRedactor.SensitiveDataDetector version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,7 @@
     <PackageVersion Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="DiffPlex" Version="1.7.2" />
-    <PackageVersion Include="DotUtils.MsBuild.BinlogRedactor.SensitiveDataDetector" Version="0.0.8" />
+    <PackageVersion Include="DotUtils.MsBuild.BinlogRedactor.SensitiveDataDetector" Version="0.0.9" />
     <PackageVersion Include="DotUtils.StreamUtils.Sources" Version="0.0.8" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="GuiLabs.Language.Xml" Version="1.2.93" />

--- a/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
@@ -18,7 +18,6 @@ using System.Xml;
 using DotUtils.MsBuild.SensitiveDataDetector;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Logging.StructuredLogger;
-using Microsoft.Build.SensitiveDataDetector;
 using Microsoft.Language.Xml;
 using Mono.Cecil;
 using StructuredLogViewer.Core.ProjectGraph;

--- a/src/StructuredLogViewer/MainWindow.xaml.cs
+++ b/src/StructuredLogViewer/MainWindow.xaml.cs
@@ -692,6 +692,7 @@ Use project(.) or project(.csproj) to search all projects (slow)." };
                 try
                 {
                     BuildAnalyzer.AnalyzeBuild(build);
+                    build.SearchExtensions.Add(new SecretsSearch(build));
                     build.SearchExtensions.Add(new NuGetSearch(build));
                 }
                 catch (Exception ex)

--- a/src/StructuredLogger.Utils/BinlogRedactor.cs
+++ b/src/StructuredLogger.Utils/BinlogRedactor.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Threading;
-using Microsoft.Build.Logging;
 using Microsoft.Build.Logging.StructuredLogger;
 using Microsoft.Build.SensitiveDataDetector;
 
@@ -61,7 +60,7 @@ namespace StructuredLogger.Utils
                 sensitiveDataKind |= SensitiveDataKind.Username;
             }
 
-            ISensitiveDataRedactor sensitiveDataRedactor = SensitiveDataDetectorFactory.GetSecretsDetector(
+            ISensitiveDataRedactor sensitiveDataRedactor = SensitiveDataDetectorFactory.GetSecretsRedactor(
                 sensitiveDataKind,
                 redactorOptions.IdentifyReplacemenets,
                 redactorOptions.TokensToRedact);

--- a/src/StructuredLogger.Utils/SecretsSearch.cs
+++ b/src/StructuredLogger.Utils/SecretsSearch.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using DotUtils.MsBuild.SensitiveDataDetector;
+using Microsoft.Build.SensitiveDataDetector;
+using NuGet.Packaging;
+using StructuredLogViewer;
+
+namespace Microsoft.Build.Logging.StructuredLogger
+{
+    public class SecretsSearch : ISearchExtension
+    {
+        private readonly Search _search;
+        private readonly Build _build;
+        private const string SecretKeyword = "secret";
+        private readonly ConcurrentDictionary<string, List<SecretDescriptor>> _cache = new ConcurrentDictionary<string, List<SecretDescriptor>>();
+
+        private readonly List<ISensitiveDataDetector> SecretsDetectors = new List<ISensitiveDataDetector>
+        {
+            SensitiveDataDetectorFactory.GetSecretsDetector(SensitiveDataKind.CommonSecrets, false),
+            SensitiveDataDetectorFactory.GetSecretsDetector(SensitiveDataKind.ExplicitSecrets, false),
+            SensitiveDataDetectorFactory.GetSecretsDetector(SensitiveDataKind.Username, false)
+        };
+
+        public SecretsSearch(Build build)
+        {
+            _build = build ?? throw new ArgumentNullException(nameof(build));
+
+            _search = new Search(
+                new[] { build },
+                build.StringTable.Instances,
+                5000,
+                markResultsInTree: false);
+        }
+
+        public bool TryGetResults(NodeQueryMatcher nodeQueryMatcher, IList<SearchResult> resultCollector, int maxResults)
+        {
+            if (!string.Equals(nodeQueryMatcher.TypeKeyword, SecretKeyword, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            foreach (var stringInstance in _build.StringTable.Instances)
+            {
+                if (_cache.TryGetValue(stringInstance, out List<SecretDescriptor> cachedSensitiveData) && cachedSensitiveData.Count > 0)
+                {
+                    IEnumerable<SearchResult> nodes = _search.FindNodes(stringInstance, CancellationToken.None);
+                    resultCollector.AddRange(nodes.Take(maxResults).Select(n => CreateSearchResult(n, cachedSensitiveData.First().Secret)));
+                }
+                else
+                {
+                    resultCollector.AddRange(GetSearchResult(stringInstance).Take(maxResults)); 
+                }
+            }
+
+            return true;
+        }
+
+        public List<SecretDescriptor> GetSecrets(string stringInstance)
+        {
+            if (_cache.TryGetValue(stringInstance, out var cachedSensitiveData) && cachedSensitiveData.Count > 0)
+            {
+                return cachedSensitiveData;
+            }
+
+            var sensitiveData = new List<SecretDescriptor>();
+            foreach (ISensitiveDataDetector detector in SecretsDetectors)
+            {
+                Dictionary<SensitiveDataKind, List<SecretDescriptor>> detectedData = detector.Detect(stringInstance);
+                if (detectedData.Count > 0 && detectedData.First().Value.Count > 0)
+                {
+                    sensitiveData.AddRange(detectedData.First().Value);
+                }
+            }
+
+            _cache.TryAdd(stringInstance, sensitiveData);
+
+            return sensitiveData;
+        }
+
+        private List<SearchResult> GetSearchResult(string stringInstance)
+        {
+            List<SearchResult> results = new List<SearchResult>();
+            List<SecretDescriptor> sensitiveData = GetSecrets(stringInstance);
+
+            if (sensitiveData.Count > 0)
+            {
+                IEnumerable<SearchResult> nodes = _search.FindNodes(stringInstance, CancellationToken.None);
+                results.AddRange(nodes.Select(n => CreateSearchResult(n, sensitiveData.First().Secret)));
+            }
+
+            return results;
+        }
+
+        private SearchResult CreateSearchResult(SearchResult nodeMatch, string secretText)
+        {
+            var proxy = new ProxyNode
+            {
+                Original = nodeMatch.Node,
+                SearchResult = nodeMatch,
+                Text = secretText
+            };
+            return new SearchResult(proxy);
+        }
+    }
+}

--- a/src/StructuredLogger.Utils/SecretsSearch.cs
+++ b/src/StructuredLogger.Utils/SecretsSearch.cs
@@ -11,14 +11,12 @@ namespace Microsoft.Build.Logging.StructuredLogger
     public class SecretsSearch : ISearchExtension
     {
         private readonly Build _build;
-        private readonly Search _search;
         private readonly Dictionary<SensitiveDataKind, ISensitiveDataDetector> _detectors;
         private readonly Dictionary<string, Dictionary<SensitiveDataKind, List<SecretDescriptor>>> _secretCache = new();
 
         public SecretsSearch(Build build)
         {
             _build = build ?? throw new ArgumentNullException(nameof(build));
-            _search = new Search([build], build.StringTable.Instances, 5000, markResultsInTree: false);
 
             _detectors = new()
             {

--- a/src/StructuredLogger.Utils/SecretsSearch.cs
+++ b/src/StructuredLogger.Utils/SecretsSearch.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
         {
             SensitiveDataDetectorFactory.GetSecretsDetector(SensitiveDataKind.CommonSecrets, false),
             SensitiveDataDetectorFactory.GetSecretsDetector(SensitiveDataKind.ExplicitSecrets, false),
-            SensitiveDataDetectorFactory.GetSecretsDetector(SensitiveDataKind.Username, false)
+            //SensitiveDataDetectorFactory.GetSecretsDetector(SensitiveDataKind.Username, false)
         };
 
         public SecretsSearch(Build build)

--- a/src/StructuredLogger.Utils/SecretsSearch.cs
+++ b/src/StructuredLogger.Utils/SecretsSearch.cs
@@ -33,9 +33,16 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 var activeDetectors = GetActiveDetectors(matcher.NotMatchers);
                 var foundResults = ScanForSecrets(_build.StringTable.Instances, activeDetectors, maxResults);
 
-                foreach (var result in foundResults)
+                if (foundResults.Any())
                 {
-                    results.Add(result);
+                    foreach (var result in foundResults)
+                    {
+                        results.Add(result);
+                    }
+                }
+                else
+                {
+                    results.Add(new SearchResult(new Message { Text = "No secret(s) were detected in the tree." }));
                 }
 
                 return true;
@@ -44,9 +51,9 @@ namespace Microsoft.Build.Logging.StructuredLogger
             return false;
         }
 
-        public List<SecretDescriptor> SearchSecrets(string text, NodeQueryMatcher? matcher, int maxResults)
+        public List<SecretDescriptor> SearchSecrets(string text, IList<NodeQueryMatcher> matcher, int maxResults)
         {
-            var activeDetectors = GetActiveDetectors(matcher == null ? [] : [matcher]);
+            var activeDetectors = GetActiveDetectors(matcher);
 
             var secrets = DetectSecrets(text, activeDetectors);
 


### PR DESCRIPTION
## Fixes
https://github.com/KirillOsenkov/MSBuildStructuredLog/issues/823

## Context
This change adds a support of a new search key word "**$secret**" that allows to detect all the suspicious tree entries, based on the capabilities of this library [MSBuild.BinlogRedactor](https://github.com/dotutils/MSBuild.BinlogRedactor).

MSBuild.BinlogRedactor is already used for secrets reduction functionality, but it this context it's possible to check the presence of the secrets on fly
![{4CD40D35-CD93-4195-B83B-30873E35C1D2}](https://github.com/user-attachments/assets/882ff8ab-7488-498c-a888-89d57874aaa5)


**$secret not**([SensitiveDataKind](https://github.com/dotutils/MSBuild.BinlogRedactor/blob/main/src/DotUtils.MsBuild.SensitiveDataDetector/SensitiveDataDetectorFactory.cs)) statement is supported here:
![{E743D083-2878-4655-AACF-711D9A8E6610}](https://github.com/user-attachments/assets/7462c24a-8dfb-4b74-bf5d-3b1772c3c8ba)

It's possible to use the new keyword on 2 tabs:
 **"Search Log"** 
![{12CCFBFD-AC63-4A06-B1F7-86948D7B721A}](https://github.com/user-attachments/assets/b15743fa-a1e7-4ccc-907b-82c2dd842ee9)

**"Find in Files"**
![{ED9BC1B4-EBC7-4979-B8E2-097B9A01AB53}](https://github.com/user-attachments/assets/9183422a-a14d-4b0c-89e0-78ec419d5c3f)

## Changes made
 A new SecretsSearch class was implemented based on ISearchExtension interface.
To make this functionality available on "Find in Files" tab, the method was extended https://github.com/KirillOsenkov/MSBuildStructuredLog/blob/6e4fc91055cc354e57684649d10a03e0e826b072/src/StructuredLogViewer/Controls/BuildControl.xaml.cs#L1022. There was an idea to use factory for handing this case, but we agreed with to postpone this and get back on demand.
[msbuild_logWithFalseSecrets.zip](https://github.com/user-attachments/files/17588093/msbuild_logWithFalseSecrets.zip)

