### PR TITLE
Add "Copy visible subtree" command

### DIFF
--- a/src/StructuredLogViewer.Avalonia/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer.Avalonia/Controls/BuildControl.xaml.cs
@@ -35,6 +35,7 @@ namespace StructuredLogViewer.Avalonia.Controls
 
         private MenuItem copyItem;
         private MenuItem copySubtreeItem;
+        private MenuItem copyVisibleSubtreeItem;
         private MenuItem sortChildrenByNameItem;
         private MenuItem sortChildrenByDurationItem;
         private MenuItem copyNameItem;
@@ -143,22 +144,28 @@ namespace StructuredLogViewer.Avalonia.Controls
             sharedTreeContextMenu = new ContextMenu();
             var sharedCopyAllItem = new MenuItem() { Header = "Copy All" };
             var sharedCopySubtreeItem = new MenuItem() { Header = "Copy subtree" };
+            var sharedCopyVisibleSubtreeItem = new MenuItem() { Header = "Copy visible subtree" };
             sharedCopyAllItem.Click += (s, a) => CopyAll();
             sharedCopySubtreeItem.Click += (s, a) => CopySubtree();
+            sharedCopyVisibleSubtreeItem.Click += (s, a) => CopySubtree(visibleOnly: true);
             sharedTreeContextMenu.AddItem(sharedCopyAllItem);
             sharedTreeContextMenu.AddItem(sharedCopySubtreeItem);
+            sharedTreeContextMenu.AddItem(sharedCopyVisibleSubtreeItem);
 
             // Files
             filesTreeContextMenu = new ContextMenu();
             var filesCopyAllItem = new MenuItem { Header = "Copy All" };
             var filesCopyPathsItem = new MenuItem { Header = "Copy file paths" };
             var filesCopySubtreeItem = new MenuItem { Header = "Copy subtree" };
+            var filesCopyVisibleSubtreeItem = new MenuItem { Header = "Copy visible subtree" };
             filesCopyAllItem.Click += (s, a) => CopyAll();
             filesCopyPathsItem.Click += (s, a) => CopyPaths();
             filesCopySubtreeItem.Click += (s, a) => CopySubtree();
+            filesCopyVisibleSubtreeItem.Click += (s, a) => CopySubtree(visibleOnly: true);
             filesTreeContextMenu.AddItem(filesCopyAllItem);
             filesTreeContextMenu.AddItem(filesCopyPathsItem);
             filesTreeContextMenu.AddItem(filesCopySubtreeItem);
+            filesTreeContextMenu.AddItem(filesCopyVisibleSubtreeItem);
 
             // Build Log
             var contextMenu = new ContextMenu();
@@ -166,6 +173,7 @@ namespace StructuredLogViewer.Avalonia.Controls
             //contextMenu.Opened += ContextMenu_Opened;
             copyItem = new MenuItem() { Header = "Copy" };
             copySubtreeItem = new MenuItem() { Header = "Copy subtree" };
+            copyVisibleSubtreeItem = new MenuItem() { Header = "Copy visible subtree" };
             sortChildrenByNameItem = new MenuItem() { Header = "Sort children by name" };
             sortChildrenByDurationItem = new MenuItem() { Header = "Sort children by duration" };
             copyNameItem = new MenuItem() { Header = "Copy name" };
@@ -176,6 +184,7 @@ namespace StructuredLogViewer.Avalonia.Controls
             hideItem = new MenuItem() { Header = "Hide" };
             copyItem.Click += (s, a) => Copy();
             copySubtreeItem.Click += (s, a) => CopySubtree(treeView);
+            copyVisibleSubtreeItem.Click += (s, a) => CopySubtree(treeView, visibleOnly: true);
             sortChildrenByNameItem.Click += (s, a) => SortChildrenByName();
             sortChildrenByDurationItem.Click += (s, a) => SortChildrenByDuration();
             copyNameItem.Click += (s, a) => CopyName();
@@ -188,6 +197,7 @@ namespace StructuredLogViewer.Avalonia.Controls
             contextMenu.AddItem(preprocessItem);
             contextMenu.AddItem(copyItem);
             contextMenu.AddItem(copySubtreeItem);
+            contextMenu.AddItem(copyVisibleSubtreeItem);
             contextMenu.AddItem(sortChildrenByNameItem);
             contextMenu.AddItem(sortChildrenByDurationItem);
             contextMenu.AddItem(copyNameItem);
@@ -485,6 +495,7 @@ Recent:
             showFileInExplorerItem.IsVisible = CanShowInExplorer();
             var hasChildren = node is TreeNode t && t.HasChildren;
             copySubtreeItem.IsVisible = hasChildren;
+            copyVisibleSubtreeItem.IsVisible = hasChildren;
             sortChildrenByNameItem.IsVisible = hasChildren;
             sortChildrenByDurationItem.IsVisible = hasChildren;
             preprocessItem.IsVisible = node is IPreprocessable p && preprocessedFileManager.CanPreprocess(p);
