### PR TITLE
Add themed Chrome titlebar

### DIFF
--- a/src/StructuredLogViewer/MainWindow.xaml
+++ b/src/StructuredLogViewer/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="StructuredLogViewer.MainWindow"
+<Window x:Class="StructuredLogViewer.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:StructuredLogViewer"
@@ -10,45 +10,60 @@
         TextOptions.TextRenderingMode="ClearType"
         KeyDown="Window_KeyDown"
         KeyUp="Window_KeyUp"
+        WindowStyle="SingleBorderWindow"
         SnapsToDevicePixels="True">
+  <WindowChrome.WindowChrome>
+    <WindowChrome
+        CaptionHeight="20"
+        CornerRadius="4"
+        ResizeBorderThickness="4"/>
+  </WindowChrome.WindowChrome>
   <DockPanel>
     <DockPanel.LayoutTransform>
       <ScaleTransform x:Name="scaleTransform" CenterX="0" CenterY="0" ScaleX="1" ScaleY="1" />
     </DockPanel.LayoutTransform>
-    <Grid DockPanel.Dock="Top">
-    <Menu x:Name="mainMenu">
-      <MenuItem Header="_File">
-        <MenuItem Header="Start Page" Click="StartPage_Click" />
-        <Separator />
-        <MenuItem Header="_Build Solution/Project..." Click="Build_Click" InputGestureText="F6" />
-        <MenuItem Header="Rebuild Solution/Project" Click="Rebuild_Click" InputGestureText="Shift+F6" />
-        <Separator />
-        <MenuItem Header="_Open Log..." Click="Open_Click" InputGestureText="Ctrl+O" />
-        <MenuItem Header="_Open Graph..." Click="OpenGraph_Click" />
-        <MenuItem x:Name="ReloadMenu" Header="_Reload" Click="Reload_Click" InputGestureText="F5" />
-        <MenuItem x:Name="SaveAsMenu" Header="_Save Log As..." Click="SaveAs_Click" InputGestureText="Ctrl+S" />
-        <MenuItem x:Name="RedactSecretsMenu" Header="_Redact Secrets" Click="RedactSecrets_Click" InputGestureText="Ctrl+R" />
-                <Separator />
-        <MenuItem x:Name="StatsMenu" Header="_Statistics..." Click="Stats_Click" />
-        <Separator />
-        <MenuItem x:Name="RecentProjectsMenu" Header="Recent Projects" Visibility="Collapsed">
-        </MenuItem>
-        <MenuItem x:Name="RecentLogsMenu" Header="Recent Logs" Visibility="Collapsed">
-        </MenuItem>
-        <Separator x:Name="RecentItemsSeparator" Visibility="Collapsed" />
-        <MenuItem Header="Set _MSBuild Path" Click="SetMSBuild_Click" />
-        <Separator />
-        <MenuItem Header="E_xit" Click="Exit_Click" InputGestureText="Alt+F4" />
-      </MenuItem>
-      <MenuItem Header="_Help">
-        <MenuItem Header="Search Syntax" Click="HelpLink3_Click" />
-        <MenuItem Header="https://github.com/KirillOsenkov/MSBuildStructuredLog" Click="HelpLink_Click" />
-        <MenuItem Header="https://msbuildlog.com" Click="HelpLink2_Click" />
-        <MenuItem Header="Try a prototype with LLM-integration" Click="LLMButton_Click" />
-        <Separator />
-        <MenuItem Header="About" Click="HelpAbout_Click" />
-      </MenuItem>
-    </Menu>
+    <Grid DockPanel.Dock="Top" WindowChrome.IsHitTestVisibleInChrome="true">
+      <StackPanel Orientation="Horizontal" VerticalAlignment="Bottom" HorizontalAlignment="Left" Margin="8,8,0,0">
+        <Viewbox Stretch="Uniform" Height="20" Width="20">
+          <Canvas Width="100" Height="100">
+            <ContentControl Content="{DynamicResource LoggerIcon}" />
+          </Canvas>
+        </Viewbox>
+
+        <Menu x:Name="mainMenu" VerticalAlignment="Bottom">
+          <MenuItem Header="_File">
+            <MenuItem Header="Start Page" Click="StartPage_Click" />
+            <Separator />
+            <MenuItem Header="_Build Solution/Project..." Click="Build_Click" InputGestureText="F6" />
+            <MenuItem Header="Rebuild Solution/Project" Click="Rebuild_Click" InputGestureText="Shift+F6" />
+            <Separator />
+            <MenuItem Header="_Open Log..." Click="Open_Click" InputGestureText="Ctrl+O" />
+            <MenuItem Header="_Open Graph..." Click="OpenGraph_Click" />
+            <MenuItem x:Name="ReloadMenu" Header="_Reload" Click="Reload_Click" InputGestureText="F5" />
+            <MenuItem x:Name="SaveAsMenu" Header="_Save Log As..." Click="SaveAs_Click" InputGestureText="Ctrl+S" />
+            <MenuItem x:Name="RedactSecretsMenu" Header="_Redact Secrets" Click="RedactSecrets_Click" InputGestureText="Ctrl+R" />
+            <Separator />
+            <MenuItem x:Name="StatsMenu" Header="_Statistics..." Click="Stats_Click" />
+            <Separator />
+            <MenuItem x:Name="RecentProjectsMenu" Header="Recent Projects" Visibility="Collapsed">
+            </MenuItem>
+            <MenuItem x:Name="RecentLogsMenu" Header="Recent Logs" Visibility="Collapsed">
+            </MenuItem>
+            <Separator x:Name="RecentItemsSeparator" Visibility="Collapsed" />
+            <MenuItem Header="Set _MSBuild Path" Click="SetMSBuild_Click" />
+            <Separator />
+            <MenuItem Header="E_xit" Click="Exit_Click" InputGestureText="Alt+F4" />
+          </MenuItem>
+          <MenuItem Header="_Help">
+            <MenuItem Header="Search Syntax" Click="HelpLink3_Click" />
+            <MenuItem Header="https://github.com/KirillOsenkov/MSBuildStructuredLog" Click="HelpLink_Click" />
+            <MenuItem Header="https://msbuildlog.com" Click="HelpLink2_Click" />
+            <MenuItem Header="Try a prototype with LLM-integration" Click="LLMButton_Click" />
+            <Separator />
+            <MenuItem Header="About" Click="HelpAbout_Click" />
+          </MenuItem>
+        </Menu>
+      </StackPanel>
     <StackPanel Orientation="Horizontal"
         HorizontalAlignment="Right"
         VerticalAlignment="Top">
