### PR TITLE
Upgrade TFMs from net8.0 to net10.0

### DIFF
--- a/src/BinlogTool/BinlogTool.csproj
+++ b/src/BinlogTool/BinlogTool.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Version>$(BinlogToolVersion)</Version>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RollForward>major</RollForward>
     <LangVersion>latest</LangVersion>
     <DebugType>embedded</DebugType>

--- a/src/BinlogToolExe/BinlogToolExe.csproj
+++ b/src/BinlogToolExe/BinlogToolExe.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Version>$(BinlogToolVersion)</Version>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RollForward>major</RollForward>
     <LangVersion>latest</LangVersion>
     <DebugType>embedded</DebugType>

--- a/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj
+++ b/src/StructuredLogViewer.Avalonia/StructuredLogViewer.Avalonia.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ApplicationIcon>StructuredLogger.ico</ApplicationIcon>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
   </PropertyGroup>

--- a/src/StructuredLogViewer/StructuredLogViewer.csproj
+++ b/src/StructuredLogViewer/StructuredLogViewer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net472;net10.0-windows</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <RootNamespace>StructuredLogViewer</RootNamespace>
     <UseWPF>true</UseWPF>
@@ -69,7 +69,7 @@
       BeforeTargets="GetCopyToOutputDirectoryItems"
       Condition="$(TargetFramework) == 'net472'">
     <PropertyGroup>
-      <CoreTaskRunnerOutDir>$([System.IO.Path]::GetFullPath(`$(OutDir)\..\..\..\TaskRunner\$(Configuration)\net8.0`))\</CoreTaskRunnerOutDir>
+      <CoreTaskRunnerOutDir>$([System.IO.Path]::GetFullPath(`$(OutDir)\..\..\..\TaskRunner\$(Configuration)\net10.0`))\</CoreTaskRunnerOutDir>
     </PropertyGroup>
     <ItemGroup>
       <TaskRunnerFile Include="$(CoreTaskRunnerOutDir)TaskRunner.dll" />

--- a/src/StructuredLogger.Utils/StructuredLogger.Utils.csproj
+++ b/src/StructuredLogger.Utils/StructuredLogger.Utils.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
     <NBGV_DoNotEmitNonVersionCustomAttributes>true</NBGV_DoNotEmitNonVersionCustomAttributes>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>

--- a/src/StructuredLogger/StructuredLogger.csproj
+++ b/src/StructuredLogger/StructuredLogger.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
     <NBGV_DoNotEmitNonVersionCustomAttributes>true</NBGV_DoNotEmitNonVersionCustomAttributes>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>

--- a/src/TaskRunner/TaskRunner.csproj
+++ b/src/TaskRunner/TaskRunner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net10.0</TargetFrameworks>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
 
@@ -10,7 +10,7 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(TargetFramework) == 'net8.0'">
+  <PropertyGroup Condition="$(TargetFramework) == 'net10.0'">
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
     <RollForward>LatestMajor</RollForward>
     <UseAppHost>false</UseAppHost>


### PR DESCRIPTION
Bumps all net8.0 TFMs to net10.0. Projects on netstandard2.0 and net472 are left as-is.

Also fixes the hardcoded `net8.0` path in the TaskRunner copy target in `StructuredLogViewer.csproj`.

### Perf

Tested binlog parse/load times on 5 binlogs ranging from 8 MB (3K records) to 424 MB (4.5M records). 5 runs, 2 warmup, Release.

net10 gives a free **~10–20% speedup** on binlog parsing across the board — just from the runtime upgrade. The largest file (424 MB) saw ~13% improvement on raw record replay and ~2% on full object model construction.