### PR TITLE
Improve start page shadow in dark theme

### DIFF
--- a/src/StructuredLogViewer/themes/Generic.xaml
+++ b/src/StructuredLogViewer/themes/Generic.xaml
@@ -993,12 +993,12 @@
           VerticalAlignment="Center">
         <Rectangle Fill="Black">
           <Rectangle.Effect>
-            <DropShadowEffect BlurRadius="40" 
-                            Color="LightGray" 
+            <DropShadowEffect BlurRadius="20" 
+                            Color="Black" 
                             Direction="-45" 
-                            Opacity="1.0" 
+                            Opacity="0.2" 
                             RenderingBias="Performance" 
-                            ShadowDepth="40" />
+                            ShadowDepth="10" />
           </Rectangle.Effect>
         </Rectangle>
         <Grid Background="{DynamicResource Theme_WhiteBackground}">


### PR DESCRIPTION
In dark theme, the shadow was lighter than the background, so it was more of a glow than a shadow, which looked a bit off.

This approach uses opacity to blend with whatever background the theme chooses. I made it a bit smaller too, so it was more noticeable in dark mode.

Before

<img width="2025" height="1556" alt="image" src="https://github.com/user-attachments/assets/51d44481-bd6b-4dc4-a4f3-924801f9fa80" />

After

<img width="2023" height="1554" alt="image" src="https://github.com/user-attachments/assets/cddd2ea2-5ed8-4e6e-9c36-97e99d5aae50" />
