### PR TITLE
Recover truncated binlogs from killed or timed-out builds

### DIFF
--- a/src/StructuredLogger.Tests/BinaryLoggerTests.cs
+++ b/src/StructuredLogger.Tests/BinaryLoggerTests.cs
@@ -438,5 +438,244 @@ namespace Microsoft.Build.UnitTests
             // There is nothing else in the stream
             memoryStream.Position.Should().Be(length);
         }
+
+        // ---------------------------------------------------------------------------------------
+        // Truncated / interrupted binlog recovery.
+        //
+        // A build that is hard-killed (test-run timeout killer, taskkill /F, CI job cancel, OOM,
+        // crash) never runs BinaryLogger.Shutdown(), so its .binlog is missing the trailing
+        // EndOfFile marker (and the gzip footer). The reader must recover every complete record
+        // written before the cut, stop cleanly instead of throwing, and flag the log as truncated
+        // so the viewer/CLI can tell the user the log was "recovered" and is "partial".
+        // ---------------------------------------------------------------------------------------
+
+        [Fact]
+        public void InterruptedLog_ReadStopsCleanlyAndFlagsTruncation()
+        {
+            // No EndOfFile marker => the producing build was interrupted before it finalized the log.
+            byte[] records = WriteEventRecords(count: 5, withEndOfFileMarker: false);
+
+            var (recovered, truncated, thrown) = ReadAllEvents(records);
+
+            thrown.Should().BeNull("a truncated log must stop cleanly, not throw");
+            recovered.Should().Be(5, "every complete record written before the cut is still recoverable");
+            truncated.Should().BeTrue("a stream that ends without an EndOfFile marker is a truncated log");
+        }
+
+        [Fact]
+        public void FinalizedLog_ReadDoesNotFlagTruncation()
+        {
+            // A cleanly shut-down build terminates the record stream with an EndOfFile marker.
+            byte[] records = WriteEventRecords(count: 5, withEndOfFileMarker: true);
+
+            var (recovered, truncated, thrown) = ReadAllEvents(records);
+
+            thrown.Should().BeNull();
+            recovered.Should().Be(5);
+            truncated.Should().BeFalse("an EndOfFile marker means the log was finalized - not truncated");
+        }
+
+        [Theory]
+        [InlineData(0.90)]
+        [InlineData(0.60)]
+        [InlineData(0.35)]
+        [InlineData(0.15)]
+        public void TruncatedLog_ReadRecoversPrefixWithoutThrowing(double keptFraction)
+        {
+            // Cut the stream at an arbitrary offset to hit both record-boundary and mid-record
+            // truncation. Whatever the cut, reading must never throw and must flag truncation.
+            byte[] full = WriteEventRecords(count: 8, withEndOfFileMarker: true);
+            int keep = Math.Max(1, (int)(full.Length * keptFraction));
+            byte[] truncatedRecords = full.Take(keep).ToArray();
+
+            var (recovered, truncated, thrown) = ReadAllEvents(truncatedRecords);
+
+            thrown.Should().BeNull("mid-stream truncation must be handled without crashing");
+            truncated.Should().BeTrue("a cut stream loses its EndOfFile marker");
+            recovered.Should().BeInRange(0, 8);
+        }
+
+        [Fact]
+        public void ReadRaw_TruncatedLog_ReturnsSyntheticEndOfFileWithoutThrowing()
+        {
+            // The raw record path backs BinlogTool `dumprecords` / ChunkBinlog, which used to crash
+            // (0xE0434352) on a truncated log. It must now terminate at a synthetic EndOfFile.
+            byte[] full = WriteEventRecords(count: 6, withEndOfFileMarker: false);
+            byte[] truncatedRecords = full.Take(full.Length / 2).ToArray();
+
+            var memoryStream = new MemoryStream(truncatedRecords);
+            var binaryReader = new BinaryReader(memoryStream);
+            using var reader = new Logging.StructuredLogger.BuildEventArgsReader(binaryReader, BinaryLogger.FileFormatVersion);
+
+            Exception thrown = null;
+            bool reachedEndOfFile = false;
+            try
+            {
+                for (int guard = 0; guard < 10_000; guard++)
+                {
+                    var raw = reader.ReadRaw();
+                    if (raw.RecordKind == BinaryLogRecordKind.EndOfFile)
+                    {
+                        reachedEndOfFile = true;
+                        break;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                thrown = ex;
+            }
+
+            thrown.Should().BeNull("the raw reader must stop cleanly on a truncated log instead of crashing");
+            reachedEndOfFile.Should().BeTrue("raw reading terminates at a synthetic EndOfFile");
+            reader.ReachedEndOfStreamPrematurely.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Replay_InterruptedLog_SetsHasEncounteredTruncation()
+        {
+            // End-to-end through the real seam: gzip + file header + BinLogReader.Replay.
+            using var stream = CreateBinlogStream(withEndOfFileMarker: false);
+
+            var reader = new BinLogReader();
+            reader.Replay(stream);
+
+            reader.HasEncounteredTruncation.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Replay_FinalizedLog_DoesNotSetTruncation()
+        {
+            using var stream = CreateBinlogStream(withEndOfFileMarker: true);
+
+            var reader = new BinLogReader();
+            reader.Replay(stream);
+
+            reader.HasEncounteredTruncation.Should().BeFalse();
+        }
+
+        [Fact]
+        public void ReadBuild_InterruptedLog_SurfacesRecoveredPartialError()
+        {
+            // The user-facing behavior: a truncated binlog opens as a build carrying exactly one
+            // clear "recovered a partial binlog" error (message text mirrors BinaryLog.cs).
+            using var stream = CreateBinlogStream(withEndOfFileMarker: false);
+
+            var build = BinaryLog.ReadBuild(stream);
+
+            build.Should().NotBeNull();
+            var truncationErrors = build.FindChildrenRecursive<Microsoft.Build.Logging.StructuredLogger.Error>(
+                e => e.Text != null && e.Text.StartsWith("Recovered a partial binlog"));
+            truncationErrors.Should().ContainSingle("a truncated binlog is surfaced as a single 'recovered a partial binlog' error");
+        }
+
+        [Fact]
+        public void ReadBuild_FinalizedLog_HasNoTruncationError()
+        {
+            using var stream = CreateBinlogStream(withEndOfFileMarker: true);
+
+            var build = BinaryLog.ReadBuild(stream);
+
+            build.Should().NotBeNull();
+            var truncationErrors = build.FindChildrenRecursive<Microsoft.Build.Logging.StructuredLogger.Error>(
+                e => e.Text != null && e.Text.StartsWith("Recovered a partial binlog"));
+            truncationErrors.Should().BeEmpty("a finalized binlog must not report truncation");
+        }
+
+        // Writes `count` well-formed build event records as a raw record stream (no file header, no
+        // gzip), mirroring the ForwardCompatibleRead_* tests. Optionally terminates with an EndOfFile
+        // marker to represent a cleanly finalized log.
+        private static byte[] WriteEventRecords(int count, bool withEndOfFileMarker)
+        {
+            var memoryStream = new MemoryStream();
+            var binaryWriter = new BinaryWriter(memoryStream);
+            var writer = new BuildEventArgsWriter(binaryWriter);
+
+            for (int i = 0; i < count; i++)
+            {
+                writer.Write(CreateEvent(i));
+            }
+
+            binaryWriter.Flush();
+
+            if (withEndOfFileMarker)
+            {
+                // The EndOfFile terminator is written straight to the underlying stream (as
+                // BinaryLogger.Shutdown does with stream.WriteByte), not through the record-framing
+                // writer, which buffers into a discarded per-record stream.
+                memoryStream.WriteByte((byte)BinaryLogRecordKind.EndOfFile);
+            }
+
+            return memoryStream.ToArray();
+        }
+
+        // Builds a complete gzip-compressed binlog stream (file header + records) the way
+        // BinaryLogger writes one, optionally without the trailing EndOfFile marker to simulate a
+        // hard-killed build. The gzip itself is valid; only the record stream inside is unterminated.
+        private static Stream CreateBinlogStream(bool withEndOfFileMarker)
+        {
+            var decompressed = new MemoryStream();
+            var binaryWriter = new BinaryWriter(decompressed);
+
+            // File header: fileFormatVersion + minimumReaderVersion, both raw Int32 (v18+).
+            binaryWriter.Write(BinaryLogger.FileFormatVersion);
+            binaryWriter.Write(BinaryLogger.FileFormatVersion);
+
+            var writer = new BuildEventArgsWriter(binaryWriter);
+            writer.Write(new BuildStartedEventArgs("Build started", helpKeyword: null));
+            for (int i = 0; i < 4; i++)
+            {
+                writer.Write(CreateEvent(i));
+            }
+
+            binaryWriter.Flush();
+
+            if (withEndOfFileMarker)
+            {
+                // Terminator written directly to the stream, matching BinaryLogger.Shutdown.
+                decompressed.WriteByte((byte)BinaryLogRecordKind.EndOfFile);
+            }
+
+            decompressed.Position = 0;
+
+            var compressed = new MemoryStream();
+            using (var gzip = new System.IO.Compression.GZipStream(compressed, System.IO.Compression.CompressionLevel.Optimal, leaveOpen: true))
+            {
+                decompressed.CopyTo(gzip);
+            }
+
+            compressed.Position = 0;
+            return compressed;
+        }
+
+        private static BuildEventArgs CreateEvent(int i) => (i % 3) switch
+        {
+            0 => new BuildMessageEventArgs($"message {i} with a reasonably long payload so records span several bytes", "Help", "Sender", MessageImportance.Normal),
+            1 => new BuildErrorEventArgs("Subcategory", $"CODE{i}", "File.cs", i + 1, i + 2, i + 3, i + 4, $"error message {i}", "Help", "Sender"),
+            _ => new BuildWarningEventArgs("Subcategory", $"WARN{i}", "File.cs", i + 1, i + 2, i + 3, i + 4, $"warning message {i}", "Help", "Sender"),
+        };
+
+        private static (int recovered, bool truncated, Exception thrown) ReadAllEvents(byte[] recordBytes)
+        {
+            var memoryStream = new MemoryStream(recordBytes);
+            var binaryReader = new BinaryReader(memoryStream);
+            using var reader = new Logging.StructuredLogger.BuildEventArgsReader(binaryReader, BinaryLogger.FileFormatVersion);
+
+            int recovered = 0;
+            Exception thrown = null;
+            try
+            {
+                while (reader.Read() != null)
+                {
+                    recovered++;
+                }
+            }
+            catch (Exception ex)
+            {
+                thrown = ex;
+            }
+
+            return (recovered, reader.ReachedEndOfStreamPrematurely, thrown);
+        }
     }
 }

--- a/src/StructuredLogger/BinaryLog.cs
+++ b/src/StructuredLogger/BinaryLog.cs
@@ -179,6 +179,16 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 build.AddChild(node);
             }
 
+            if (eventSource.HasEncounteredTruncation && build != null)
+            {
+                build.AddChild(new Error()
+                {
+                    Text = "Recovered a partial binlog. The build was stopped before the log was " +
+                        "finalized, so it holds only the events collected up to that point — " +
+                        "everything shown is valid."
+                });
+            }
+
             return build;
         }
     }

