### PR TITLE
Add MSBuild Server lifecycle node support (binlog format v27)

### DIFF
--- a/src/StructuredLogViewer.Avalonia/App.xaml
+++ b/src/StructuredLogViewer.Avalonia/App.xaml
@@ -303,6 +303,19 @@
                            Opacity="{Binding IsLowRelevance, Converter={StaticResource RelevanceConverter}}" />
             </StackPanel>
         </DataTemplate>
+
+        <DataTemplate DataType="{x:Type l:MSBuildServerNode}">
+            <StackPanel Orientation="Horizontal">
+                <Rectangle Name="icon"
+                           Classes="nodeIcon"
+                           Stroke="{StaticResource MSBuildServerStroke}"
+                           Fill="{StaticResource MSBuildServerBrush}" />
+                <TextBlock Name="messageText"
+                           Classes="nodeText"
+                           Text="{Binding ShortenedText}"
+                           Opacity="{Binding IsLowRelevance, Converter={StaticResource RelevanceConverter}}" />
+            </StackPanel>
+        </DataTemplate>
         
         <TreeDataTemplate DataType="{x:Type l:Import}"
                           ItemsSource="{Binding Children}">

--- a/src/StructuredLogViewer.Avalonia/Resources.xaml
+++ b/src/StructuredLogViewer.Avalonia/Resources.xaml
@@ -14,6 +14,7 @@
     <SolidColorBrush x:Key="ItemStroke" Color="MediumAquamarine" />
     <SolidColorBrush x:Key="MetadataStroke" Color="MediumAquamarine" />
     <SolidColorBrush x:Key="MessageStroke" Color="LightGray" />
+    <SolidColorBrush x:Key="MSBuildServerStroke" Color="CornflowerBlue" />
     <SolidColorBrush x:Key="ImportStroke" Color="Sienna" />
     <SolidColorBrush x:Key="NoImportStroke" Color="Red" />
     <SolidColorBrush x:Key="ErrorStroke" Color="Red" />
@@ -62,6 +63,11 @@
     <LinearGradientBrush x:Key="MessageBrush" StartPoint="0%,0%" EndPoint="100%,100%">
         <GradientStop Color="White" Offset="0" />
         <GradientStop Color="LightGray" Offset="1" />
+    </LinearGradientBrush>
+
+    <LinearGradientBrush x:Key="MSBuildServerBrush" StartPoint="0%,0%" EndPoint="100%,100%">
+        <GradientStop Color="AliceBlue" Offset="0" />
+        <GradientStop Color="CornflowerBlue" Offset="1" />
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="ErrorBrush" StartPoint="0%,0%" EndPoint="100%,100%">

--- a/src/StructuredLogViewer/themes/Generic.xaml
+++ b/src/StructuredLogViewer/themes/Generic.xaml
@@ -60,6 +60,7 @@
   <SolidColorBrush x:Key="AddItemStroke" Color="Teal" />
   <SolidColorBrush x:Key="MetadataStroke" Color="Teal" />
   <SolidColorBrush x:Key="MessageStroke" Color="LightGray" />
+  <SolidColorBrush x:Key="MSBuildServerStroke" Color="CornflowerBlue" />
   <SolidColorBrush x:Key="ImportStroke" Color="Sienna" />
   <SolidColorBrush x:Key="NoImportStroke" Color="Red" />
   <SolidColorBrush x:Key="NoImportFill" Color="BlanchedAlmond" />
@@ -118,6 +119,11 @@
   <LinearGradientBrush x:Key="MessageBrush" StartPoint="0,0" EndPoint="1,1">
     <GradientStop Color="White" Offset="0" />
     <GradientStop Color="LightGray" Offset="1" />
+  </LinearGradientBrush>
+
+  <LinearGradientBrush x:Key="MSBuildServerBrush" StartPoint="0,0" EndPoint="1,1">
+    <GradientStop Color="AliceBlue" Offset="0" />
+    <GradientStop Color="CornflowerBlue" Offset="1" />
   </LinearGradientBrush>
 
   <LinearGradientBrush x:Key="ErrorBrush" StartPoint="0,0" EndPoint="1,1">
