### PR TITLE
Add Tooltip for MSBuild Properties in Preprocess View.

### DIFF
--- a/src/StructuredLogViewer/Controls/DocumentOutline.cs
+++ b/src/StructuredLogViewer/Controls/DocumentOutline.cs
@@ -1,4 +1,10 @@
-using System;
+﻿using System;
+using System.Linq;
+using System.Text;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Input;
+using ICSharpCode.AvalonEdit;
 using Microsoft.Build.Logging.StructuredLogger;
 using StructuredLogViewer.Controls;
 
@@ -22,6 +28,158 @@ namespace StructuredLogViewer
                 var projectImport = PreprocessContext.GetImportFromPosition(caretOffset);
                 ImportSelected?.Invoke(projectImport);
             };
+
+            textEditor.MouseHover += (sender, e) =>
+            {
+                if (e.LeftButton == MouseButtonState.Released && e.RightButton == MouseButtonState.Released)
+                {
+                    var mousePos = e.GetPosition(textEditor);
+                    this.TryUpdateToolTipText(textViewerControl, mousePos);
+                }
+            };
         }
+
+        private void TryUpdateToolTipText(TextViewerControl textViewerControl, System.Windows.Point mousePosition)
+        {
+            var textPos = textViewerControl.TextEditor.GetPositionFromPoint(mousePosition);
+            textViewerControl.ToolTip ??= new ToolTip() { Placement = PlacementMode.Relative, PlacementTarget = textViewerControl.TextEditor };
+            ToolTip tooltip = textViewerControl.ToolTip as ToolTip;
+
+            if (!textPos.HasValue || !this.TryGetWordAtPosition(textViewerControl, textPos.Value, out string type, out string title)
+                || string.IsNullOrEmpty(type) || string.IsNullOrEmpty(title))
+            {
+                CloseToolTip();
+                return;
+            }
+
+            StringBuilder content = new();
+
+            if (type == "<PropertyGroup>")
+            {
+                var propertyGroup = this.PreprocessContext.Evaluation.Children.FirstOrDefault(p => p.Title == "Properties");
+                if (propertyGroup is Folder propertyFolder)
+                {
+                    var propertyEntry = propertyFolder.Children.FirstOrDefault(p => p.Title == title);
+                    if (propertyEntry is Property property)
+                    {
+                        content.Append($"{title} =\n{property.Value.NormalizePropertyValue()}");
+                    }
+                }
+
+                // Search the "Property reassignment" folder.
+                var prFolder = this.PreprocessContext.Evaluation.Children.FirstOrDefault(p => p.Title == "Property reassignment");
+                if (prFolder is TimedNode folder)
+                {
+                    var entryFolder = folder.Children.FirstOrDefault(p => p.Title == title);
+                    if (entryFolder is Folder prEntries)
+                    {
+                        int count = 1;
+                        foreach (var entry in prEntries.Children)
+                        {
+                            if (count == 1)
+                            {
+                                content.Append("\nPrevious values:");
+                            }
+
+                            var match = Strings.PropertyReassignmentRegex.Match(entry.Title);
+                            if (match.Success)
+                            {
+                                string value;
+
+                                // Print the original value on first pass.
+                                if (count == 1)
+                                {
+                                    value = match.Groups["OrgValue"].Value;
+                                    value = value.NormalizePropertyValue();
+                                    content.Append($"\n{count}: " + value);
+                                    count++;
+                                }
+
+                                value = match.Groups["NewValue"].Value;
+                                value = value.NormalizePropertyValue();
+                                content.Append($"\n{count}: " + value);
+                                count++;
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (content.Length == 0)
+            {
+                CloseToolTip();
+                return;
+            }
+
+            tooltip.HorizontalOffset = mousePosition.X;
+            tooltip.VerticalOffset = mousePosition.Y;
+            tooltip.Content = $"{content}";
+
+            if (!tooltip.IsOpen)
+            {
+                tooltip.IsOpen = true;
+            }
+
+            void CloseToolTip()
+            {
+                tooltip.Content = string.Empty;
+                tooltip.IsOpen = false;
+            }
+        }
+
+        private bool TryGetWordAtPosition(TextViewerControl textViewerControl, TextViewPosition textPos, out string type, out string word)
+        {
+            type = string.Empty;
+            word = string.Empty;
+
+            var document = textViewerControl.TextEditor.Document;
+            var offset = document.GetOffset(textPos.Line, textPos.Column);
+            int start = ICSharpCode.AvalonEdit.Document.TextUtilities.GetNextCaretPosition(document, offset + 1, System.Windows.Documents.LogicalDirection.Backward, ICSharpCode.AvalonEdit.Document.CaretPositioningMode.WordBorder);
+            int end = ICSharpCode.AvalonEdit.Document.TextUtilities.GetNextCaretPosition(document, offset, System.Windows.Documents.LogicalDirection.Forward, ICSharpCode.AvalonEdit.Document.CaretPositioningMode.WordBorder);
+
+            if (start == -1 || end == -1 || end <= start)
+            {
+                return false;
+            }
+
+            // Try parsing the word by looking for the special characters before the word.
+            if (start > 2)
+            {
+                // naively check for $(.
+                word = document.GetText(start - 2, 2);
+                if (word == "$(")
+                {
+                    word = document.GetText(start, end - start).Trim();
+                    type = "<PropertyGroup>";
+                    return true;
+                }
+            }
+
+            // Use the folding control to extract the containing type.
+            var typeCandidate = textViewerControl.FoldingManager.GetFoldingsContaining(start)?.LastOrDefault(f => allowedFoldingNodes.Contains(f.Title));
+
+            if (string.IsNullOrEmpty(typeCandidate?.Title))
+            {
+                return false;
+            }
+
+            word = document.GetText(start, end - start).Trim(specialCharacters).Trim();
+            type = typeCandidate.Title;
+
+            if (string.IsNullOrEmpty(word))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private char[] specialCharacters = ['@', '$', '(', ')', '<', '>', '\r', '\n', ' '];
+
+        private string[] allowedFoldingNodes = [
+            "<Project>",
+            "<PropertyGroup>",
+            "<ItemGroup>",
+            ];
     }
 }

--- a/src/StructuredLogViewer/Controls/TextViewerControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/TextViewerControl.xaml.cs
@@ -24,9 +24,9 @@ namespace StructuredLogViewer.Controls
     public partial class TextViewerControl : UserControl
     {
         private static readonly Regex solutionFileRegex = new Regex(@"^\s*Microsoft Visual Studio Solution File", RegexOptions.Compiled | RegexOptions.Singleline);
-        private FoldingManager foldingManager;
 
         public string FilePath { get; private set; }
+        public FoldingManager FoldingManager { get; private set; }
         public string Text { get; private set; }
         public Action Preprocess { get; private set; }
         public bool IsXml { get; private set; }
@@ -43,7 +43,7 @@ namespace StructuredLogViewer.Controls
 
             SearchPanel.Install(textArea);
 
-            foldingManager = FoldingManager.Install(textEditor.TextArea);
+            this.FoldingManager = FoldingManager.Install(textEditor.TextArea);
 
             textArea.MouseRightButtonDown += TextAreaMouseRightButtonDown;
             DataObject.AddSettingDataHandler(textArea, OnSettingData);
@@ -216,7 +216,7 @@ namespace StructuredLogViewer.Controls
                 textEditor.SyntaxHighlighting = highlighting;
 
                 var foldingStrategy = new XmlFoldingStrategy();
-                foldingStrategy.UpdateFoldings(foldingManager, textEditor.Document);
+                foldingStrategy.UpdateFoldings(this.FoldingManager, textEditor.Document);
 
                 gotoProjectMenu.Visibility = Visibility.Visible;
             }
@@ -399,7 +399,7 @@ async
                 selectionStart--;
             }
 
-            var projFolding = foldingManager.GetFoldingsContaining(selectionStart)?.LastOrDefault(f => f.Title == "<Project>");
+            var projFolding = this.FoldingManager.GetFoldingsContaining(selectionStart)?.LastOrDefault(f => f.Title == "<Project>");
             if (projFolding != null)
             {
                 textEditor.Select(projFolding.StartOffset, projFolding.Title.Length);

--- a/src/StructuredLogger/Strings/Strings.cs
+++ b/src/StructuredLogger/Strings/Strings.cs
@@ -327,32 +327,32 @@ namespace Microsoft.Build.Logging.StructuredLogger
             {
                 case "cs-CZ":
                     text = text
-                        .Replace(@"$({0})={1} (", @"\$\((?<Name>\w+)\)="".*"" \(")
-                        .Replace(@"{2})", @".*\)")
+                        .Replace(@"$({0})={1} (", @"\$\((?<Name>\w+)\)=""(?<NewValue>.*)"" \(")
+                        .Replace(@"{2})", @"(?<OrgValue>.*)\)")
                         .Replace("{3}", @"(?<File>.*) \((?<Line>\d+),(?<Column>\d+)\)");
                     break;
                 case "ko-KR":
                     text = text
                         .Replace(@"$({0})={3}", @"\$\((?<Name>\w+)\)=(?<File>.*) \((?<Line>\d+),(?<Column>\d+)\)")
-                        .Replace("{1}", ".*")
-                        .Replace("{2}", ".*");
+                        .Replace("{1}", "(?<NewValue>.*)")
+                        .Replace("{2}", "(?<OrgValue>.*)");
                     break;
                 case "pl-PL":
                     text = text
-                        .Replace(@"$({0})=„{1}” (", @"\$\((?<Name>\w+)\)=„.*” \(")
-                        .Replace(@"„{2}”)", @"„.*”\)")
+                        .Replace(@"$({0})=„{1}” (", @"\$\((?<Name>\w+)\)=„(?<NewValue>.*)” \(")
+                        .Replace(@"„{2}”)", @"„(?<OrgValue>.*)”\)")
                         .Replace("{3}", @"(?<File>.*) \((?<Line>\d+),(?<Column>\d+)\)");
                     break;
                 case "zh-Hans":
                     text = text
-                        .Replace(@"$({0})=“{1}”(", @"\$\((?<Name>\w+)\)=“.*”\(")
-                        .Replace(@"{2}”)", @".*”\)")
+                        .Replace(@"$({0})=“{1}”(", @"\$\((?<Name>\w+)\)=“(?<NewValue>.*)”\(")
+                        .Replace(@"{2}”)", @"(?<OrgValue>.*)”\)")
                         .Replace("{3}", @"(?<File>.*) \((?<Line>\d+),(?<Column>\d+)\)");
                     break;
                 default:
                     text = text
-                        .Replace(@"$({0})=""{1}"" (", @"\$\((?<Name>\w+)\)="".*"" \(")
-                        .Replace(@"{2}"")", @".*""\)")
+                        .Replace(@"$({0})=""{1}"" (", @"\$\((?<Name>\w+)\)=""(?<NewValue>.*)"" \(")
+                        .Replace(@"{2}"")", @"(?<OrgValue>.*)""\)")
                         .Replace("{3}", @"(?<File>.*) \((?<Line>\d+),(?<Column>\d+)\)");
                     break;
             }

--- a/src/StructuredLogger/TextUtilities.cs
+++ b/src/StructuredLogger/TextUtilities.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.Build.Logging.StructuredLogger
 {
@@ -247,6 +248,22 @@ namespace Microsoft.Build.Logging.StructuredLogger
 #else
                 text.Replace("\r\n", "\n").Replace("\r", "\n");
 #endif
+
+            return text;
+        }
+
+        /// <summary>
+        /// Normalize MSBuild property value for user reading.
+        /// </summary>
+        /// <returns>Returns a string without new lines, tabs, or excessive spaces.</returns>
+        public static string NormalizePropertyValue(this string text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return text;
+            }
+
+            text = Regex.Replace(text, @"(\s+)", " ");
 
             return text;
         }
@@ -728,7 +745,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
             }
 
             int previous = 0;
-            for (int i = 0; i > -1 && i < text.Length; )
+            for (int i = 0; i > -1 && i < text.Length;)
             {
                 i = text.IndexOf(openParen, i);
                 if (i == -1)


### PR DESCRIPTION
### Add Tooltip for MSBuild Properties in Preprocess View.
 - Add a simple tooltip that quickly shows the evaluated value for the property and the previous evaluations.
 - This feature saves time as it avoids a search in the "Properties and Item" tab.
 - I would like to add item group too, but the visual tends to be too long.  The tooltip popup should first richer.  

![image](https://github.com/user-attachments/assets/3c40a33d-909f-4cc1-b693-9bb715978245)