--- a/src/StructuredLogger/BinaryLogger/BinLogReader.cs
+++ b/src/StructuredLogger/BinaryLogger/BinLogReader.cs
@@ -38,6 +38,14 @@ namespace Microsoft.Build.Logging.StructuredLogger
         public event Action<BinaryLogReaderErrorEventArgs>? RecoverableReadError;
 
         /// <summary>
+        /// Set to true after <see cref="Replay(Stream, Progress)"/> if the log ended without an
+        /// EndOfFile marker, i.e. it was truncated because the build that produced it was interrupted
+        /// (killed, timed out, or crashed) before it could be finalized. All complete records were
+        /// still replayed.
+        /// </summary>
+        public bool HasEncounteredTruncation { get; private set; }
+
+        /// <summary>
         /// Read the provided binary log file and raise corresponding events for each BuildEventArgs
         /// </summary>
         /// <param name="sourceFilePath">The full file path of the binary log file</param>
@@ -180,6 +188,8 @@ namespace Microsoft.Build.Logging.StructuredLogger
                     }
                 }
             }
+
+            HasEncounteredTruncation = reader.ReachedEndOfStreamPrematurely;
 
             if (progress != null)
             {

--- a/src/StructuredLogger/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/StructuredLogger/BinaryLogger/BuildEventArgsReader.cs
@@ -177,27 +177,39 @@ namespace Microsoft.Build.Logging.StructuredLogger
             ////                           $"Raw data reading is not supported for file format version {_fileFormatVersion} (needs >=18).");
             ////}
 
-            if (_lastSubStream?.IsAtEnd == false)
+            try
             {
-                _lastSubStream.ReadToEnd();
+                if (_lastSubStream?.IsAtEnd == false)
+                {
+                    _lastSubStream.ReadToEnd();
+                }
+
+                BinaryLogRecordKind recordKind =
+                    PreprocessRecordsTillNextEvent(decodeTextualRecords ? IsTextualDataRecord : (_ => false));
+
+                if (recordKind == BinaryLogRecordKind.EndOfFile)
+                {
+                    return new(recordKind, Stream.Null);
+                }
+
+                int serializedEventLength = ReadInt32();
+                Stream stream = _binaryReader.BaseStream.Slice(serializedEventLength);
+
+                _lastSubStream = stream as SubStream;
+
+                _recordNumber += 1;
+
+                return new(recordKind, stream);
             }
-
-            BinaryLogRecordKind recordKind =
-                PreprocessRecordsTillNextEvent(decodeTextualRecords ? IsTextualDataRecord : (_ => false));
-
-            if (recordKind == BinaryLogRecordKind.EndOfFile)
+            catch (EndOfStreamException)
             {
-                return new(recordKind, Stream.Null);
+                // Truncated/interrupted log: the stream ends before a record is complete and no
+                // EndOfFile marker was written. Report a synthetic end-of-file so raw consumers
+                // (ChunkBinlog, BinlogTool dumprecords) stop cleanly instead of crashing, and record
+                // that the log was truncated.
+                ReachedEndOfStreamPrematurely = true;
+                return new(BinaryLogRecordKind.EndOfFile, Stream.Null);
             }
-
-            int serializedEventLength = ReadInt32();
-            Stream stream = _binaryReader.BaseStream.Slice(serializedEventLength);
-
-            _lastSubStream = stream as SubStream;
-
-            _recordNumber += 1;
-
-            return new(recordKind, stream);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -213,6 +225,15 @@ namespace Microsoft.Build.Logging.StructuredLogger
         internal BinaryLogRecordKind LastRecordKind;
 
         /// <summary>
+        /// Set to true when the reader reached the physical end of the stream without encountering
+        /// the <see cref="BinaryLogRecordKind.EndOfFile"/> marker. This means the log was truncated
+        /// because the build that produced it was interrupted (killed, timed out, or crashed) before
+        /// <c>BinaryLogger.Shutdown()</c> could finalize it. Every complete record read before that
+        /// point is still valid and has been returned.
+        /// </summary>
+        public bool ReachedEndOfStreamPrematurely { get; private set; }
+
+        /// <summary>
         /// Reads the next log record from the <see cref="BinaryReader"/>.
         /// </summary>
         /// <returns>
@@ -225,19 +246,32 @@ namespace Microsoft.Build.Logging.StructuredLogger
             BuildEventArgs? result = null;
             while (result == null)
             {
-                BinaryLogRecordKind recordKind = PreprocessRecordsTillNextEvent(IsAuxiliaryRecord);
-                LastRecordKind = recordKind;
-
-                if (recordKind == BinaryLogRecordKind.EndOfFile)
-                {
-                    return null;
-                }
-
+                BinaryLogRecordKind recordKind;
                 int serializedEventLength = 0;
-                if (_fileFormatVersion >= BinaryLogger.ForwardCompatibilityMinimalVersion)
+                try
                 {
-                    serializedEventLength = ReadInt32(); // record length
-                    _readStream.BytesCountAllowedToRead = serializedEventLength;
+                    recordKind = PreprocessRecordsTillNextEvent(IsAuxiliaryRecord);
+                    LastRecordKind = recordKind;
+
+                    if (recordKind == BinaryLogRecordKind.EndOfFile)
+                    {
+                        return null;
+                    }
+
+                    if (_fileFormatVersion >= BinaryLogger.ForwardCompatibilityMinimalVersion)
+                    {
+                        serializedEventLength = ReadInt32(); // record length
+                        _readStream.BytesCountAllowedToRead = serializedEventLength;
+                    }
+                }
+                catch (EndOfStreamException)
+                {
+                    // Reached the physical end of a truncated log while positioning at / sizing the
+                    // next record, with no EndOfFile marker present. The producing build was killed
+                    // (timeout, taskkill /F, crash) before BinaryLogger.Shutdown() ran. Stop cleanly
+                    // so all complete records read so far are recovered.
+                    ReachedEndOfStreamPrematurely = true;
+                    return null;
                 }
 
                 bool hasError = false;
@@ -264,6 +298,13 @@ namespace Microsoft.Build.Logging.StructuredLogger
                             : string.Empty);
 
                     HandleError(ErrorFactory, _skipUnknownEvents, ReaderErrorType.UnknownFormatOfEventData, recordKind, e);
+                }
+                catch (EndOfStreamException)
+                {
+                    // Ran out of physical bytes in the middle of a record (the log was truncated by an
+                    // interrupted build). Recover everything up to here and stop without throwing.
+                    ReachedEndOfStreamPrematurely = true;
+                    return null;
                 }
 
                 if (result == null && !hasError)


