### PR TITLE
Fix compilation bug when using preview SDK and C# 14

### DIFF
--- a/src/StructuredLogViewer/Controls/GraphControl.cs
+++ b/src/StructuredLogViewer/Controls/GraphControl.cs
@@ -228,7 +228,7 @@ public class GraphControl
         var groups = verticesToDisplay.GroupBy(groupBy).OrderBy(g => g.Key).ToArray();
         if (Inverted)
         {
-            groups = groups.Reverse().ToArray();
+            Array.Reverse(groups);
         }
 
         foreach (var vertexGroup in groups)

--- a/src/StructuredLogger/Analyzers/TargetGraph.cs
+++ b/src/StructuredLogger/Analyzers/TargetGraph.cs
@@ -136,14 +136,14 @@ namespace Microsoft.Build.Logging.StructuredLogger
             if (before.Length > 0)
             {
                 var folder = new Folder { Name = $"BeforeTargets" };
-                Add(folder, before.Reverse());
+                Add(folder, before.AsEnumerable().Reverse());
                 graphFolder.AddChild(folder);
             }
 
             if (after.Length > 0)
             {
                 var folder = new Folder { Name = $"AfterTargets" };
-                Add(folder, after.Reverse());
+                Add(folder, after.AsEnumerable().Reverse());
                 graphFolder.AddChild(folder);
             }
 


### PR DESCRIPTION
I started seeing compile errors in these lines in certain builds.

Possibly due to: https://github.com/dotnet/csharplang/blob/main/proposals/csharp-14.0/first-class-span-types.md

The `Reverse` extension method on these spans is now being considered as coming from `MemoryExtensions`, rather than `Enumerable`.