### PR TITLE
Update Avalonia to 11.3.11 to fix Monospace font on Linux

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <CentralPackageTransitivePinningEnabled>True</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <PropertyGroup>
-    <AvaloniaVersion>11.1.3</AvaloniaVersion>
+    <AvaloniaVersion>11.3.11</AvaloniaVersion>
     <MSBuildPackageVersion>17.5.0</MSBuildPackageVersion>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Prior to Avalonia 11.2.0, it wasn't able to use "Monospace" on Linux. The change https://github.com/AvaloniaUI/Avalonia/pull/15703 shipped in 11.2.0 fixes that.

On Linux, fonts are resolved using fontconfig library. It can be configured by defining match patterns in fonts.conf. So, generic family names such as "Monospace" are usually defined as match patterns.

Prior to the change, this line prevented Avalonia from using the correctly resolved font for the generic family name, although the underlying library (Skia) resolved the correct font.

https://github.com/AvaloniaUI/Avalonia/commit/112187984b20787d749b94914e93299a3c7a0191#diff-047c1353fd5bbb011dbd2dea7c1d1a021f0fcfe583f6b9d4d0ab5888b67302f2L59