### PR TITLE
Fix RecordKind populating

### DIFF
--- a/src/StructuredLogger/BinaryLogger/BinLogReader.cs
+++ b/src/StructuredLogger/BinaryLogger/BinLogReader.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using Microsoft.Build.Framework;
+using StructuredLogger.BinaryLogger;
 
 namespace Microsoft.Build.Logging.StructuredLogger
 {
@@ -319,7 +320,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
             else
             {
                 return ReadRecordsFromDecompressedStream(reader, true)
-                    .Select(r => new RecordInfo(r.Args != null ? ToBinaryLogRecordKind(r.Args) : r.Kind, r.Start, r.Length));
+                    .Select(r => new RecordInfo(r.Kind, r.Start, r.Length));
             }
         }
 
@@ -363,6 +364,12 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 PropertyInitialValueSetEventArgs _ => BinaryLogRecordKind.PropertyInitialValueSet,
                 AssemblyLoadBuildEventArgs _ => BinaryLogRecordKind.AssemblyLoad,
                 BuildMessageEventArgs _ => BinaryLogRecordKind.Message,
+                BuildSubmissionStartedEventArgs _ => BinaryLogRecordKind.BuildSubmissionStarted,
+                BuildCanceledEventArgs _ => BinaryLogRecordKind.BuildCanceled,
+                BuildCheckTracingEventArgs _ => BinaryLogRecordKind.BuildCheckTracing,
+                BuildCheckAcquisitionEventArgs _ => BinaryLogRecordKind.BuildCheckAcquisition,
+                BuildCheckEventArgs _ => BinaryLogRecordKind.BuildCheckMessage,
+
                 _ => throw new NotImplementedException(),
             };
 
@@ -460,7 +467,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
                     Args = instance,
                     Start = start,
                     Length = reader.Position - start,
-                    Kind = reader.LastRecordKind
+                    Kind = ToBinaryLogRecordKind(instance)
                 };
 
                 yield return record;

--- a/src/StructuredLogger/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/StructuredLogger/BinaryLogger/BuildEventArgsReader.cs
@@ -210,8 +210,6 @@ namespace Microsoft.Build.Logging.StructuredLogger
             }
         }
 
-        internal BinaryLogRecordKind LastRecordKind;
-
         /// <summary>
         /// Reads the next log record from the <see cref="BinaryReader"/>.
         /// </summary>
@@ -226,7 +224,6 @@ namespace Microsoft.Build.Logging.StructuredLogger
             while (result == null)
             {
                 BinaryLogRecordKind recordKind = PreprocessRecordsTillNextEvent(IsAuxiliaryRecord);
-                LastRecordKind = recordKind;
 
                 if (recordKind == BinaryLogRecordKind.EndOfFile)
                 {


### PR DESCRIPTION
Fix #877

## Background

`Record.Kind` was not populated in `ReadRecordsFromDecompressedStream` execution path - so added it there

## Drawback

Missing test(s) on `ReadRecords`

This change will require the `ToBinaryLogRecordKind` to be kept properly in sync with possible new added EventArgs - otherwise `ReadRecords` might throw otherwise. So test would be nice to prevent about forgotting. (btw. this affects api only - not the GUI - it uses different reading methods)


WDYT @KirillOsenkov? Would you preffer this to already added fix (https://github.com/KirillOsenkov/MSBuildStructuredLog/commit/78d683efc99fa0c1b8eac14a5d21dfdbecc8ecfe)?

