### PR TITLE
Add "Go to > Target Graph" command on target nodes

### DIFF
--- a/src/StructuredLogViewer/Controls/GraphHostControl.cs
+++ b/src/StructuredLogViewer/Controls/GraphHostControl.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Windows;
@@ -6,14 +6,22 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using System.Windows.Threading;
 using Microsoft.Build.Logging.StructuredLogger;
 
 namespace StructuredLogViewer.Controls;
 
 public class GraphHostControl : DockPanel
 {
-    public GraphHostControl()
+    private readonly string initialSelection;
+    
+    public GraphHostControl() : this(null)
     {
+    }
+    
+    public GraphHostControl(string initialSelection)
+    {
+        this.initialSelection = initialSelection;
         Initialize();
     }
 
@@ -71,10 +79,26 @@ public class GraphHostControl : DockPanel
             if (graph != null)
             {
                 graphControl.Digraph = graph;
+                
+                // Apply initial selection if specified
+                if (!string.IsNullOrEmpty(initialSelection))
+                {
+                    // Delay until loaded
+                    Dispatcher.BeginInvoke(() => Locate(initialSelection), DispatcherPriority.Loaded);
+                }
             }
 
             UpdateVisibility();
         }
+    }
+
+    /// <summary>
+    /// Locates and selects a node in the graph by searching for the specified text.
+    /// </summary>
+    /// <param name="text">The text to search for in the graph nodes</param>
+    public void Locate(string text)
+    {
+        graphControl?.Locate(text);
     }
 
     private void UpdateVisibility()


### PR DESCRIPTION
Currently the Target Graph is accessible via project or evaluation nodes only.

This change allows the graph to be accessed via target nodes. When opened, the target is automatically selected.

<img width="774" height="641" alt="image" src="https://github.com/user-attachments/assets/b6dcabd3-8235-4459-94a8-abe27d445fed" />

<img width="909" height="887" alt="image" src="https://github.com/user-attachments/assets/e0a1c48b-8be2-491f-ae68-5e7c4b10006b" />
