### PR TITLE
Use System.CommandLine for CLI

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,6 +41,7 @@
     <PackageVersion Include="squirrel.windows" Version="1.4.4" />
     <PackageVersion Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.10" />
     <PackageVersion Include="System.Formats.Asn1" Version="8.0.1" />
     <PackageVersion Include="System.Memory" Version="4.6.0" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0" />

--- a/src/BinlogTool/BinlogTool.csproj
+++ b/src/BinlogTool/BinlogTool.csproj
@@ -29,6 +29,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.CommandLine" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="$(IconFilePath)" Pack="true" PackagePath="" />
   </ItemGroup>
 

--- a/src/BinlogTool/Program.cs
+++ b/src/BinlogTool/Program.cs
@@ -1,273 +1,249 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.CommandLine;
 using System.IO;
-using System.Linq;
-using System.Threading;
-using Microsoft.Build.Logging.StructuredLogger;
+using BinlogTool;
 
-namespace BinlogTool
+var root = new RootCommand("binlogtool - utilities for MSBuild binary logs");
+
+root.SetAction(parseResult =>
 {
-    class Program
+    // No command specified: show help.
+    root.Parse("--help").Invoke();
+    return 1;
+});
+root.Subcommands.Add(CreateListTools());
+root.Subcommands.Add(CreateSaveFiles());
+root.Subcommands.Add(CreateReconstruct());
+root.Subcommands.Add(CreateListNuget());
+root.Subcommands.Add(CreateListProperties());
+root.Subcommands.Add(CreateCompilerInvocations());
+root.Subcommands.Add(CreateDoubleWrites());
+root.Subcommands.Add(CreateSaveStrings());
+root.Subcommands.Add(CreateSearch());
+root.Subcommands.Add(CreateRedact());
+root.Subcommands.Add(CreateDumpRecords());
+
+return root.Parse(args).Invoke();
+
+// binlogtool listtools input.binlog
+Command CreateListTools()
+{
+    var binlog = new Argument<string>("input.binlog") { Description = "Path to the binlog to read." };
+    var command = new Command("listtools", "List the tools invoked in the binlog.") { binlog };
+    command.SetAction(parseResult =>
     {
-        static int Main(string[] args)
+        new ListTools().Run(parseResult.GetValue(binlog));
+        return 0;
+    });
+    return command;
+}
+
+// binlogtool savefiles input.binlog output_path
+Command CreateSaveFiles()
+{
+    var binlog = new Argument<string>("input.binlog") { Description = "Path to the binlog to read." };
+    var outputRoot = new Argument<string>("output_path") { Description = "Directory to write the files to." };
+    var command = new Command("savefiles", "Save all files embedded in the binlog to disk.") { binlog, outputRoot };
+    command.SetAction(parseResult =>
+    {
+        new SaveFiles(args).Run(parseResult.GetValue(binlog), parseResult.GetValue(outputRoot));
+        return 0;
+    });
+    return command;
+}
+
+// binlogtool reconstruct input.binlog output_path
+Command CreateReconstruct()
+{
+    var binlog = new Argument<string>("input.binlog") { Description = "Path to the binlog to read." };
+    var outputRoot = new Argument<string>("output_path") { Description = "Directory to reconstruct the sources into." };
+    var command = new Command("reconstruct", "Reconstruct the source tree from the binlog.") { binlog, outputRoot };
+    command.SetAction(parseResult =>
+    {
+        new SaveFiles(args).Run(parseResult.GetValue(binlog), parseResult.GetValue(outputRoot), reconstruct: true);
+        return 0;
+    });
+    return command;
+}
+
+// binlogtool listnuget input.binlog [output_path]
+Command CreateListNuget()
+{
+    var binlog = new Argument<string>("input.binlog") { Description = "Path to the binlog to read." };
+    var outputFile = new Argument<string>("output_path")
+    {
+        Description = "Optional file to write the results to.",
+        Arity = ArgumentArity.ZeroOrOne
+    };
+    var command = new Command("listnuget", "List the NuGet packages referenced in the binlog.") { binlog, outputFile };
+    command.SetAction(parseResult =>
+    {
+        var input = parseResult.GetValue(binlog);
+        if (!File.Exists(input))
         {
-            if (args.Length == 0)
-            {
-                Console.WriteLine(@"Usage:
-    binlogtool listtools input.binlog
-    binlogtool savefiles input.binlog output_path
-    binlogtool listnuget input.binlog output_path
-    binlogtool listproperties input.binlog
-    binlogtool doublewrites input.binlog output_path
-    binlogtool reconstruct input.binlog output_path
-    binlogtool savestrings input.binlog output.txt
-    binlogtool search *.binlog search string
-    binlogtool redact --input:path --recurse --in-place -p:list -p:of -p:secrets -p:to -p:redact
-    binlogtool dumprecords [[--input:]path] [--include-total] [--include-rollup] [--exclude-details]");
-                return 0;
-            }
-
-            var firstArg = args[0];
-
-            if (args.Length == 3 && string.Equals(firstArg, "savefiles", StringComparison.OrdinalIgnoreCase))
-            {
-                var binlog = args[1];
-                var outputRoot = args[2];
-
-                new SaveFiles(args).Run(binlog, outputRoot);
-                return 0;
-            }
-
-            if (args.Length >= 2 && string.Equals(firstArg, "listnuget", StringComparison.OrdinalIgnoreCase))
-            {
-                var binlog = args[1];
-                if (!File.Exists(binlog))
-                {
-                    Console.Error.WriteLine($"Binlog file {binlog} not found");
-                    return -6;
-                }
-
-                string outputFile = null;
-                if (args.Length == 3)
-                {
-                    outputFile = args[2];
-                }
-
-                int result = new ListNuget(args).Run(binlog, outputFile);
-                return result;
-            }
-
-            if (args.Length == 3 && string.Equals(firstArg, "reconstruct", StringComparison.OrdinalIgnoreCase))
-            {
-                var binlog = args[1];
-                var outputRoot = args[2];
-
-                new SaveFiles(args).Run(binlog, outputRoot, reconstruct: true);
-                return 0;
-            }
-
-            if (args.Length == 3 && string.Equals(firstArg, "savestrings", StringComparison.OrdinalIgnoreCase))
-            {
-                var binlog = args[1];
-                var outputFile = args[2];
-
-                new SaveStrings().Run(binlog, outputFile);
-                return 0;
-            }
-
-            if (args.Length == 2 && string.Equals(firstArg, "listProperties", StringComparison.OrdinalIgnoreCase))
-            {
-                var binlog = args[1];
-                new ListProperties().Run(binlog);
-                return 0;
-            }
-
-            if (args.Length >= 2 && string.Equals(firstArg, "compilerinvocations", StringComparison.OrdinalIgnoreCase))
-            {
-                string binlog = args[1];
-                string outputFile = null;
-                if (args.Length == 3)
-                {
-                    outputFile = args[2];
-                }
-
-                if (File.Exists(binlog))
-                {
-                    new CompilerInvocations().Run(binlog, outputFile);
-                }
-
-                return 0;
-            }
-
-            if (args.Length >= 2 && string.Equals(firstArg, "doublewrites", StringComparison.OrdinalIgnoreCase))
-            {
-                string binlog = args[1];
-                string outputFile = null;
-                if (args.Length == 3)
-                {
-                    outputFile = args[2];
-                }
-
-                if (File.Exists(binlog))
-                {
-                    new DoubleWrites().Run(binlog, outputFile);
-                }
-
-                return 0;
-            }
-
-            if (args.Length == 2 && string.Equals(firstArg, "listtools", StringComparison.OrdinalIgnoreCase))
-            {
-                var binlog = args[1];
-
-                new ListTools().Run(binlog);
-                return 0;
-            }
-
-            if (firstArg == "search")
-            {
-                if (args.Length < 3)
-                {
-                    Console.Error.WriteLine("binlogtool search *.binlog search string");
-                    return -2;
-                }
-
-                var binlogs = args[1];
-                var search = string.Join(" ", args.Skip(2));
-                new Searcher().Search2(binlogs, search);
-                return 0;
-            }
-
-            if (firstArg == "redact")
-            {
-                List<string> redactTokens = new List<string>();
-                List<string> inputPaths = new List<string>();
-                bool recurse = false;
-                bool inPlace = false;
-
-                foreach (var arg in args.Skip(1))
-                {
-                    if (arg.StartsWith("--input:", StringComparison.OrdinalIgnoreCase))
-                    {
-                        var input = arg.Substring("--input:".Length);
-                        if (string.IsNullOrEmpty(input))
-                        {
-                            Console.Error.WriteLine("Invalid input path");
-                            return -3;
-                        }
-
-                        inputPaths.Add(input);
-                    }
-                    else if (arg.StartsWith("-p:", StringComparison.OrdinalIgnoreCase))
-                    {
-                        var redactToken = arg.Substring("-p:".Length);
-                        if (string.IsNullOrEmpty(redactToken))
-                        {
-                            Console.Error.WriteLine("Invalid redact token");
-                            return -4;
-                        }
-
-                        redactTokens.Add(redactToken);
-                    }
-                    else if (arg.Equals("--recurse", StringComparison.OrdinalIgnoreCase))
-                    {
-                        recurse = true;
-                    }
-                    else if (arg.Equals("--in-place", StringComparison.OrdinalIgnoreCase))
-                    {
-                        inPlace = true;
-                    }
-                    else
-                    {
-                        Console.Error.WriteLine($"Invalid argument: {arg}");
-                        Console.Error.WriteLine("binlogtool redact --input:path --recurse --in-place -p:list -p:of -p:secrets -p:to -p:redact");
-                        Console.Error.WriteLine("All arguments are optional (missing input assumes current working directory. Missing tokens lead only to autoredactions. Missing --in-place will create new logs with suffix.)");
-                        return -5;
-                    }
-                }
-
-                Redact.Run(inputPaths, redactTokens, inPlace, recurse);
-                return 0;
-            }
-
-            if (firstArg == "dumprecords")
-            {
-                bool includeTotal = false;
-                bool includeRollup = false;
-                bool includeDetails = true;
-                List<string> inputPaths = new List<string>();
-
-                foreach (var arg in args.Skip(1))
-                {
-                    if (arg.StartsWith("--input:", StringComparison.OrdinalIgnoreCase))
-                    {
-                        var input = arg.Substring("--input:".Length);
-                        if (string.IsNullOrEmpty(input))
-                        {
-                            Console.Error.WriteLine("Invalid input path");
-                            return -3;
-                        }
-
-                        inputPaths.Add(input);
-                    }
-                    // [--include-total] [--include-rollup] [--exclude-details]
-                    else if (arg.Equals("--include-total", StringComparison.OrdinalIgnoreCase))
-                    {
-                        includeTotal = true;
-                    }
-                    else if (arg.Equals("--include-rollup", StringComparison.OrdinalIgnoreCase))
-                    {
-                        includeRollup = true;
-                    }
-                    else if (arg.Equals("--exclude-details", StringComparison.OrdinalIgnoreCase))
-                    {
-                        includeDetails = false;
-                    }
-                    else if (arg.EndsWith(".binlog", StringComparison.OrdinalIgnoreCase))
-                    {
-                        inputPaths.Add(arg);
-                    }
-                    else
-                    {
-                        Console.Error.WriteLine($"Invalid argument: {arg}");
-                        Console.Error.WriteLine("binlogtool dumprecords [[--input:]path] [--include-total] [--include-rollup] [--exclude-details]");
-                        Console.Error.WriteLine("All arguments are optional (Missing input assumes current working directory. Rollup and total is disabled by default, detail overview is enabled by default. Input(s) arguments can be specified without switch.)");
-                        return -5;
-                    }
-                }
-
-                DumpRecords.Run(inputPaths, includeTotal, includeRollup, includeDetails);
-                return 0;
-            }
-
-            Console.Error.WriteLine("Invalid arguments");
-            return -1;
+            Console.Error.WriteLine($"Binlog file {input} not found");
+            return -6;
         }
 
-        private static void ReadStrings()
-        {
-            var strings = Serialization.ReadStringsFromFile(@"C:\temp\strings2.zip");
-            var ordered = strings.OrderByDescending(s => s.Length).ToArray();
-            var top100 = ordered.Take(3000);
+        return new ListNuget(args).Run(input, parseResult.GetValue(outputFile));
+    });
+    return command;
+}
 
-            int i = 1;
-            foreach (var str in top100)
-            {
-                File.WriteAllText($@"C:\temp\strings2\{i++}.txt", str);
-            }
+// binlogtool listproperties input.binlog
+Command CreateListProperties()
+{
+    var binlog = new Argument<string>("input.binlog") { Description = "Path to the binlog to read." };
+    var command = new Command("listproperties", "List the properties set during the build.") { binlog };
+    command.SetAction(parseResult =>
+    {
+        new ListProperties().Run(parseResult.GetValue(binlog));
+        return 0;
+    });
+    return command;
+}
+
+// binlogtool compilerinvocations input.binlog [output_path]
+Command CreateCompilerInvocations()
+{
+    var binlog = new Argument<string>("input.binlog") { Description = "Path to the binlog to read." };
+    var outputFile = new Argument<string>("output_path")
+    {
+        Description = "Optional file to write the results to.",
+        Arity = ArgumentArity.ZeroOrOne
+    };
+    var command = new Command("compilerinvocations", "List the compiler invocations in the binlog.") { binlog, outputFile };
+    command.SetAction(parseResult =>
+    {
+        var input = parseResult.GetValue(binlog);
+        if (File.Exists(input))
+        {
+            new CompilerInvocations().Run(input, parseResult.GetValue(outputFile));
         }
 
-        private static void CompareStrings()
+        return 0;
+    });
+    return command;
+}
+
+// binlogtool doublewrites input.binlog [output_path]
+Command CreateDoubleWrites()
+{
+    var binlog = new Argument<string>("input.binlog") { Description = "Path to the binlog to read." };
+    var outputFile = new Argument<string>("output_path")
+    {
+        Description = "Optional file to write the results to.",
+        Arity = ArgumentArity.ZeroOrOne
+    };
+    var command = new Command("doublewrites", "Report files written more than once during the build.") { binlog, outputFile };
+    command.SetAction(parseResult =>
+    {
+        var input = parseResult.GetValue(binlog);
+        if (File.Exists(input))
         {
-            var left = Serialization.ReadStringsFromFile(@"C:\temp\1.txt");
-            var right = Serialization.ReadStringsFromFile(@"C:\temp\2.txt");
-
-            var onlyLeft = left.Except(right).ToArray();
-            var onlyRight = right.Except(left).ToArray();
-
-            File.WriteAllLines(@"C:\temp\onlyLeft.txt", onlyLeft);
-            File.WriteAllLines(@"C:\temp\onlyRight.txt", onlyRight);
+            new DoubleWrites().Run(input, parseResult.GetValue(outputFile));
         }
-    }
+
+        return 0;
+    });
+    return command;
+}
+
+// binlogtool savestrings input.binlog output.txt
+Command CreateSaveStrings()
+{
+    var binlog = new Argument<string>("input.binlog") { Description = "Path to the binlog to read." };
+    var outputFile = new Argument<string>("output.txt") { Description = "File to write the strings to." };
+    var command = new Command("savestrings", "Save the string table from the binlog.") { binlog, outputFile };
+    command.SetAction(parseResult =>
+    {
+        new SaveStrings().Run(parseResult.GetValue(binlog), parseResult.GetValue(outputFile));
+        return 0;
+    });
+    return command;
+}
+
+// binlogtool search *.binlog search string
+Command CreateSearch()
+{
+    var binlogs = new Argument<string>("*.binlog") { Description = "Binlog file or glob pattern to search." };
+    var searchTerms = new Argument<string[]>("search string")
+    {
+        Description = "Search query (remaining arguments are joined with spaces).",
+        Arity = ArgumentArity.OneOrMore
+    };
+    var command = new Command("search", "Search one or more binlogs.") { binlogs, searchTerms };
+    command.SetAction(parseResult =>
+    {
+        var search = string.Join(" ", parseResult.GetValue(searchTerms) ?? Array.Empty<string>());
+        new Searcher().Search2(parseResult.GetValue(binlogs), search);
+        return 0;
+    });
+    return command;
+}
+
+// binlogtool redact --input:path --recurse --in-place -p:secret
+Command CreateRedact()
+{
+    var input = new Option<List<string>>("--input")
+    {
+        Description = "Binlog file or directory to redact. Defaults to the current working directory.",
+        AllowMultipleArgumentsPerToken = false
+    };
+    var tokens = new Option<List<string>>("-p")
+    {
+        Description = "Secret to redact. Can be specified multiple times.",
+        AllowMultipleArgumentsPerToken = false
+    };
+    var recurse = new Option<bool>("--recurse") { Description = "Recurse into subdirectories." };
+    var inPlace = new Option<bool>("--in-place") { Description = "Overwrite the input logs instead of writing new ones with a suffix." };
+
+    var command = new Command("redact", "Redact secrets from binlogs.") { input, tokens, recurse, inPlace };
+    command.SetAction(parseResult =>
+    {
+        Redact.Run(
+            parseResult.GetValue(input) ?? new List<string>(),
+            parseResult.GetValue(tokens) ?? new List<string>(),
+            parseResult.GetValue(inPlace),
+            parseResult.GetValue(recurse));
+        return 0;
+    });
+    return command;
+}
+
+// binlogtool dumprecords [[--input:]path] [--include-total] [--include-rollup] [--exclude-details]
+Command CreateDumpRecords()
+{
+    var input = new Option<List<string>>("--input")
+    {
+        Description = "Binlog file or directory. Defaults to the current working directory.",
+        AllowMultipleArgumentsPerToken = false
+    };
+    var positionalInput = new Argument<List<string>>("path")
+    {
+        Description = "Binlog path(s), can also be given without the --input switch.",
+        Arity = ArgumentArity.ZeroOrMore
+    };
+    var includeTotal = new Option<bool>("--include-total") { Description = "Include the total record count." };
+    var includeRollup = new Option<bool>("--include-rollup") { Description = "Include the per-type rollup." };
+    var excludeDetails = new Option<bool>("--exclude-details") { Description = "Exclude the detailed overview." };
+
+    var command = new Command("dumprecords", "Dump the records contained in binlogs.")
+    {
+        input, positionalInput, includeTotal, includeRollup, excludeDetails
+    };
+    command.SetAction(parseResult =>
+    {
+        var inputPaths = new List<string>(parseResult.GetValue(input) ?? new List<string>());
+        inputPaths.AddRange(parseResult.GetValue(positionalInput) ?? new List<string>());
+
+        DumpRecords.Run(
+            inputPaths,
+            parseResult.GetValue(includeTotal),
+            parseResult.GetValue(includeRollup),
+            !parseResult.GetValue(excludeDetails));
+        return 0;
+    });
+    return command;
 }

--- a/src/BinlogToolExe/BinlogToolExe.csproj
+++ b/src/BinlogToolExe/BinlogToolExe.csproj
@@ -26,6 +26,10 @@
     <ProjectReference Include="..\StructuredLogger\StructuredLogger.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.CommandLine" />
+  </ItemGroup>
+
   <Target Name="PublishBinlogToolExe"
           DependsOnTargets="Publish"
           Condition="$(Configuration) == 'Release' AND $([MSBuild]::IsOSPlatform(`Windows`))">


### PR DESCRIPTION
from
```
Usage:
    binlogtool listtools input.binlog
    binlogtool savefiles input.binlog output_path
    binlogtool listnuget input.binlog output_path
    binlogtool listproperties input.binlog
    binlogtool doublewrites input.binlog output_path
    binlogtool reconstruct input.binlog output_path
    binlogtool savestrings input.binlog output.txt
    binlogtool search *.binlog search string
    binlogtool redact --input:path --recurse --in-place -p:list -p:of -p:secrets -p:to -p:redact
    binlogtool dumprecords [[--input:]path] [--include-total] [--include-rollup] [--exclude-details]
```
to
```
Description:
  binlogtool - utilities for MSBuild binary logs

Usage:
  BinlogTool [command] [options]

Options:
  -?, -h, --help  Show help and usage information
  --version       Show version information.

Commands:
  listtools <input.binlog>                          List the tools invoked in the binlog.
  savefiles <input.binlog> <output_path>            Save all files embedded in the binlog to disk.
  reconstruct <input.binlog> <output_path>          Reconstruct the source tree from the binlog.
  listnuget <input.binlog> <output_path>            List the NuGet packages referenced in the binlog.
  listproperties <input.binlog>                     List the properties set during the build.
  compilerinvocations <input.binlog> <output_path>  List the compiler invocations in the binlog.
  doublewrites <input.binlog> <output_path>         Report files written more than once during the build.
  savestrings <input.binlog> <output.txt>           Save the string table from the binlog.
  search <*.binlog> <search string>                 Search one or more binlogs.
  redact                                            Redact secrets from binlogs.
  dumprecords <path>                                Dump the records contained in binlogs.
```