@@ -86,7 +101,17 @@
             <TextBlock Text="LLM integration (Preview)" VerticalAlignment="Center" />
           </StackPanel>
       </Button>
-    </StackPanel>
+        <StackPanel Orientation="Horizontal"
+                          HorizontalAlignment="Right" 
+                          Margin="10,0">
+          <Button Content="-" Width="25" Height="20" 
+                          Click="WindowMinimize_Click"/>
+          <Button x:Name="MaximizeButton" Content="□" Width="25" Height="20" 
+                          Click="WindowMaximize_Click"/>
+          <Button Content="X" Width="25" Height="20" 
+                          Click="WindowClose_Click" />
+        </StackPanel>
+      </StackPanel>
     </Grid>
     <Grid>
       <ContentPresenter x:Name="mainContent" Margin="7"/>

--- a/src/StructuredLogViewer/MainWindow.xaml.cs
+++ b/src/StructuredLogViewer/MainWindow.xaml.cs
@@ -36,11 +36,11 @@ namespace StructuredLogViewer
         {
             AppDomain.CurrentDomain.FirstChanceException += CurrentDomain_FirstChanceException;
 
-            InitializeComponent();
-
             var uri = new Uri("StructuredLogViewer;component/themes/Generic.xaml", UriKind.Relative);
             var generic = new ResourceDictionary { Source = uri };
             Application.Current.Resources.MergedDictionaries.Add(generic);
+
+            InitializeComponent();
 
             SourceInitialized += MainWindow_SourceInitialized;
             Loaded += MainWindow_Loaded;
@@ -268,6 +268,9 @@ namespace StructuredLogViewer
 
         private async void MainWindow_Loaded(object sender, RoutedEventArgs e)
         {
+            MaximizeButton.Content = this.WindowState == WindowState.Maximized ? "❐" :
+                MaximizeButton.Content = "□";
+
             try
             {
                 if (!HandleArguments() && !TryOpenFromClipboard())
@@ -1254,6 +1257,30 @@ that project." };
         private void LLMButton_Click(object sender, RoutedEventArgs e)
         {
             Process.Start(new ProcessStartInfo("https://github.com/JanKrivanek/MSBuildStructuredLog/releases") { UseShellExecute = true });
+        }
+
+        private void WindowMinimize_Click(object sender, RoutedEventArgs e)
+        {
+            WindowState = WindowState.Minimized;
+        }
+
+        private void WindowMaximize_Click(object sender, RoutedEventArgs e)
+        {
+            if (WindowState == WindowState.Maximized)
+            {
+                WindowState = WindowState.Normal;
+                MaximizeButton.Content = "□"; // Restore symbol
+            }
+            else
+            {
+                WindowState = WindowState.Maximized;
+                MaximizeButton.Content = "❐"; // Maximize symbol
+            }
+        }
+
+        private void WindowClose_Click(object sender, RoutedEventArgs e)
+        {
+            Close();
         }
     }
 }

--- a/src/StructuredLogViewer/themes/Generic.xaml
+++ b/src/StructuredLogViewer/themes/Generic.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:l="clr-namespace:Microsoft.Build.Logging.StructuredLogger;assembly=StructuredLogger"
                     xmlns:local="clr-namespace:Microsoft.Build.Logging.StructuredLogger"
@@ -132,6 +132,23 @@
 
   <SolidColorBrush x:Key="SearchResultBrush" Color="DarkOrange" />
   <SolidColorBrush x:Key="ContainsSearchResultBrush" Color="Bisque" />
+
+  <Canvas x:Key="LoggerIcon" x:Shared="False">
+    <Canvas.Effect>
+      <DropShadowEffect BlurRadius="15" Color="Gray" Opacity="0.5" />
+    </Canvas.Effect>
+    <Canvas.RenderTransform>
+      <ScaleTransform ScaleX="1" ScaleY="1" />
+    </Canvas.RenderTransform>
+    <Rectangle Width="35" Height="35" Canvas.Left="0" Canvas.Top="0" Stroke="{DynamicResource TargetStroke}" Fill="{DynamicResource TargetBrush}" />
+    <Rectangle Width="35" Height="35" Canvas.Left="25" Canvas.Top="35" Stroke="{DynamicResource ParameterStroke}" Fill="{DynamicResource ParameterBrush}" />
+    <Rectangle Width="35" Height="35" Canvas.Left="25" Canvas.Top="70" Stroke="{DynamicResource TaskStroke}" Fill="{DynamicResource TaskBrush}" />
+    <Rectangle Width="35" Height="35" Canvas.Left="60" Canvas.Top="35" Stroke="{DynamicResource ItemStroke}" Fill="{DynamicResource ItemBrush}" />
+    <Rectangle Width="35" Height="35" Canvas.Left="60" Canvas.Top="70" Stroke="{DynamicResource FolderStroke}" Fill="{DynamicResource ClosedFolderBrush}" />
+    <Line X1="16" Y1="35" X2="16" Y2="87" Stroke="Black" />
+    <Line X1="16" Y1="87" X2="25" Y2="87" Stroke="Black" />
+    <Line X1="16" Y1="53" X2="25" Y2="53" Stroke="Black" />
+  </Canvas>
 
   <DrawingBrush x:Key="SlnIcon">
     <DrawingBrush.Drawing>
@@ -1042,20 +1059,7 @@
                   Grid.Column="1">
               <StackPanel>
                 <Canvas Width="100" Height="100" Margin="20">
-                  <Canvas.Effect>
-                    <DropShadowEffect BlurRadius="15" Color="Gray" Opacity="0.5" />
-                  </Canvas.Effect>
-                  <Canvas.RenderTransform>
-                    <ScaleTransform ScaleX="1" ScaleY="1" />
-                  </Canvas.RenderTransform>
-                  <Rectangle Width="35" Height="35" Canvas.Left="0" Canvas.Top="0" Stroke="{DynamicResource TargetStroke}" Fill="{DynamicResource TargetBrush}" />
-                  <Rectangle Width="35" Height="35" Canvas.Left="25" Canvas.Top="35" Stroke="{DynamicResource ParameterStroke}" Fill="{DynamicResource ParameterBrush}" />
-                  <Rectangle Width="35" Height="35" Canvas.Left="25" Canvas.Top="70" Stroke="{DynamicResource TaskStroke}" Fill="{DynamicResource TaskBrush}" />
-                  <Rectangle Width="35" Height="35" Canvas.Left="60" Canvas.Top="35" Stroke="{DynamicResource ItemStroke}" Fill="{DynamicResource ItemBrush}" />
-                  <Rectangle Width="35" Height="35" Canvas.Left="60" Canvas.Top="70" Stroke="{DynamicResource FolderStroke}" Fill="{DynamicResource ClosedFolderBrush}" />
-                  <Line X1="16" Y1="35" X2="16" Y2="87" Stroke="Black" />
-                  <Line X1="16" Y1="87" X2="25" Y2="87" Stroke="Black" />
-                  <Line X1="16" Y1="53" X2="25" Y2="53" Stroke="Black" />
+                  <ContentControl Content="{StaticResource LoggerIcon}"/>
                 </Canvas>
                 <TextBlock Text="Open Log File"
                          FontSize="16"


### PR DESCRIPTION
## Add a custom chromed title bar to match the dark/light theme.

Before:
<img width="2769" height="225" alt="image" src="https://github.com/user-attachments/assets/ca3b8533-ba38-4269-ba72-50c43b4949a9" />
<img width="2742" height="198" alt="image" src="https://github.com/user-attachments/assets/a5ec44cb-d9e2-40c8-9cf4-8206dee4a3a3" />

After:
<img width="2370" height="150" alt="image" src="https://github.com/user-attachments/assets/b2a96a8c-42ec-4464-8a22-762754f6ec50" />
<img width="2346" height="168" alt="image" src="https://github.com/user-attachments/assets/5c0d33b5-72f5-4f21-9f5e-1762c011f4df" />