@@ -1002,7 +1013,7 @@ Recent:
             }
         }
 
-        public void CopySubtree(TreeView tree = null)
+        public void CopySubtree(TreeView tree = null, bool visibleOnly = false)
         {
             tree = tree ?? ActiveTreeView;
             if (tree == null)
@@ -1012,7 +1023,7 @@ Recent:
 
             if (tree.SelectedItem is BaseNode treeNode)
             {
-                var text = Microsoft.Build.Logging.StructuredLogger.StringWriter.GetString(treeNode);
+                var text = Microsoft.Build.Logging.StructuredLogger.StringWriter.GetString(treeNode, visibleOnly);
                 CopyToClipboard(text);
             }
         }

--- a/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
@@ -39,6 +39,7 @@ namespace StructuredLogViewer.Controls
         private MenuItem gotoMenuGroup;
         private MenuItem copyItem;
         private MenuItem copySubtreeItem;
+        private MenuItem copyVisibleSubtreeItem;
         private MenuItem viewSubtreeTextItem;
         private MenuItem searchInSubtreeItem;
         private MenuItem searchInNodeByNameItem;
@@ -169,16 +170,19 @@ namespace StructuredLogViewer.Controls
             var sharedCopyItem = new MenuItem() { Header = "Copy" };
             var sharedCopyAllItem = new MenuItem() { Header = "Copy All" };
             var sharedCopySubtreeItem = new MenuItem() { Header = "Copy subtree" };
+            var sharedCopyVisibleSubtreeItem = new MenuItem() { Header = "Copy visible subtree" };
             favoriteSharedItem.Click += (s, a) => AddToFavorites();
             unfavoriteSharedItem.Click += (s, a) => RemoveFromFavorites();
             sharedCopyItem.Click += (s, a) => Copy();
             sharedCopyAllItem.Click += (s, a) => CopyAll();
             sharedCopySubtreeItem.Click += (s, a) => CopySubtree();
+            sharedCopyVisibleSubtreeItem.Click += (s, a) => CopySubtree(visibleOnly: true);
             sharedTreeContextMenu.AddItem(favoriteSharedItem);
             sharedTreeContextMenu.AddItem(unfavoriteSharedItem);
             sharedTreeContextMenu.AddItem(sharedCopyItem);
             sharedTreeContextMenu.AddItem(sharedCopyAllItem);
             sharedTreeContextMenu.AddItem(sharedCopySubtreeItem);
+            sharedTreeContextMenu.AddItem(sharedCopyVisibleSubtreeItem);
 
             // Files
             filesTreeContextMenu = new ContextMenu();
@@ -186,14 +190,17 @@ namespace StructuredLogViewer.Controls
             var filesCopyAllItem = new MenuItem { Header = "Copy All" };
             var filesCopyPathsItem = new MenuItem { Header = "Copy file paths" };
             var filesCopySubtreeItem = new MenuItem { Header = "Copy subtree" };
+            var filesCopyVisibleSubtreeItem = new MenuItem { Header = "Copy visible subtree" };
             filesCopyItem.Click += (s, a) => Copy();
             filesCopyAllItem.Click += (s, a) => CopyAll();
             filesCopyPathsItem.Click += (s, a) => CopyPaths();
             filesCopySubtreeItem.Click += (s, a) => CopySubtree();
+            filesCopyVisibleSubtreeItem.Click += (s, a) => CopySubtree(visibleOnly: true);
             filesTreeContextMenu.AddItem(filesCopyItem);
             filesTreeContextMenu.AddItem(filesCopyAllItem);
             filesTreeContextMenu.AddItem(filesCopyPathsItem);
             filesTreeContextMenu.AddItem(filesCopySubtreeItem);
+            filesTreeContextMenu.AddItem(filesCopyVisibleSubtreeItem);
 
             // Build Log
             var contextMenu = new ContextMenu();
@@ -204,6 +211,7 @@ namespace StructuredLogViewer.Controls
 
             copyItem = new MenuItem() { Header = "Copy" };
             copySubtreeItem = new MenuItem() { Header = "Copy subtree" };
+            copyVisibleSubtreeItem = new MenuItem() { Header = "Copy visible subtree" };
             viewSubtreeTextItem = new MenuItem() { Header = "View subtree text" };
             searchInSubtreeItem = new MenuItem() { Header = "Search in subtree" };
             excludeSubtreeFromSearchItem = new MenuItem() { Header = "Exclude subtree from search" };
@@ -246,6 +254,7 @@ namespace StructuredLogViewer.Controls
             debugItem = new MenuItem() { Header = "Debug" };
             copyItem.Click += (s, a) => Copy();
             copySubtreeItem.Click += (s, a) => CopySubtree(ActiveTreeView);
