### PR TITLE
Support VS Code Insiders with auto-detection and variant picker

### DIFF
--- a/src/StructuredLogViewer.Core/SettingsService.cs
+++ b/src/StructuredLogViewer.Core/SettingsService.cs
@@ -382,6 +382,14 @@ namespace StructuredLogViewer
             set => Set(ref vsCodeHintDismissed, value);
         }
 
+        private static string? preferredVSCodeVariant;
+        public static string? PreferredVSCodeVariant
+        {
+            get => Get(ref preferredVSCodeVariant);
+
+            set => Set(ref preferredVSCodeVariant, value);
+        }
+
         private static string? windowPosition;
         public static string? WindowPosition
         {
@@ -412,6 +420,7 @@ namespace StructuredLogViewer
         const string ShowConfigurationAndPlatformSetting = "ShowConfigurationAndPlatform=";
         const string UseDarkThemeSetting = "UseDarkTheme=";
         const string VSCodeHintDismissedSetting = "VSCodeHintDismissed=";
+        const string PreferredVSCodeVariantSetting = "PreferredVSCodeVariant=";
         const string WindowPositionSetting = "WindowPosition=";
         const string IgnoreEmbeddedFilesSetting = "IgnoreEmbeddedFiles=";
 
@@ -424,6 +433,7 @@ namespace StructuredLogViewer
             sb.AppendLine(ShowConfigurationAndPlatformSetting + ShowConfigurationAndPlatform.ToString());
             sb.AppendLine(UseDarkThemeSetting + useDarkTheme.ToString());
             sb.AppendLine(VSCodeHintDismissedSetting + vsCodeHintDismissed.ToString());
+            sb.AppendLine(PreferredVSCodeVariantSetting + preferredVSCodeVariant);
             sb.AppendLine(WindowPositionSetting + windowPosition);
             sb.AppendLine(IgnoreEmbeddedFilesSetting + IgnoreEmbeddedFiles);
 
@@ -453,6 +463,7 @@ namespace StructuredLogViewer
                     ProcessLine(ShowConfigurationAndPlatformSetting, line, ref ProjectOrEvaluationHelper.ShowConfigurationAndPlatform);
                     ProcessLine(UseDarkThemeSetting, line, ref useDarkTheme);
                     ProcessLine(VSCodeHintDismissedSetting, line, ref vsCodeHintDismissed);
+                    ProcessString(PreferredVSCodeVariantSetting, line, ref preferredVSCodeVariant);
                     ProcessString(WindowPositionSetting, line, ref windowPosition);
                     ProcessString(IgnoreEmbeddedFilesSetting, line, ref ignoreEmbeddedFiles);
 

--- a/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
@@ -23,6 +23,22 @@ using TPLTask = System.Threading.Tasks.Task;
 
 namespace StructuredLogViewer.Controls
 {
+    public class VSCodeInstallation
+    {
+        public string Name { get; }
+        public string ExePath { get; }
+        public string UriScheme { get; }
+        public string CliName { get; }
+
+        public VSCodeInstallation(string name, string exePath, string uriScheme, string cliName)
+        {
+            Name = name;
+            ExePath = exePath;
+            UriScheme = uriScheme;
+            CliName = cliName;
+        }
+    }
+
     public partial class BuildControl : UserControl
     {
         public Build Build { get; set; }
@@ -491,7 +507,7 @@ Right-clicking a project node may show the 'Preprocess' option if the version of
         /// Launches VS Code with the workspace folder and binlog URI handler.
         /// Auto-installs the binlog-analyzer extension if not already installed.
         /// </summary>
-        public void OpenInVSCode()
+        public void OpenInVSCode(VSCodeInstallation installation = null)
         {
             var binlogPath = Build?.LogFilePath;
             if (string.IsNullOrEmpty(binlogPath))
@@ -500,11 +516,16 @@ Right-clicking a project node may show the 'Preprocess' option if the version of
                 return;
             }
 
-            var codeExe = FindVSCodeExecutable();
-            if (codeExe == null)
+            if (installation == null)
+            {
+                var installations = FindVSCodeInstallations();
+                installation = installations.FirstOrDefault();
+            }
+
+            if (installation == null)
             {
                 MessageBox.Show(
-                    "Could not find VS Code (Code.exe). Make sure VS Code is installed.",
+                    "Could not find VS Code or VS Code Insiders.\nMake sure one of them is installed.",
                     "Open in VS Code",
                     MessageBoxButton.OK,
                     MessageBoxImage.Error);
@@ -513,12 +534,12 @@ Right-clicking a project node may show the 'Preprocess' option if the version of
 
             try
             {
-                TPLTask.Run(() => EnsureExtensionInstalled(codeExe));
+                TPLTask.Run(() => EnsureExtensionInstalled(installation));
 
                 var folder = GetWorkspacePath();
 
-                // Build the URI to trigger the extension's binlog loading
-                var uri = "vscode://dotutils.binlog-analyzer/open?path=" + Uri.EscapeDataString(binlogPath);
+                // Build the URI using the correct scheme for this variant
+                var uri = $"{installation.UriScheme}://dotutils.binlog-analyzer/open?path=" + Uri.EscapeDataString(binlogPath);
                 foreach (var attached in attachedBinlogs)
                 {
                     uri += "&path=" + Uri.EscapeDataString(attached);
@@ -526,6 +547,7 @@ Right-clicking a project node may show the 'Preprocess' option if the version of
 
                 // Launch VS Code with folder, then send URI after a short delay.
                 // Combining --new-window + --open-url in one call can cause VS Code to ignore the folder.
+                var codeExe = installation.ExePath;
                 var folderArg = !string.IsNullOrEmpty(folder) ? $"\"{folder}\"" : "";
                 Process.Start(new ProcessStartInfo { FileName = codeExe, Arguments = $"--new-window {folderArg}".Trim(), UseShellExecute = true });
 
@@ -543,8 +565,8 @@ Right-clicking a project node may show the 'Preprocess' option if the version of
             catch (Exception ex)
             {
                 MessageBox.Show(
-                    $"Failed to open VS Code.\n\n{ex.Message}",
-                    "Open in VS Code",
+                    $"Failed to open {installation.Name}.\n\n{ex.Message}",
+                    $"Open in {installation.Name}",
                     MessageBoxButton.OK,
                     MessageBoxImage.Error);
             }
@@ -552,15 +574,15 @@ Right-clicking a project node may show the 'Preprocess' option if the version of
 
         private static readonly string ExtensionId = "dotutils.binlog-analyzer";
 
-        private static void EnsureExtensionInstalled(string codeExe)
+        private static void EnsureExtensionInstalled(VSCodeInstallation installation)
         {
             try
             {
-                var codeDir = Path.GetDirectoryName(codeExe);
-                var codeCli = Path.Combine(codeDir, "bin", "code.cmd");
+                var codeDir = Path.GetDirectoryName(installation.ExePath);
+                var codeCli = Path.Combine(codeDir, "bin", installation.CliName + ".cmd");
                 if (!File.Exists(codeCli))
                 {
-                    codeCli = Path.Combine(codeDir, "bin", "code");
+                    codeCli = Path.Combine(codeDir, "bin", installation.CliName);
                 }
 
                 // Check if extension is already installed
@@ -600,41 +622,64 @@ Right-clicking a project node may show the 'Preprocess' option if the version of
             }
         }
 
-        private static string FindVSCodeExecutable()
+        public static List<VSCodeInstallation> FindVSCodeInstallations()
         {
-            // Check common install locations for Code.exe
-            string[] candidates =
+            var installations = new List<VSCodeInstallation>();
+
+            var variants = new[]
             {
-                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Programs", "Microsoft VS Code", "Code.exe"),
-                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Microsoft VS Code", "Code.exe"),
-                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Microsoft VS Code", "Code.exe"),
+                new { Name = "VS Code", FolderName = "Microsoft VS Code", ExeName = "Code.exe", UriScheme = "vscode", CliName = "code" },
+                new { Name = "VS Code Insiders", FolderName = "Microsoft VS Code Insiders", ExeName = "Code - Insiders.exe", UriScheme = "vscode-insiders", CliName = "code-insiders" },
             };
 
-            foreach (var candidate in candidates)
+            foreach (var variant in variants)
             {
-                if (File.Exists(candidate))
-                    return candidate;
+                string[] candidates =
+                {
+                    Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Programs", variant.FolderName, variant.ExeName),
+                    Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), variant.FolderName, variant.ExeName),
+                    Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), variant.FolderName, variant.ExeName),
+                };
+
+                foreach (var candidate in candidates)
+                {
+                    if (File.Exists(candidate))
+                    {
+                        installations.Add(new VSCodeInstallation(variant.Name, candidate, variant.UriScheme, variant.CliName));
+                        break;
+                    }
+                }
             }
 
-            // Fallback: resolve from code.cmd in PATH
+            // Fallback: resolve from code.cmd / code-insiders.cmd in PATH
             try
             {
                 var pathDirs = Environment.GetEnvironmentVariable("PATH")?.Split(Path.PathSeparator) ?? Array.Empty<string>();
-                foreach (var dir in pathDirs)
+                foreach (var variant in variants)
                 {
-                    var codeCmdPath = Path.Combine(dir, "code.cmd");
-                    if (File.Exists(codeCmdPath))
+                    if (installations.Any(i => i.CliName == variant.CliName))
+                        continue;
+
+                    var cmdName = variant.CliName + ".cmd";
+                    foreach (var dir in pathDirs)
                     {
-                        // code.cmd is in <install>/bin/, Code.exe is in <install>/
-                        var codeExe = Path.Combine(Path.GetDirectoryName(dir) ?? dir, "Code.exe");
-                        if (File.Exists(codeExe))
-                            return codeExe;
+                        var codeCmdPath = Path.Combine(dir, cmdName);
+                        if (File.Exists(codeCmdPath))
+                        {
+                            // code.cmd is in <install>/bin/, Code.exe is in <install>/
+                            var codeExe = Path.Combine(Path.GetDirectoryName(dir) ?? dir, variant.ExeName);
+                            if (File.Exists(codeExe))
+                            {
+                                installations.Add(new VSCodeInstallation(variant.Name, codeExe, variant.UriScheme, variant.CliName));
+                                break;
+                            }
+                        }
                     }
                 }
             }
             catch { }
 
-            return null;
+            return installations;
         }
 
         public void Dispose()

--- a/src/StructuredLogViewer/MainWindow.xaml
+++ b/src/StructuredLogViewer/MainWindow.xaml
@@ -84,17 +84,30 @@
         </Button>
         <Button x:Name="openInVSCodeButton"
             Padding="8,2,8,2"
-            Margin="0,0,8,0"
             Click="OpenInVSCode_Click"
             ToolTip="Open in VS Code with Copilot Chat and binlog MCP tools"
             Background="{DynamicResource Theme_InfoBarBackground}"
             Foreground="{DynamicResource Theme_InfoBarForeground}"
-            BorderThickness="1"
+            BorderThickness="1,1,0,1"
             Visibility="Collapsed">
           <StackPanel Orientation="Horizontal">
             <TextBlock Text="✨" FontSize="14" Margin="0,0,4,0" />
             <TextBlock x:Name="openInVSCodeText" Text="Open in VS Code" />
           </StackPanel>
+        </Button>
+        <Button x:Name="vsCodeDropdownButton"
+            Padding="4,2,4,2"
+            Margin="0,0,8,0"
+            Click="VSCodeDropdown_Click"
+            ToolTip="Choose VS Code variant"
+            Background="{DynamicResource Theme_InfoBarBackground}"
+            Foreground="{DynamicResource Theme_InfoBarForeground}"
+            BorderThickness="1"
+            Visibility="Collapsed">
+          <TextBlock Text="▾" FontSize="10" />
+          <Button.ContextMenu>
+            <ContextMenu x:Name="vsCodeVariantMenu" />
+          </Button.ContextMenu>
         </Button>
     </StackPanel>
     </Grid>

--- a/src/StructuredLogViewer/MainWindow.xaml.cs
+++ b/src/StructuredLogViewer/MainWindow.xaml.cs
@@ -29,6 +29,9 @@ namespace StructuredLogViewer
         private string lastSearchText;
         private double scale = 1.0;
 
+        private List<VSCodeInstallation> vsCodeInstallations;
+        private VSCodeInstallation selectedVSCodeInstallation;
+
         public const string DefaultTitle = "MSBuild Structured Log Viewer";
 
         public string VersionMessage { get; set; } = "Locally built version";
@@ -487,6 +490,7 @@ namespace StructuredLogViewer
                 projectFilePath = null;
                 currentBuild = null;
                 openInVSCodeButton.Visibility = Visibility.Collapsed;
+                vsCodeDropdownButton.Visibility = Visibility.Collapsed;
                 attachBinlogButton.Visibility = Visibility.Collapsed;
             }
 
@@ -496,7 +500,15 @@ namespace StructuredLogViewer
                 SaveAsMenu.Visibility = Visibility.Visible;
                 RedactSecretsMenu.Visibility = Visibility.Visible;
 
+                if (vsCodeInstallations == null)
+                {
+                    DetectVSCodeInstallations();
+                }
+
                 openInVSCodeButton.Visibility = Visibility.Visible;
+                vsCodeDropdownButton.Visibility = vsCodeInstallations.Count > 1
+                    ? Visibility.Visible
+                    : Visibility.Collapsed;
                 attachBinlogButton.Visibility = Visibility.Visible;
                 UpdateAttachmentLabel();
                 UpdateVSCodeTooltip(buildControl);
@@ -518,6 +530,7 @@ namespace StructuredLogViewer
                 SaveAsMenu.Visibility = Visibility.Collapsed;
                 RedactSecretsMenu.Visibility = Visibility.Collapsed;
                 openInVSCodeButton.Visibility = Visibility.Collapsed;
+                vsCodeDropdownButton.Visibility = Visibility.Collapsed;
                 attachBinlogButton.Visibility = Visibility.Collapsed;
                 vsCodeHintBar.Visibility = Visibility.Collapsed;
             }
