### PR TITLE
Add "Direct references only" option to graph control

### DIFF
--- a/src/StructuredLogViewer/Controls/GraphHostControl.cs
+++ b/src/StructuredLogViewer/Controls/GraphHostControl.cs
@@ -160,6 +160,13 @@ public class GraphHostControl : DockPanel
             Margin = new Thickness(0, 0, 8, 0)
         };
 
+        var directReferencesOnlyCheck = new CheckBox
+        {
+            Content = "Direct references only",
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(0, 0, 8, 0)
+        };
+
         var helpButton = new Button
         {
             Content = "Help",
@@ -242,6 +249,7 @@ public class GraphHostControl : DockPanel
 
         toolbar.Children.Add(showTextButton);
         toolbar.Children.Add(transitiveReduceCheck);
+        toolbar.Children.Add(directReferencesOnlyCheck);
         toolbar.Children.Add(depthCheckbox);
         toolbar.Children.Add(horizontalCheckbox);
         toolbar.Children.Add(invertedCheckbox);
@@ -297,6 +305,9 @@ public class GraphHostControl : DockPanel
 
         transitiveReduceCheck.Checked += (s, e) => graphControl.HideTransitiveEdges = true;
         transitiveReduceCheck.Unchecked += (s, e) => graphControl.HideTransitiveEdges = false;
+
+        directReferencesOnlyCheck.Checked += (s, e) => graphControl.DirectReferencesOnly = true;
+        directReferencesOnlyCheck.Unchecked += (s, e) => graphControl.DirectReferencesOnly = false;
 
         void Locate()
         {


### PR DESCRIPTION
The size of the target graph is often so large that related nodes aren't visible within the viewport.

This change adds a checkbox to the toolbar that causes nodes that aren't directly referenced from the selected node. Clicking on one of those nodes will refocus the graph around that node, adding any newly needed nodes and hiding any no longer directly referenced.

Screencast (includes command from #894, though that's not in this PR):

![direct-references-only](https://github.com/user-attachments/assets/8c70b974-f15f-43f0-89e4-e34421949979)