+            copyVisibleSubtreeItem.Click += (s, a) => CopySubtree(ActiveTreeView, visibleOnly: true);
             viewSubtreeTextItem.Click += (s, a) => ViewSubtreeText();
             searchInSubtreeItem.Click += (s, a) => SearchInSubtree();
             excludeSubtreeFromSearchItem.Click += (s, a) => ExcludeSubtreeFromSearch();
@@ -309,6 +318,7 @@ namespace StructuredLogViewer.Controls
 
             contextMenu.AddItem(copyItem);
             contextMenu.AddItem(copySubtreeItem);
+            contextMenu.AddItem(copyVisibleSubtreeItem);
             contextMenu.AddItem(copyFilePathItem);
             contextMenu.AddItem(copyChildrenItem);
             contextMenu.AddItem(copyNameItem);
@@ -977,6 +987,7 @@ Recent (");
             var hasChildren = node is TreeNode t && t.HasChildren;
             var hasChildrenVisibility = hasChildren ? Visibility.Visible : Visibility.Collapsed;
             copySubtreeItem.Visibility = hasChildrenVisibility;
+            copyVisibleSubtreeItem.Visibility = hasChildrenVisibility;
             viewSubtreeTextItem.Visibility = hasChildrenVisibility;
             copyChildrenItem.Visibility = hasChildrenVisibility;
             sortChildrenByNameItem.Visibility = hasChildrenVisibility;
@@ -1893,7 +1904,7 @@ Recent (");
             }
         }
 
-        public void CopySubtree(TreeView tree = null)
+        public void CopySubtree(TreeView tree = null, bool visibleOnly = false)
         {
             tree ??= ActiveTreeView;
             if (tree == null)
@@ -1903,7 +1914,7 @@ Recent (");
 
             if (tree.SelectedItem is BaseNode treeNode)
             {
-                var text = Microsoft.Build.Logging.StructuredLogger.StringWriter.GetString(treeNode);
+                var text = Microsoft.Build.Logging.StructuredLogger.StringWriter.GetString(treeNode, visibleOnly);
                 CopyToClipboard(text);
             }
         }

--- a/src/StructuredLogger/Serialization/StringWriter.cs
+++ b/src/StructuredLogger/Serialization/StringWriter.cs
@@ -6,16 +6,16 @@ namespace Microsoft.Build.Logging.StructuredLogger
     {
         public static int MaxStringLength = 100_000_000;
 
-        public static string GetString(BaseNode rootNode)
+        public static string GetString(BaseNode rootNode, bool visibleOnly = false)
         {
             var sb = new StringBuilder();
 
-            WriteNode(rootNode, sb, 0);
+            WriteNode(rootNode, sb, indent: 0, visibleOnly);
 
             return sb.ToString();
         }
 
-        private static void WriteNode(BaseNode node, StringBuilder sb, int indent = 0)
+        private static void WriteNode(BaseNode node, StringBuilder sb, int indent, bool visibleOnly)
         {
             if (node == null)
             {
@@ -33,22 +33,22 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
             sb.AppendLine(text);
 
-            var treeNode = node as TreeNode;
-            if (treeNode != null && treeNode.HasChildren)
+            if (node is TreeNode { HasChildren: true } treeNode)
             {
-                foreach (var child in treeNode.Children)
+                // Only recurse into children if we're not in visibleOnly mode, or if we are and the node is expanded
+                if (!visibleOnly || treeNode.IsExpanded)
                 {
-                    WriteNode(child, sb, indent + 1);
+                    foreach (var child in treeNode.Children)
+                    {
+                        WriteNode(child, sb, indent + 1, visibleOnly);
+                    }
                 }
             }
         }
 
         private static void Indent(StringBuilder sb, int indent)
         {
-            for (int i = 0; i < indent * 4; i++)
-            {
-                sb.Append(' ');
-            }
+            sb.Append(' ', indent * 4);
         }
     }
 }


### PR DESCRIPTION
The current "Copy subtree" command copies the *entire* subtree, including nodes that aren't visible in the tree given the current expansion state.

This change adds a new command that only copies what's visible in the tree.

My use case was having a long list of targets within a project, and two binlogs (before and after). It's very hard to spot the differences here, so I want to export the target names and compare then in another tool. This command enables that.

---

<img width="857" height="279" alt="image" src="https://github.com/user-attachments/assets/f13cba5b-fbed-4ec4-a1c0-65b4e23d45d6" />

Puts the following on the clipboard:

```
_EnableNpmPack
    Exec
    _ExecuteNpmPack = false
    _ExecuteNpmPack = true
    Task "Message" skipped, due to false condition; (!$(_ExecuteNpmPack) and '$(AllowSkipNpmPack)' == 'true') was evaluated as (!true and '' == 'true').
    Task "Error" skipped, due to false condition; (!$(_ExecuteNpmPack) and '$(AllowSkipNpmPack)' != 'true') was evaluated as (!true and '' != 'true').
```

Note how the "Exec" task doesn't list any children.