@@ -639,6 +645,19 @@
                             ItemsSource="{Binding Children}">
     <StackPanel Orientation="Horizontal">
       <Rectangle x:Name="icon" Style="{StaticResource NodeIcon}" Stroke="{DynamicResource MessageStroke}" Fill="{DynamicResource MessageBrush}" />
+      <TextBlock x:Name="messageText" Text="{Binding ShortenedText}" />
+    </StackPanel>
+    <DataTemplate.Triggers>
+      <DataTrigger Binding="{Binding IsLowRelevance}" Value="True">
+        <Setter TargetName="messageText" Property="Opacity" Value="0.25" />
+      </DataTrigger>
+    </DataTemplate.Triggers>
+  </HierarchicalDataTemplate>
+
+  <HierarchicalDataTemplate DataType="{x:Type l:MSBuildServerNode}"
+                            ItemsSource="{Binding Children}">
+    <StackPanel Orientation="Horizontal">
+      <Rectangle x:Name="icon" Style="{StaticResource NodeIcon}" Stroke="{DynamicResource MSBuildServerStroke}" Fill="{DynamicResource MSBuildServerBrush}" />
       <TextBlock x:Name="messageText" Text="{Binding ShortenedText}" />
     </StackPanel>
     <DataTemplate.Triggers>

--- a/src/StructuredLogger/BinaryLogger/BinaryLogRecordKind.cs
+++ b/src/StructuredLogger/BinaryLogger/BinaryLogRecordKind.cs
@@ -37,5 +37,7 @@
         BuildCheckAcquisition,
         BuildSubmissionStarted,
         BuildCanceled,
+        LoggersRegistered,
+        MSBuildServerLifecycle,
     }
 }

--- a/src/StructuredLogger/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/StructuredLogger/BinaryLogger/BuildEventArgsReader.cs
@@ -342,6 +342,8 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 BinaryLogRecordKind.BuildCheckAcquisition => ReadBuildCheckAcquisitionEventArgs(),
                 BinaryLogRecordKind.BuildSubmissionStarted => ReadBuildSubmissionStartedEventArgs(),
                 BinaryLogRecordKind.BuildCanceled => ReadBuildCanceledEventArgs(),
+                BinaryLogRecordKind.LoggersRegistered => ReadLoggersRegisteredEventArgs(),
+                BinaryLogRecordKind.MSBuildServerLifecycle => ReadMSBuildServerLifecycleEventArgs(),
                 _ => null,
                 
             };
@@ -1345,6 +1347,66 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 assemblyPath,
                 mvid,
                 appDomainName);
