### PR TITLE
Enable target graph horizontal scroll with mouse wheel

### DIFF
--- a/src/StructuredLogViewer/Controls/GraphControl.cs
+++ b/src/StructuredLogViewer/Controls/GraphControl.cs
@@ -47,12 +47,13 @@ public class GraphControl
         grid.Children.Add(canvas);
         grid.Children.Add(layersControl);
 
-        scrollViewer = new ScrollViewer()
+        scrollViewer = new ScrollViewer
         {
             HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
-            VerticalScrollBarVisibility = ScrollBarVisibility.Auto
+            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+            Content = grid
         };
-        scrollViewer.Content = grid;
+        scrollViewer.SetValue(ScrollViewerHelper.ShiftWheelScrollsHorizontallyProperty, true);
     }
 
     private bool darkTheme;

--- a/src/StructuredLogViewer/ScrollViewerHelper.cs
+++ b/src/StructuredLogViewer/ScrollViewerHelper.cs
@@ -53,6 +53,9 @@ namespace StructuredLogViewer
             if (d == null)
                 return null;
 
+            if (d is T t)
+                return t;
+
             var childCount = VisualTreeHelper.GetChildrenCount(d);
 
             for (var i = 0; i < childCount; i++)


### PR DESCRIPTION
Like other panels in this app, holding shift and scrolling the mouse wheel should scroll horizontally rather than vertically.