### PR TITLE
Preserve search text during rebuild process in Avalonia version

### DIFF
--- a/src/StructuredLogViewer.Avalonia/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer.Avalonia/Controls/BuildControl.xaml.cs
@@ -887,6 +887,8 @@ Recent:
 
         public string InitialSearchText { get; set; }
 
+        public string SearchText => searchLogControl?.SearchText;
+
         public void SelectItem(BaseNode item)
         {
             var parentChain = item.GetParentChainExcludingThis();

--- a/src/StructuredLogViewer.Avalonia/MainWindow.xaml.cs
+++ b/src/StructuredLogViewer.Avalonia/MainWindow.xaml.cs
@@ -388,7 +388,7 @@ namespace StructuredLogViewer.Avalonia
             SetContent(parametersScreen);
         }
 
-        private async void BuildCore(string projectFilePath, string customArguments)
+        private async void BuildCore(string projectFilePath, string customArguments, string searchText = null)
         {
             var progress = new BuildProgress() { IsIndeterminate = true };
             progress.ProgressText = $"Building {projectFilePath}...";
@@ -398,6 +398,10 @@ namespace StructuredLogViewer.Avalonia
             progress.ProgressText = "Analyzing build...";
             await QueueAnalyzeBuild(result);
             DisplayBuild(result);
+            if (!string.IsNullOrWhiteSpace(searchText) && CurrentBuildControl != null)
+            {
+                CurrentBuildControl.InitialSearchText = searchText;
+            }
         }
 
         private async Task QueueAnalyzeBuild(Build build)
@@ -466,8 +470,9 @@ namespace StructuredLogViewer.Avalonia
         {
             if (!string.IsNullOrEmpty(projectFilePath))
             {
+                var searchText = CurrentBuildControl?.SearchText;
                 var args = SettingsService.GetCustomArguments(projectFilePath);
-                BuildCore(projectFilePath, args);
+                BuildCore(projectFilePath, args, searchText);
             }
         }
 


### PR DESCRIPTION
This pull request ensures that the search text is preserved and reapplied during the rebuild process in the Avalonia version of the application. The implementation was mostly copied from the Windows version. The functionality to display the first error is still in place, but will only work if the search term is left blank (as it is done in the Windows version).