### PR TITLE
Include MSBuild node id with timing information

### DIFF
--- a/src/StructuredLogViewer.Core/Timeline/Block.cs
+++ b/src/StructuredLogViewer.Core/Timeline/Block.cs
@@ -36,6 +36,7 @@ namespace StructuredLogViewer
                 text += "\n" + TextUtilities.DisplayDuration(timedNode.Duration);
                 text += "\nStart: " + TextUtilities.Display(timedNode.StartTime);
                 text += "\nEnd: " + TextUtilities.Display(timedNode.EndTime);
+                text += "\nNode: " + TextUtilities.DisplayNodeId(timedNode.NodeId);
             }
 
             return text;

--- a/src/StructuredLogger/ObjectModel/TimedNode.cs
+++ b/src/StructuredLogger/ObjectModel/TimedNode.cs
@@ -52,7 +52,8 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
             return $@"Start: {TextUtilities.Display(StartTime, displayDate: true, fullPrecision)}
 End: {TextUtilities.Display(EndTime, displayDate: true, fullPrecision)}
-Duration: {duration}";
+Duration: {duration}
+Node: {TextUtilities.DisplayNodeId(NodeId)}";
         }
 
         public override string ToolTip => GetTimeAndDurationText();

--- a/src/StructuredLogger/TextUtilities.cs
+++ b/src/StructuredLogger/TextUtilities.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+
+using Microsoft.Build.Framework;
 
 namespace Microsoft.Build.Logging.StructuredLogger
 {
@@ -531,6 +534,23 @@ namespace Microsoft.Build.Logging.StructuredLogger
             }
 
             return span.Milliseconds + " ms";
+        }
+
+        public static string DisplayNodeId(int nodeId)
+        {
+            if (nodeId == BuildEventContext.InvalidNodeId)
+            {
+                return "Invalid";
+            }
+            else if (nodeId == 0)
+            {
+                return "N/A";
+            }
+            else
+            {
+                // Use the invariant culture so there are never any digit seperators
+                return nodeId.ToString("D", CultureInfo.InvariantCulture);
+            }
         }
 
         public static string Display(this DateTime time, bool displayDate = false, bool fullPrecision = false)


### PR DESCRIPTION
Sometimes it's useful to know which MSBuild node ran a given target/task. For example, to correlate with PID-based logging of msbuild.exe activity.

Include the node when "timing and duration" information is displayed, like from the "Show time and duration" context menu or the tooltip in the Timeline and Tracing views.

Here are some screenshots of where it shows up:

<img width="369" height="157" alt="screenshot of the &quot;Show time and duration&quot; view" src="https://github.com/user-attachments/assets/1e9d9862-121e-4d33-8eeb-d5a57f1d2ec7" />
<br />
<img width="334" height="148" alt="screenshot of the timeline view tooltip" src="https://github.com/user-attachments/assets/868cb58a-0b7e-4aec-8c31-ce4b164962f8" />
<br />
<img width="320" height="142" alt="screenshot of the tracing view tooltip" src="https://github.com/user-attachments/assets/5cebed1c-f67a-430e-bf3a-6c3840066452" />
