### PR TITLE
Bump DotUtils SensitiveDataDetector to 1.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
     <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.1" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="DiffPlex" Version="1.7.2" />
-    <PackageVersion Include="DotUtils.MsBuild.BinlogRedactor.SensitiveDataDetector" Version="0.0.9" />
+    <PackageVersion Include="DotUtils.MsBuild.BinlogRedactor.SensitiveDataDetector" Version="1.0.0" />
     <PackageVersion Include="DotUtils.StreamUtils.Sources" Version="0.0.8" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="GuiLabs.Language.Xml" Version="1.2.93" />


### PR DESCRIPTION
## Summary
Bumps the `DotUtils.MsBuild.BinlogRedactor.SensitiveDataDetector` dependency (the secrets-detection engine used by `StructuredLogger.Utils`) from **0.0.9** to **1.0.0**.

## Validation
- `StructuredLogger.Utils` builds cleanly against 1.0.0 on both `netstandard2.0` and `net10.0`.
- The detector's public API (`SensitiveDataDetectorFactory`, `ISensitiveDataDetector.Detect`, `ISensitiveDataRedactor.Redact`, `SecretDescriptor`, `SensitiveDataKind`) is unchanged, so this is a non-breaking dependency update.

## Note
Requires `DotUtils.MsBuild.BinlogRedactor.SensitiveDataDetector 1.0.0` to be published to nuget.org first (see dotutils/MSBuild.BinlogRedactor#16, which makes that package nuget.org-publishable by moving off an internal prerelease `Microsoft.Build` dev build).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>