+            SetCommonFields(e, fields);
+            e.ProjectFile = fields.ProjectFile;
+
+            return e;
+        }
+
+        private BuildEventArgs ReadMSBuildServerLifecycleEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields(readImportance: true);
+
+            MSBuildServerLifecycleKind kind = (MSBuildServerLifecycleKind)ReadInt32();
+            int processId = ReadInt32();
+            string reason = ReadDeduplicatedString();
+            string reasonCode = ReadDeduplicatedString();
+            bool shortLived = ReadBoolean();
+
+            var e = new MSBuildServerLifecycleEventArgs(
+                kind,
+                processId,
+                reason,
+                reasonCode,
+                fields.Message,
+                fields.Importance,
+                shortLived);
+            SetCommonFields(e, fields);
+            e.ProjectFile = fields.ProjectFile;
+
+            return e;
+        }
+
+        private BuildEventArgs ReadLoggersRegisteredEventArgs()
+        {
+            // Registered-loggers event (binary-log format v26+). This fork does not have a strongly-typed node
+            // for it; read (and discard) the logger list — including each logger's output file paths — so the
+            // record is fully consumed, and surface the "Enabled loggers: ..." text as an ordinary message
+            // instead of skipping it.
+            var fields = ReadBuildEventArgsFields();
+
+            int count = ReadInt32();
+            for (int i = 0; i < count; i++)
+            {
+                ReadDeduplicatedString(); // LoggerName
+                ReadDeduplicatedString(); // Parameters
+                if (ReadBoolean())        // has verbosity
+                {
+                    ReadInt32();          // Verbosity
+                }
+
+                int pathCount = ReadInt32();
+                for (int j = 0; j < pathCount; j++)
+                {
+                    ReadDeduplicatedString(); // output file path
+                }
+            }
+
+            var e = new BuildMessageEventArgs(
+                fields.Message,
+                fields.HelpKeyword,
+                fields.SenderName,
+                fields.Importance);
             SetCommonFields(e, fields);
             e.ProjectFile = fields.ProjectFile;
 

--- a/src/StructuredLogger/BinaryLogger/MSBuildServerLifecycleEventArgs.cs
+++ b/src/StructuredLogger/BinaryLogger/MSBuildServerLifecycleEventArgs.cs
@@ -1,0 +1,58 @@
+using System;
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// Identifies how a build related to the MSBuild Server node.
+    /// </summary>
+    public enum MSBuildServerLifecycleKind
+    {
+        Spawned,
+        Reused,
+        NotUsed,
+    }
+
+    /// <summary>
+    /// Records how a build related to the MSBuild Server node (spawned, reused, or requested but not used).
+    /// Emitted by MSBuild under its own binary-log record kind (see dotnet/msbuild).
+    /// </summary>
+    [Serializable]
+    public class MSBuildServerLifecycleEventArgs : BuildMessageEventArgs
+    {
+        public MSBuildServerLifecycleEventArgs()
+        {
+        }
+
+        public MSBuildServerLifecycleEventArgs(
+            MSBuildServerLifecycleKind kind,
+            int processId,
+            string reason,
+            string reasonCode,
+            string message,
+            MessageImportance importance,
+            bool shortLived)
+            : base(message, null, "MSBuild", importance)
+        {
+            Kind = kind;
+            ProcessId = processId;
+            Reason = reason;
+            ReasonCode = reasonCode;
+            ShortLived = shortLived;
+        }
+
+        /// <summary>How the build related to the MSBuild Server node.</summary>
+        public MSBuildServerLifecycleKind Kind { get; set; }
+
+        /// <summary><see langword="true"/> when a spawned server will shut down after this build (short-lived).</summary>
+        public bool ShortLived { get; set; }
+
+        /// <summary>The MSBuild Server node's process id, or 0 when not applicable.</summary>
+        public int ProcessId { get; set; }
+
+        /// <summary>A localized reason the server was not used (for <see cref="MSBuildServerLifecycleKind.NotUsed"/>).</summary>
+        public string Reason { get; set; }
+
+        /// <summary>A stable, non-localized code for the fall-back cause (for <see cref="MSBuildServerLifecycleKind.NotUsed"/>).</summary>
+        public string ReasonCode { get; set; }
+    }
+}

--- a/src/StructuredLogger/Construction/MessageProcessor.cs
+++ b/src/StructuredLogger/Construction/MessageProcessor.cs
@@ -26,6 +26,32 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
         private string Intern(string text) => stringTable.Intern(text);
 
