### PR TITLE
remove hardcoded RIDs

### DIFF
--- a/build-macos.cake
+++ b/build-macos.cake
@@ -20,7 +20,8 @@ var buildDirs =
 var netCoreProject = new {
         Path = $"{netCoreAppsRoot}/{netCoreApp}",
         Name = netCoreApp,
-        Framework = XmlPeek($"{netCoreAppsRoot}/{netCoreApp}/{netCoreApp}.csproj", "//*[local-name()='TargetFramework']/text()")
+        Framework = XmlPeek($"{netCoreAppsRoot}/{netCoreApp}/{netCoreApp}.csproj", "//*[local-name()='TargetFramework']/text()"),
+        Runtimes = new[] { "osx-x64", "osx-arm64" }
     };
 
 

--- a/build-macos.cake
+++ b/build-macos.cake
@@ -20,8 +20,7 @@ var buildDirs =
 var netCoreProject = new {
         Path = $"{netCoreAppsRoot}/{netCoreApp}",
         Name = netCoreApp,
-        Framework = XmlPeek($"{netCoreAppsRoot}/{netCoreApp}/{netCoreApp}.csproj", "//*[local-name()='TargetFramework']/text()"),
-        Runtimes = XmlPeek($"{netCoreAppsRoot}/{netCoreApp}/{netCoreApp}.csproj", "//*[local-name()='RuntimeIdentifiers']/text()").Split(';')
+        Framework = XmlPeek($"{netCoreAppsRoot}/{netCoreApp}/{netCoreApp}.csproj", "//*[local-name()='TargetFramework']/text()")
     };
 
 

--- a/src/BinlogTool/BinlogTool.csproj
+++ b/src/BinlogTool/BinlogTool.csproj
@@ -38,7 +38,7 @@
       <NuspecPath>$(MSBuildProjectDirectory)\binlogtoolexe.nuspec</NuspecPath>
       <NupkgPath>$(OutDir)binlogtoolexe.nupkg</NupkgPath>
     </PropertyGroup>
-    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Restore;Publish" Properties="RuntimeIdentifier=win-x64;Configuration=Release;PublishSingleFile=true;SelfContained=false;PackAsTool=false;PublishTrimmed=true;TargetFramework=$(TargetFramework)" />
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Restore;Publish" Properties="Configuration=Release;PublishSingleFile=true;SelfContained=false;PackAsTool=false;PublishTrimmed=true;TargetFramework=$(TargetFramework)" />
     <PackTask
         PackItem="$(NuspecPath)"
         NuspecFile="$(NuspecPath)"

--- a/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj
+++ b/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <ApplicationIcon>StructuredLogger.ico</ApplicationIcon>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
   </PropertyGroup>


### PR DESCRIPTION
these are not necessary and make it work on any platform supported by runtime like linux-arm64 without hardcoding them
```
dotnet publish -c Release --self-contained
```

will publish for current RID. with `-r other-rid` will publish for other-rid (cross build)