### PR TITLE
Show full file path in tooltips

### DIFF
--- a/src/StructuredLogViewer.Avalonia/Controls/DocumentWell.xaml
+++ b/src/StructuredLogViewer.Avalonia/Controls/DocumentWell.xaml
@@ -10,7 +10,7 @@
     <TabControl Name="tabControl" ItemsSource="{Binding #documentWell.Tabs}">
       <TabControl.ItemTemplate>
         <DataTemplate DataType="{x:Type local:SourceFileTab}">
-            <StackPanel Orientation="Horizontal">
+            <StackPanel Orientation="Horizontal" ToolTip.Tip="{Binding FilePath}">
                 <TextBlock MinWidth="50"
                             Text="{Binding FileName}"
                             VerticalAlignment="Center" />

--- a/src/StructuredLogViewer.Avalonia/Controls/TextViewerControl.xaml
+++ b/src/StructuredLogViewer.Avalonia/Controls/TextViewerControl.xaml
@@ -47,7 +47,8 @@
                Padding="4"
                Background="Transparent"
                BorderThickness="0"
-               IsReadOnly="True" />
+               IsReadOnly="True"
+               ToolTip.Tip="{Binding #filePathText.Text}" />
     </DockPanel>
 
     <a:TextEditor Name="textEditor"

--- a/src/StructuredLogViewer/Controls/SourceFileTabHeader.cs
+++ b/src/StructuredLogViewer/Controls/SourceFileTabHeader.cs
@@ -13,9 +13,11 @@ namespace StructuredLogViewer.Controls
             this.tab = sourceFileTab;
             Close = new Command(InvokeClose);
             Header = Path.GetFileName(tab.FilePath);
+            FullPath = tab.FilePath;
         }
 
         public string Header { get; private set; }
+        public string FullPath { get; private set; }
 
         public Command Close { get; }
         public event Action<SourceFileTab> CloseRequested;

--- a/src/StructuredLogViewer/Controls/TextViewerControl.xaml
+++ b/src/StructuredLogViewer/Controls/TextViewerControl.xaml
@@ -63,7 +63,8 @@
                Background="Transparent"
                BorderThickness="0"
                IsReadOnly="True" 
-               IsReadOnlyCaretVisible="True" />
+               IsReadOnlyCaretVisible="True"
+               ToolTip="{Binding RelativeSource={RelativeSource Self}, Path=Text}" />
     </DockPanel>
 
     <a:TextEditor x:Name="textEditor"

--- a/src/StructuredLogViewer/themes/Generic.xaml
+++ b/src/StructuredLogViewer/themes/Generic.xaml
@@ -1211,7 +1211,7 @@
   </ControlTemplate>
 
   <DataTemplate x:Key="SourceFileTabHeaderTemplate">
-    <Grid>
+    <Grid ToolTip="{Binding FullPath}">
       <Grid.ColumnDefinitions>
         <ColumnDefinition Width="Auto" />
         <ColumnDefinition Width="Auto" />


### PR DESCRIPTION
When opening source, you might see a tab with a title like `Sdk.targets`. It can be hard to know which SDK this comes from. The full path is shown in the toolbar, but this can be truncated.

This change adds a tooltip to the tab and the toolbar item, showing the full path.

<img width="1154" height="106" alt="image" src="https://github.com/user-attachments/assets/109a9df7-3170-43d4-9c1b-c251fc730af3" />

<img width="1152" height="99" alt="image" src="https://github.com/user-attachments/assets/a6f93278-a0f4-4849-b996-060425264c7f" />