+        /// <summary>Name of the folder under Build that collects MSBuild Server lifecycle events.</summary>
+        private const string MSBuildServerFolderName = "MSBuild Server";
+
+        /// <summary>
+        /// Adds an MSBuild Server lifecycle event as a dedicated node under a "MSBuild Server" folder.
+        /// </summary>
+        private void ProcessMSBuildServerLifecycle(MSBuildServerLifecycleEventArgs args)
+        {
+            var node = new MSBuildServerNode
+            {
+                Text = Intern(args.Message),
+                Kind = Intern(args.Kind.ToString()),
+                ShortLived = args.ShortLived,
+                Reason = string.IsNullOrEmpty(args.Reason) ? null : Intern(args.Reason),
+                ReasonCode = string.IsNullOrEmpty(args.ReasonCode) ? null : Intern(args.ReasonCode),
+            };
+
+            if (args.ProcessId != 0)
+            {
+                node.ProcessId = args.ProcessId;
+            }
+
+            var folder = construction.Build.GetOrCreateNodeWithName<Folder>(MSBuildServerFolderName);
+            folder.AddChild(node);
+        }
+
         public void Process(BuildMessageEventArgs args)
         {
             if (args == null)
@@ -36,6 +62,14 @@ namespace Microsoft.Build.Logging.StructuredLogger
             if (fileFormatVersion == 0)
             {
                 fileFormatVersion = construction.Build.FileFormatVersion;
+            }
+
+            // MSBuild Server lifecycle events (spawn/reuse/not-used) are a dedicated, structured event type.
+            // Surface them under a "MSBuild Server" folder with their own node type (and icon).
+            if (args is MSBuildServerLifecycleEventArgs serverLifecycle)
+            {
+                ProcessMSBuildServerLifecycle(serverLifecycle);
+                return;
             }
 
             if (args is TaskParameterEventArgs taskParameter)

--- a/src/StructuredLogger/ObjectModel/MSBuildServerNode.cs
+++ b/src/StructuredLogger/ObjectModel/MSBuildServerNode.cs
@@ -1,0 +1,30 @@
+namespace Microsoft.Build.Logging.StructuredLogger
+{
+    /// <summary>
+    /// Represents an MSBuild Server lifecycle event for a build: the server node was freshly spawned,
+    /// an already-running node was reused, or the server was requested but the build ran in-process.
+    /// MSBuild emits these as a dedicated MSBuildServerLifecycleEventArgs (its own binary-log record kind);
+    /// see documentation/MSBuild-Server.md in dotnet/msbuild.
+    /// </summary>
+    public class MSBuildServerNode : Message
+    {
+        /// <summary>"Spawned", "Reused", or "NotUsed".</summary>
+        public string Kind { get; set; }
+
+        /// <summary>True when a spawned server will shut down after this build (short-lived).</summary>
+        public bool ShortLived { get; set; }
+
+        /// <summary>The server node's process id, when known (for spawned/reused).</summary>
+        public int? ProcessId { get; set; }
+
+        /// <summary>The localized reason the server was not used, when applicable (for not-used).</summary>
+        public string Reason { get; set; }
+
+        /// <summary>A stable, non-localized code for the fall-back cause (for not-used), e.g. "node-reuse-disabled".</summary>
+        public string ReasonCode { get; set; }
+
+        // Serialize as a plain Message (matching TimedMessage / MessageWithLocation) so .buildlog round-tripping
+        // keeps working; the dedicated DataTemplate keyed on this CLR type still gives it a distinct icon.
+        public override string TypeName => nameof(Message);
+    }
+}


### PR DESCRIPTION
Companion to [dotnet/msbuild#14156](https://github.com/dotnet/msbuild/pull/14156), which records how each build relates to the MSBuild Server node as a dedicated `MSBuildServerLifecycleEventArgs`, serialized under its own `BinaryLogRecordKind.MSBuildServerLifecycle` (binary-log **format version 27**).

This teaches the viewer to read and render that record.

### Changes
- **Read** the new `MSBuildServerLifecycle` record (`BuildEventArgsReader` + a vendored `MSBuildServerLifecycleEventArgs`).
- **Render** it as a dedicated `MSBuildServerNode` under a **"MSBuild Server"** folder, with a distinct icon (WPF `Generic.xaml` + Avalonia). The node exposes `Kind` (Spawned / Reused / NotUsed), `ShortLived`, `ProcessId`, `Reason` and `ReasonCode`.
- Also **read the `LoggersRegistered` record** (format v26). Without this, opening a v26/v27 binlog reports *"Skipped some data unknown to this version of Viewer"* for that record; it is now surfaced as an ordinary message.

### Behavior for the four server scenarios
| Scenario | Node |
|---|---|
| cold build | `Kind=Spawned` |
| next build | `Kind=Reused` (same PID) |
| `-nr:false` (non-`/mt`) | `Kind=NotUsed`, `ReasonCode=node-reuse-disabled` |
| `/mt -nr:false` | `Kind=Spawned`, `ShortLived=True` |

### Notes
- The record kind is **backward-compatible**: older viewers that predate it skip it gracefully (it is length-prefixed and its minimum-reader-version is unchanged). This PR simply lets the viewer render it instead of skipping.
- `MSBuildServerNode` serializes as a `Message` (like `TimedMessage`/`MessageWithLocation`) so `.buildlog` round-tripping is unaffected; the dedicated CLR type still drives the distinct icon.
- Draft pending the MSBuild side (dotnet/msbuild#14156) merging and the format version being finalized.
