### PR TITLE
Add support for a portable data dir

### DIFF
--- a/src/StructuredLogViewer.Core/SettingsService.cs
+++ b/src/StructuredLogViewer.Core/SettingsService.cs
@@ -155,6 +155,11 @@ namespace StructuredLogViewer
 
         public static string GetRootPath()
         {
+            if (Environment.GetEnvironmentVariable("MSBUILDSTRUCTUREDLOG_DATA_DIR") is {} dataDir)
+            {
+                return Path.GetFullPath(dataDir);
+            }
+
             var path = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
             path = Path.Combine(path, "Microsoft", "MSBuildStructuredLog");
             return path;

--- a/src/StructuredLogger/PathUtils.cs
+++ b/src/StructuredLogger/PathUtils.cs
@@ -12,6 +12,11 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
         private static string GetRootPath()
         {
+            if (Environment.GetEnvironmentVariable("MSBUILDSTRUCTUREDLOG_DATA_DIR") is {} dataDir)
+            {
+                return Path.GetFullPath(dataDir);
+            }
+
 #if NETCORE
             var path = Path.GetTempPath();
 #else


### PR DESCRIPTION
This PR adds support for `MSBUILDSTRUCTUREDLOG_DATA_DIR` environment variable – if set, app settings and logs are stored in this directory.

As a result, it should be possible to unpack the .nupkg onto a USB flash drive with a small launcher script to set the env var and use the app without touching system directories. There's still the slightly annoying banner about missing `Update.exe`, but that doesn't seem trivial to hide, so I left it alone for now.