### PR TITLE
Add sample on searching secrets without username

### DIFF
--- a/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
@@ -646,7 +646,8 @@ Right-clicking a project node may show the 'Preprocess' option if the version of
             "$task $time",
             "$message CompilerServer failed",
             "will be compiled because",
-            "$secret"
+            "$secret",
+            "$secret not(username)"
         };
 
         private static string[] nodeKinds = new[]


### PR DESCRIPTION
### Context

In https://github.com/KirillOsenkov/MSBuildStructuredLog/pull/829 @YuliiaKovalova introduced secrets searching into Viewer. The semantic for searching just for secrets - `$secret not(username)` - feels at least as important as the searching of secrets themselves - so proposing to add it to the Examples list