@@ -1278,7 +1291,7 @@ that project." };
             var buildControl = CurrentBuildControl;
             if (buildControl != null)
             {
-                buildControl.OpenInVSCode();
+                buildControl.OpenInVSCode(selectedVSCodeInstallation);
             }
         }
 
@@ -1309,13 +1322,14 @@ that project." };
         {
             var buildControl = CurrentBuildControl;
             int count = buildControl?.AttachedBinlogCount ?? 0;
+            var variantName = selectedVSCodeInstallation?.Name ?? "VS Code";
             if (count > 0)
             {
-                openInVSCodeText.Text = $"Open in VS Code (+{count} binlog{(count > 1 ? "s" : "")})";
+                openInVSCodeText.Text = $"Open in {variantName} (+{count} binlog{(count > 1 ? "s" : "")})";
             }
             else
             {
-                openInVSCodeText.Text = "Open in VS Code";
+                openInVSCodeText.Text = $"Open in {variantName}";
             }
         }
 
@@ -1356,6 +1370,60 @@ that project." };
                    "• Click the status bar to manage loaded binlogs";
 
             openInVSCodeButton.ToolTip = tip;
+        }
+
+        private void DetectVSCodeInstallations()
+        {
+            vsCodeInstallations = BuildControl.FindVSCodeInstallations();
+
+            // Restore preferred variant from settings, or default to first detected
+            var preferred = SettingsService.PreferredVSCodeVariant;
+            selectedVSCodeInstallation = vsCodeInstallations.FirstOrDefault(i => i.Name == preferred)
+                ?? vsCodeInstallations.FirstOrDefault();
+
+            // Populate the dropdown context menu
+            vsCodeVariantMenu.Items.Clear();
+            foreach (var installation in vsCodeInstallations)
+            {
+                var item = new MenuItem
+                {
+                    Header = installation.Name,
+                    IsChecked = installation == selectedVSCodeInstallation,
+                    Tag = installation
+                };
+                item.Click += VSCodeVariant_Selected;
+                vsCodeVariantMenu.Items.Add(item);
+            }
+        }
+
+        private void VSCodeDropdown_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is Button button && button.ContextMenu != null)
+            {
+                button.ContextMenu.PlacementTarget = button;
+                button.ContextMenu.Placement = System.Windows.Controls.Primitives.PlacementMode.Bottom;
+                button.ContextMenu.IsOpen = true;
+            }
+        }
+
+        private void VSCodeVariant_Selected(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Tag is VSCodeInstallation installation)
+            {
+                selectedVSCodeInstallation = installation;
+                SettingsService.PreferredVSCodeVariant = installation.Name;
+
+                // Update checkmarks
+                foreach (var item in vsCodeVariantMenu.Items)
+                {
+                    if (item is MenuItem mi)
+                    {
+                        mi.IsChecked = mi.Tag == installation;
+                    }
+                }
+
+                UpdateAttachmentLabel();
+            }
         }
 
         private void DismissVSCodeHint_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary

Auto-detect both VS Code (stable) and VS Code Insiders installations so the **Open in VS Code** button works for users who only have Insiders installed.

When multiple variants are found, a small dropdown arrow appears next to the button to let the user switch. The choice is persisted across sessions.

Closes #935

## Changes

| File | What changed |
|------|-------------|
| SettingsService.cs | New PreferredVSCodeVariant setting persisted in Settings.txt |
| BuildControl.xaml.cs | New VSCodeInstallation class; FindVSCodeInstallations() detects stable + Insiders paths and PATH; OpenInVSCode() uses correct URI scheme; EnsureExtensionInstalled() uses variant-specific CLI |
| MainWindow.xaml | Split-button UI: main button + dropdown arrow (hidden when only one variant) |
| MainWindow.xaml.cs | Lazy detection on first build load, dropdown menu, selection persistence, dynamic button label |

## Behavior

- **Only stable installed** — button says Open in VS Code, no dropdown
- **Only Insiders installed** — button says Open in VS Code Insiders, no dropdown
- **Both installed** — dropdown arrow appears to switch; choice remembered across sessions
- URI scheme switches between vscode:// and vscode-insiders:// automatically