### PR TITLE
Point 'Open in VS Code' at ms-dotnettools.msbuild-binlog-analyzer

### DIFF
--- a/src/StructuredLogViewer.Avalonia/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer.Avalonia/Controls/BuildControl.xaml.cs
@@ -461,7 +461,7 @@ Right-clicking a project node may show the 'Preprocess' option if the version of
                 var folder = GetWorkspacePath();
 
                 // Build the URI using the correct scheme for this variant
-                var uri = $"{installation.UriScheme}://dotutils.binlog-analyzer/open?path=" + Uri.EscapeDataString(binlogPath);
+                var uri = $"{installation.UriScheme}://ms-dotnettools.msbuild-binlog-analyzer/open?path=" + Uri.EscapeDataString(binlogPath);
                 foreach (var attached in attachedBinlogs)
                 {
                     uri += "&path=" + Uri.EscapeDataString(attached);
@@ -489,7 +489,7 @@ Right-clicking a project node may show the 'Preprocess' option if the version of
             }
         }
 
-        private static readonly string ExtensionId = "dotutils.binlog-analyzer";
+        private static readonly string ExtensionId = "ms-dotnettools.msbuild-binlog-analyzer";
 
         private static void EnsureExtensionInstalled(VSCodeInstallation installation)
         {

--- a/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
+++ b/src/StructuredLogViewer/Controls/BuildControl.xaml.cs
@@ -555,7 +555,7 @@ Right-clicking a project node may show the 'Preprocess' option if the version of
                 var folder = GetWorkspacePath();
 
                 // Build the URI using the correct scheme for this variant
-                var uri = $"{installation.UriScheme}://dotutils.binlog-analyzer/open?path=" + Uri.EscapeDataString(binlogPath);
+                var uri = $"{installation.UriScheme}://ms-dotnettools.msbuild-binlog-analyzer/open?path=" + Uri.EscapeDataString(binlogPath);
                 foreach (var attached in attachedBinlogs)
                 {
                     uri += "&path=" + Uri.EscapeDataString(attached);
@@ -588,7 +588,7 @@ Right-clicking a project node may show the 'Preprocess' option if the version of
             }
         }
 
-        private static readonly string ExtensionId = "dotutils.binlog-analyzer";
+        private static readonly string ExtensionId = "ms-dotnettools.msbuild-binlog-analyzer";
 
         private static void EnsureExtensionInstalled(VSCodeInstallation installation)
         {


### PR DESCRIPTION
## Summary
The `binlog-analyzer` VS Code extension moved from the personal publisher **`dotutils`** to the official Microsoft publisher **`ms-dotnettools`**. This updates "Open in VS Code" to install and launch the official extension.

## Changes
In both `src/StructuredLogViewer/Controls/BuildControl.xaml.cs` and `src/StructuredLogViewer.Avalonia/Controls/BuildControl.xaml.cs`:
- `ExtensionId` used for auto-install (`code --install-extension`): `dotutils.binlog-analyzer` → `ms-dotnettools.msbuild-binlog-analyzer`
- Deep-link URI authority (`vscode://.../open?path=`): same change.

## Why this is safe
The new extension is the same codebase and registers the same URI handler, keyed on `uri.path == "/open"` (independent of the authority), so the `open?path=` deep link keeps working unchanged. The official extension is published to the release channel, so `--install-extension` needs no `--pre-release` flag.