### PR DESCRIPTION
When a build that writes a `.binlog` is hard-killed or times out before it finalizes the log (test-host timeout killer, CI cancel that TerminateProcess-es, `taskkill /F`, OOM), the file is left with no `EndOfFile` marker and no gzip footer. Most of the build is already on disk, but reading it throws `EndOfStreamException` on the final partial record. The viewer surfaces that as a red "Error when reading the file" node with a raw stack trace, and the CLI paths (`BinlogTool`, raw `ReadRecords`) crash with `0xE0434352`. 

**This reads very harsh and as an internal error of the viewer, leading me to believe that the log is useless.** As a result a log that is mostly fine, looks corrupt and gets thrown away, which is exactly the log you want when a build times out.

This change softens it, and shows the user that this is an "expected" error state, that we know how to handle, and that we show them as much information as we can:

> Recovered a partial binlog. The build was stopped before the log was finalized, so it holds only the events collected up to that point — everything shown is valid.

The wording was chosen intentionally from multiple candidates to communicate that this expected error state (recovered) and that this is an error state (partial).

Because the fix is on the reader-side it it recovers logs from older MSBuild versions too, no writer change needed. Only the final partial record and whatever was still in the 32 KB buffer at kill time is lost.

Same `killed.binlog` (a real `dotnet build -bl` killed mid-build) before and after. 63,326 nodes recover either way, only the message changes.

