### PR TITLE
Ctrl + Shift + F focuses "Find in Files"

### DIFF
--- a/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
@@ -1916,6 +1916,24 @@ Recent (");
             leftPaneTabControl.SelectedItem = searchLogTab;
         }
 
+        public void SelectFindInFilesTab(string newText = null)
+        {
+            // Only proceed if Find in Files tab is available
+            if (findInFilesTab.Visibility != Visibility.Visible)
+            {
+                return;
+            }
+
+            if (newText != null)
+            {
+                findInFilesControl.SearchText = newText;
+            }
+
+            leftPaneTabControl.SelectedItem = findInFilesTab;
+            findInFilesControl.searchTextBox.Focus();
+            findInFilesControl.searchTextBox.SelectAll();
+        }
+
         public void Delete()
         {
             var node = treeView.SelectedItem as TreeNode;

--- a/src/StructuredLogViewer/MainWindow.xaml.cs
+++ b/src/StructuredLogViewer/MainWindow.xaml.cs
@@ -1055,6 +1055,11 @@ that project." };
             {
                 FocusSearch();
             }
+            else if (e.Key == Key.F && e.KeyboardDevice.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift))
+            {
+                CurrentBuildControl?.SelectFindInFilesTab();
+                e.Handled = true;
+            }
         }
 
         private void Window_KeyUp(object sender, KeyEventArgs e)


### PR DESCRIPTION
Similar to other editors and IDEs, make the Ctrl+Shift+F keyboard shortcut show the "Find in Files" search panel, moving focus to the search text box and selecting any existing text to make it easier to type or paste a new search term in directly.