Before:

![before](https://raw.githubusercontent.com/nohwnd/MSBuildStructuredLog/pr-assets/pr/before.png)

After:

![after](https://raw.githubusercontent.com/nohwnd/MSBuildStructuredLog/pr-assets/pr/after.png)

The raw exception and stack trace are gone, the yellow first-chance "Unable to read beyond the end of the stream" toast no longer fires because nothing throws, and `$error` finds one honest node. The build still shows as failed, which is correct, it was stopped.

**Command line**

`BinlogTool` reads the same records, so it hit the same truncation. Before this change it did not just show an error, it crashed the process:

```
binlogtool dumprecords --input:killed.binlog --include-rollup --include-total --exclude-details

RecordType, Count, Size[bytes]
==============================
Unhandled exception. System.IO.EndOfStreamException: Unable to read beyond the end of the stream.
   at System.IO.BinaryReader.ReadByte()
   at ...BuildEventArgsReader.ReadRaw(...) in BuildEventArgsReader.cs:line 185
   at ...BinLogReader.ChunkBinlogWithOffsets(...)+MoveNext() in BinLogReader.cs:line 333
   at BinlogTool.DumpRecords.RunSingle(...) in DumpRecords.cs:line 73
   at BinlogTool.Program.Main(...) in Program.cs:line 240
```

Exit code `-532462766` (`0xE0434352`, the CLR code for an unhandled managed exception).

After, the raw reader stops at a synthetic `EndOfFile` at the truncation point and the tool finishes normally:

```
binlogtool dumprecords --input:killed.binlog --include-rollup --include-total --exclude-details

...
ProjectFinished, 6, 27.00
TargetSkipped, 43, 66.95
EndOfFile, 1, 0.00

Total records: 10091
```

Exit code `0`.

I left the exit code at `0` on purpose. A finalized log of a build that failed to compile also returns `0` today, the build error is just an `Error` record in the stream:

```
binlogtool dumprecords --input:failed.binlog --include-rollup --include-total --exclude-details

Error, 1, 36.00
EndOfFile, 1, 0.00
Total records: 8797
```

Exit code `0`.

So on the command line the truncated log is now downgraded to the same level as any other build error. The tool no longer crashes, it reads what is there, and the exit code keeps the meaning it always had, that the tool processed the file and not that the build was error free. The one behavior that changed is that a truncated log used to abort with the `0xE0434352` crash code, and now returns `0` like any other readable log.

Verification: library, WPF viewer and BinlogTool all build clean. Added 11 regression tests in `BinaryLoggerTests.cs` covering the reader record path, the raw/CLI path, and the end-to-end gzip + header + `ReadBuild` seam (finalized logs stay clean, truncated logs at record-boundary and mid-record cuts recover a prefix and set the flag, and the user-facing error text is asserted). The 4 existing forward-compatibility reader tests still pass.

Related: dotnet/msbuild#3815. The writer-side counterpart (finalize on cancel, or periodic gzip member flush) would prevent the loss in the first place, this is the reader-side half that makes every already-broken log usable.

