### PR TITLE
Add filtered binary log replay

### DIFF
--- a/src/StructuredLogger.Tests/BinaryLoggerTests.cs
+++ b/src/StructuredLogger.Tests/BinaryLoggerTests.cs
@@ -158,6 +158,150 @@ namespace Microsoft.Build.UnitTests
             AssertFilesAreBinaryEqualAfterUnpack(binLog, replayedBinlog);
         }
 
+        [Fact]
+        public void Replay_EventFilter_ProducesAValidCompactBinlog()
+        {
+            var metadataSeen = new List<BinaryLogEventMetadata>();
+            var reader = new BinLogReader
+            {
+                EventFilter = metadata =>
+                {
+                    metadataSeen.Add(metadata);
+                    return metadata.BuildEventContext == null ||
+                           metadata.BuildEventContext.ProjectContextId == 101 ||
+                           metadata.OriginalBuildEventContext?.ProjectContextId == 101;
+                }
+            };
+
+            string outputPath = GetTestFile("filtered-replay.binlog");
+            File.Delete(outputPath);
+
+            var outputLogger = new BinaryLogger
+            {
+                Parameters = $"LogFile={outputPath};OmitInitialInfo",
+                CollectProjectImports = BinaryLogger.ProjectImportsCollectionMode.None,
+            };
+
+            outputLogger.Initialize(reader);
+            using (var input = CreateFilteredReplayStream())
+            {
+                reader.Replay(input);
+            }
+            outputLogger.Shutdown();
+
+            metadataSeen.Should().Contain(metadata =>
+                metadata.RecordKind == BinaryLogRecordKind.Warning &&
+                metadata.BuildEventContext != null &&
+                metadata.BuildEventContext.ProjectContextId == 202);
+            metadataSeen.Should().Contain(metadata =>
+                metadata.RecordKind == BinaryLogRecordKind.TargetSkipped &&
+                metadata.OriginalBuildEventContext != null &&
+                metadata.OriginalBuildEventContext.ProjectContextId == 101);
+
+            var replayedEvents = new List<BuildEventArgs>();
+            var outputReader = new BinLogReader();
+            outputReader.AnyEventRaised += (_, args) => replayedEvents.Add(args);
+            outputReader.Replay(outputPath);
+
+            replayedEvents.Should().Contain(e =>
+                e.GetType() == typeof(BuildMessageEventArgs) &&
+                e.Message == "selected message");
+            replayedEvents.Should().NotContain(e => e is BuildWarningEventArgs);
+            replayedEvents.Should().ContainSingle(e => e is TargetSkippedEventArgs);
+
+            var replayedStrings = new List<string>();
+            var recordReader = new BinLogReader();
+            recordReader.OnStringRead += (text, _) => replayedStrings.Add(text);
+            using (var file = File.OpenRead(outputPath))
+            using (var gzip = new System.IO.Compression.GZipStream(
+                file,
+                System.IO.Compression.CompressionMode.Decompress))
+            using (var buffered = new BufferedStream(gzip, 32768))
+            {
+                recordReader.ReadRecordsFromDecompressedStream(buffered, includeAuxiliaryRecords: true)
+                    .ToList();
+            }
+
+            replayedStrings.Should().NotContain("excluded warning");
+            replayedStrings.Should().NotContain("WARN");
+        }
+
+        [Fact]
+        public void Replay_EventFilter_PreservesTruncationRecoveryWhenRejectingEvents()
+        {
+            using var stream = CreateBinlogStream(withEndOfFileMarker: false);
+
+            var reader = new BinLogReader
+            {
+                EventFilter = _ => false,
+            };
+
+            Action replay = () => reader.Replay(stream);
+
+            replay.Should().NotThrow();
+            reader.HasEncounteredTruncation.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Read_EventFilter_PreservesTruncationRecoveryInsideRejectedEvent()
+        {
+            byte[] full = WriteEventRecords(count: 6, withEndOfFileMarker: false);
+            byte[] truncated = full.Take(full.Length / 2).ToArray();
+
+            var memoryStream = new MemoryStream(truncated);
+            var binaryReader = new BinaryReader(memoryStream);
+            using var reader = new Logging.StructuredLogger.BuildEventArgsReader(
+                binaryReader,
+                BinaryLogger.FileFormatVersion);
+
+            Action read = () =>
+            {
+                while (reader.Read(_ => false) != null)
+                {
+                }
+            };
+
+            read.Should().NotThrow();
+            reader.ReachedEndOfStreamPrematurely.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Replay_EventFilter_RetainsRequiredCulturePreamble()
+        {
+            using var stream = CreateCulturePreambleStream();
+            var replayedEvents = new List<BuildEventArgs>();
+            var reader = new BinLogReader
+            {
+                EventFilter = _ => false,
+            };
+            reader.AnyEventRaised += (_, args) => replayedEvents.Add(args);
+
+            reader.Replay(stream);
+
+            var cultureMessages = replayedEvents
+                .OfType<BuildMessageEventArgs>()
+                .Where(message =>
+                    message.SenderName == "BinaryLogger" &&
+                    message.Message.StartsWith("CurrentUICulture", StringComparison.Ordinal))
+                .ToList();
+            cultureMessages.Should().ContainSingle();
+        }
+
+        [Fact]
+        public void Replay_EventFilter_PropagatesFilterExceptions()
+        {
+            using var stream = CreateFilteredReplayStream();
+            var expected = new InvalidOperationException("filter failed");
+            var reader = new BinLogReader
+            {
+                EventFilter = _ => throw expected,
+            };
+
+            Action replay = () => reader.Replay(stream);
+
+            replay.Should().Throw<InvalidOperationException>().Which.Should().BeSameAs(expected);
+        }
+
         private static void AssertFilesAreBinaryEqualAfterUnpack(string firstPath, string secondPath)
         {
             using var br1 = Logging.StructuredLogger.BinaryLogReplayEventSource.OpenReader(firstPath);
@@ -640,6 +784,100 @@ namespace Microsoft.Build.UnitTests
 
             var compressed = new MemoryStream();
             using (var gzip = new System.IO.Compression.GZipStream(compressed, System.IO.Compression.CompressionLevel.Optimal, leaveOpen: true))
+            {
+                decompressed.CopyTo(gzip);
+            }
+
+            compressed.Position = 0;
+            return compressed;
+        }
+
+        private static Stream CreateFilteredReplayStream()
+        {
+            var selectedContext = new BuildEventContext(1, 1, 1, 1, 101, 11, 111);
+            var excludedContext = new BuildEventContext(1, 1, 2, 2, 202, 22, 222);
+            var skippedContext = new BuildEventContext(1, 1, 3, 3, 303, 33, 333);
+
+            var selectedMessage = new BuildMessageEventArgs(
+                "selected message", "Help", "Sender", MessageImportance.Normal)
+            {
+                BuildEventContext = selectedContext,
+            };
+
+            var excludedWarning = new BuildWarningEventArgs(
+                "Subcategory", "WARN", "File.cs", 1, 2, 3, 4,
+                "excluded warning", "Help", "Sender")
+            {
+                BuildEventContext = excludedContext,
+            };
+
+            var targetSkipped = new TargetSkippedEventArgs("target skipped")
+            {
+                BuildEventContext = skippedContext,
+                OriginalBuildEventContext = selectedContext,
+                TargetName = "SkippedTarget",
+                TargetFile = "Targets.targets",
+                ProjectFile = "Project.csproj",
+                BuildReason = TargetBuiltReason.DependsOn,
+                SkipReason = TargetSkipReason.PreviouslyBuiltSuccessfully,
+                OriginallySucceeded = true,
+            };
+
+            var decompressed = new MemoryStream();
+            var binaryWriter = new BinaryWriter(decompressed);
+            binaryWriter.Write(BinaryLogger.FileFormatVersion);
+            binaryWriter.Write(BinaryLogger.FileFormatVersion);
+
+            var writer = new BuildEventArgsWriter(binaryWriter);
+            writer.Write(new BuildStartedEventArgs("Build started", helpKeyword: null));
+            writer.Write(selectedMessage);
+            writer.Write(excludedWarning);
+            writer.Write(targetSkipped);
+            writer.Write(new BuildFinishedEventArgs("Build finished", helpKeyword: null, succeeded: true));
+            binaryWriter.Flush();
+            decompressed.WriteByte((byte)BinaryLogRecordKind.EndOfFile);
+            decompressed.Position = 0;
+
+            var compressed = new MemoryStream();
+            using (var gzip = new System.IO.Compression.GZipStream(
+                compressed,
+                System.IO.Compression.CompressionLevel.Optimal,
+                leaveOpen: true))
+            {
+                decompressed.CopyTo(gzip);
+            }
+
+            compressed.Position = 0;
+            return compressed;
+        }
+
+        private static Stream CreateCulturePreambleStream()
+        {
+            var decompressed = new MemoryStream();
+            var binaryWriter = new BinaryWriter(decompressed);
+            binaryWriter.Write(BinaryLogger.FileFormatVersion);
+            binaryWriter.Write(BinaryLogger.FileFormatVersion);
+
+            var writer = new BuildEventArgsWriter(binaryWriter);
+            writer.Write(new BuildMessageEventArgs(
+                "CurrentUICulture=en-US",
+                helpKeyword: null,
+                senderName: "BinaryLogger",
+                importance: MessageImportance.Low));
+            writer.Write(new BuildMessageEventArgs(
+                "filtered message",
+                helpKeyword: null,
+                senderName: "Sender",
+                importance: MessageImportance.Normal));
+            binaryWriter.Flush();
+            decompressed.WriteByte((byte)BinaryLogRecordKind.EndOfFile);
+            decompressed.Position = 0;
+
+            var compressed = new MemoryStream();
+            using (var gzip = new System.IO.Compression.GZipStream(
+                compressed,
+                System.IO.Compression.CompressionLevel.Optimal,
+                leaveOpen: true))
             {
                 decompressed.CopyTo(gzip);
             }

--- a/src/StructuredLogger.Tests/BinaryLoggerTests.cs
+++ b/src/StructuredLogger.Tests/BinaryLoggerTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using FluentAssertions;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Logging;
@@ -269,6 +270,18 @@ namespace Microsoft.Build.UnitTests
         public void Replay_EventFilter_RetainsRequiredCulturePreamble()
         {
             using var stream = CreateCulturePreambleStream();
+            AssertCulturePreambleRetained(stream);
+        }
+
+        [Fact]
+        public void Replay_EventFilter_RetainsRequiredCulturePreambleForLegacyFormat()
+        {
+            using var stream = CreateCulturePreambleStream(fileFormatVersion: 14);
+            AssertCulturePreambleRetained(stream);
+        }
+
+        private static void AssertCulturePreambleRetained(Stream stream)
+        {
             var replayedEvents = new List<BuildEventArgs>();
             var reader = new BinLogReader
             {
@@ -288,18 +301,33 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
-        public void Replay_EventFilter_PropagatesFilterExceptions()
+        public void Replay_EventFilter_PropagatesFilterExceptionsWithoutLeakingWorkers()
         {
-            using var stream = CreateFilteredReplayStream();
             var expected = new InvalidOperationException("filter failed");
-            var reader = new BinLogReader
+            ThreadPool.GetAvailableThreads(out int availableWorkersBefore, out _);
+
+            for (int i = 0; i < 8; i++)
             {
-                EventFilter = _ => throw expected,
-            };
+                using var stream = CreateFilteredReplayStream();
+                var reader = new BinLogReader
+                {
+                    EventFilter = _ => throw expected,
+                };
 
-            Action replay = () => reader.Replay(stream);
+                Action replay = () => reader.Replay(stream);
 
-            replay.Should().Throw<InvalidOperationException>().Which.Should().BeSameAs(expected);
+                replay.Should().Throw<InvalidOperationException>().Which.Should().BeSameAs(expected);
+            }
+
+            bool workersReleased = SpinWait.SpinUntil(
+                () =>
+                {
+                    ThreadPool.GetAvailableThreads(out int availableWorkersAfter, out _);
+                    return availableWorkersAfter >= availableWorkersBefore;
+                },
+                TimeSpan.FromSeconds(5));
+
+            workersReleased.Should().BeTrue("filter failures must not leave replay workers blocked");
         }
 
         private static void AssertFilesAreBinaryEqualAfterUnpack(string firstPath, string secondPath)
@@ -851,14 +879,12 @@ namespace Microsoft.Build.UnitTests
             return compressed;
         }
 
-        private static Stream CreateCulturePreambleStream()
+        private static Stream CreateCulturePreambleStream(
+            int fileFormatVersion = BinaryLogger.FileFormatVersion)
         {
-            var decompressed = new MemoryStream();
-            var binaryWriter = new BinaryWriter(decompressed);
-            binaryWriter.Write(BinaryLogger.FileFormatVersion);
-            binaryWriter.Write(BinaryLogger.FileFormatVersion);
-
-            var writer = new BuildEventArgsWriter(binaryWriter);
+            var framedRecords = new MemoryStream();
+            var framedWriter = new BinaryWriter(framedRecords);
+            var writer = new BuildEventArgsWriter(framedWriter);
             writer.Write(new BuildMessageEventArgs(
                 "CurrentUICulture=en-US",
                 helpKeyword: null,
@@ -869,8 +895,24 @@ namespace Microsoft.Build.UnitTests
                 helpKeyword: null,
                 senderName: "Sender",
                 importance: MessageImportance.Normal));
+            framedWriter.Flush();
+            framedRecords.WriteByte((byte)BinaryLogRecordKind.EndOfFile);
+            framedRecords.Position = 0;
+
+            var decompressed = new MemoryStream();
+            var binaryWriter = new BinaryWriter(decompressed);
+            binaryWriter.Write(fileFormatVersion);
+            if (fileFormatVersion >= BinaryLogger.ForwardCompatibilityMinimalVersion)
+            {
+                binaryWriter.Write(fileFormatVersion);
+                framedRecords.CopyTo(decompressed);
+            }
+            else
+            {
+                CopyRecordsWithoutLengths(framedRecords, binaryWriter);
+            }
+
             binaryWriter.Flush();
-            decompressed.WriteByte((byte)BinaryLogRecordKind.EndOfFile);
             decompressed.Position = 0;
 
             var compressed = new MemoryStream();
@@ -884,6 +926,44 @@ namespace Microsoft.Build.UnitTests
 
             compressed.Position = 0;
             return compressed;
+        }
+
+        private static void CopyRecordsWithoutLengths(
+            Stream framedRecords,
+            BinaryWriter legacyWriter)
+        {
+            using var framedReader = new BinaryReader(framedRecords);
+
+            while (true)
+            {
+                int recordKindValue = Serialization.Read7BitEncodedInt(framedReader);
+                var recordKind = (BinaryLogRecordKind)recordKindValue;
+                Serialization.Write7BitEncodedInt(legacyWriter, recordKindValue);
+
+                if (recordKind == BinaryLogRecordKind.EndOfFile)
+                {
+                    return;
+                }
+
+                if (recordKind == BinaryLogRecordKind.String)
+                {
+                    legacyWriter.Write(framedReader.ReadString());
+                    continue;
+                }
+
+                recordKind.Should().Be(
+                    BinaryLogRecordKind.Message,
+                    "the legacy culture test stream contains only strings and messages");
+
+                int recordLength = Serialization.Read7BitEncodedInt(framedReader);
+                byte[] record = framedReader.ReadBytes(recordLength);
+                if (record.Length != recordLength)
+                {
+                    throw new EndOfStreamException();
+                }
+
+                legacyWriter.Write(record);
+            }
         }
 
         private static BuildEventArgs CreateEvent(int i) => (i % 3) switch

--- a/src/StructuredLogger.Tests/BinaryLoggerTests.cs
+++ b/src/StructuredLogger.Tests/BinaryLoggerTests.cs
@@ -316,7 +316,8 @@ namespace Microsoft.Build.UnitTests
 
                 Action replay = () => reader.Replay(stream);
 
-                replay.Should().Throw<InvalidOperationException>().Which.Should().BeSameAs(expected);
+                replay.Should().Throw<BinaryLogEventFilterException>()
+                    .Which.InnerException.Should().BeSameAs(expected);
             }
 
             bool workersReleased = SpinWait.SpinUntil(

--- a/src/StructuredLogger/BinaryLogger/BinLogReader.cs
+++ b/src/StructuredLogger/BinaryLogger/BinLogReader.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
-using System.Runtime.ExceptionServices;
 using Microsoft.Build.Framework;
 
 namespace Microsoft.Build.Logging.StructuredLogger
@@ -113,9 +112,10 @@ namespace Microsoft.Build.Logging.StructuredLogger
                         {
                             instance = reader.Read(EventFilter);
                         }
-                        catch (BinaryLogEventFilterException ex)
+                        catch (BinaryLogEventFilterException)
                         {
-                            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                            // A failing filter callback is a caller bug, not a problem with the log:
+                            // abort the replay instead of reporting it via OnException and continuing.
                             throw;
                         }
                         catch (Exception ex)
@@ -176,9 +176,10 @@ namespace Microsoft.Build.Logging.StructuredLogger
                     {
                         instance = reader.Read(EventFilter);
                     }
-                    catch (BinaryLogEventFilterException ex)
+                    catch (BinaryLogEventFilterException)
                     {
-                        ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                        // A failing filter callback is a caller bug, not a problem with the log:
+                        // abort the replay instead of reporting it via OnException and continuing.
                         throw;
                     }
                     catch (Exception ex)

--- a/src/StructuredLogger/BinaryLogger/BinLogReader.cs
+++ b/src/StructuredLogger/BinaryLogger/BinLogReader.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Runtime.ExceptionServices;
 using Microsoft.Build.Framework;
 
 namespace Microsoft.Build.Logging.StructuredLogger
@@ -26,6 +27,18 @@ namespace Microsoft.Build.Logging.StructuredLogger
         public event Action<IDictionary<string, string>, long> OnNameValueListRead;
         public event Action<int> OnFileFormatVersionRead;
         public event Action<IEnumerable<string>> OnStringDictionaryComplete;
+
+        /// <summary>
+        /// Gets or sets a filter that decides which build events are deserialized and dispatched.
+        /// </summary>
+        /// <remarks>
+        /// For length-framed binlogs, rejected events skip their type-specific payload without
+        /// deserializing it. Auxiliary records are always read so retained events can resolve their
+        /// string and name/value-list references. Reader preamble events required to interpret
+        /// subsequent events, such as the current UI culture marker, are retained regardless of the
+        /// filter. The filter is responsible for retaining a structurally consistent event set.
+        /// </remarks>
+        public BinaryLogEventFilter EventFilter { get; set; }
 
         /// <summary>
         /// Raised when there was an exception reading a record from the file.
@@ -96,7 +109,12 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
                     try
                     {
-                        instance = reader.Read();
+                        instance = reader.Read(EventFilter);
+                    }
+                    catch (BinaryLogEventFilterException ex)
+                    {
+                        ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                        throw;
                     }
                     catch (Exception ex)
                     {
@@ -151,7 +169,12 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
                     try
                     {
-                        instance = reader.Read();
+                        instance = reader.Read(EventFilter);
+                    }
+                    catch (BinaryLogEventFilterException ex)
+                    {
+                        ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                        throw;
                     }
                     catch (Exception ex)
                     {

--- a/src/StructuredLogger/BinaryLogger/BinLogReader.cs
+++ b/src/StructuredLogger/BinaryLogger/BinLogReader.cs
@@ -103,44 +103,49 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
                 var streamLength = stream.Length;
 
-                while (true)
+                try
                 {
-                    BuildEventArgs instance = null;
+                    while (true)
+                    {
+                        BuildEventArgs instance = null;
 
-                    try
-                    {
-                        instance = reader.Read(EventFilter);
-                    }
-                    catch (BinaryLogEventFilterException ex)
-                    {
-                        ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
-                        throw;
-                    }
-                    catch (Exception ex)
-                    {
-                        OnException?.Invoke(ex);
-                    }
+                        try
+                        {
+                            instance = reader.Read(EventFilter);
+                        }
+                        catch (BinaryLogEventFilterException ex)
+                        {
+                            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                            throw;
+                        }
+                        catch (Exception ex)
+                        {
+                            OnException?.Invoke(ex);
+                        }
 
-                    recordsRead++;
-                    if (instance == null)
-                    {
-                        queue.CompleteAdding();
-                        break;
-                    }
+                        recordsRead++;
+                        if (instance == null)
+                        {
+                            break;
+                        }
 
-                    queue.Add(instance);
+                        queue.Add(instance);
 
-                    // only check the stopwatch every 1000 records, otherwise Stopwatch is showing up in profiles
-                    if (progress != null && (recordsRead % 1000) == 0 && stopwatch.ElapsedMilliseconds > 200)
-                    {
-                        stopwatch.Restart();
-                        var streamPosition = stream.Position;
-                        double ratio = (double)streamPosition / streamLength;
-                        progress.Report(new ProgressUpdate { Ratio = ratio, BufferLength = queue.Count });
+                        // only check the stopwatch every 1000 records, otherwise Stopwatch is showing up in profiles
+                        if (progress != null && (recordsRead % 1000) == 0 && stopwatch.ElapsedMilliseconds > 200)
+                        {
+                            stopwatch.Restart();
+                            var streamPosition = stream.Position;
+                            double ratio = (double)streamPosition / streamLength;
+                            progress.Report(new ProgressUpdate { Ratio = ratio, BufferLength = queue.Count });
+                        }
                     }
                 }
-
-                queue.Completion.Wait();
+                finally
+                {
+                    queue.CompleteAdding();
+                    queue.Completion.Wait();
+                }
 
                 if (reader.FileFormatVersion >= 10)
                 {

--- a/src/StructuredLogger/BinaryLogger/BinaryLogEventFilter.cs
+++ b/src/StructuredLogger/BinaryLogger/BinaryLogEventFilter.cs
@@ -1,0 +1,59 @@
+using System;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.Build.Logging.StructuredLogger
+{
+    /// <summary>
+    /// Metadata available before a length-framed binary log event is fully deserialized.
+    /// </summary>
+    public readonly struct BinaryLogEventMetadata
+    {
+        public BinaryLogEventMetadata(
+            BinaryLogRecordKind recordKind,
+            BuildEventContext buildEventContext,
+            BuildEventContext originalBuildEventContext = null)
+        {
+            RecordKind = recordKind;
+            BuildEventContext = buildEventContext;
+            OriginalBuildEventContext = originalBuildEventContext;
+        }
+
+        /// <summary>
+        /// The serialized event type.
+        /// </summary>
+        public BinaryLogRecordKind RecordKind { get; }
+
+        /// <summary>
+        /// The event's build context, or <see langword="null"/> when the event has no context.
+        /// </summary>
+        public BuildEventContext BuildEventContext { get; }
+
+        /// <summary>
+        /// The original context carried by a target-skipped event, or <see langword="null"/>.
+        /// </summary>
+        public BuildEventContext OriginalBuildEventContext { get; }
+    }
+
+    /// <summary>
+    /// Decides whether a binary log event should be deserialized and dispatched.
+    /// </summary>
+    /// <remarks>
+    /// Returning <see langword="false"/> skips the event. For length-framed binlogs, the
+    /// type-specific payload can be skipped without deserializing it. Auxiliary string,
+    /// name/value-list, and embedded-content records are still read so retained events can be
+    /// decoded correctly.
+    ///
+    /// The filter is responsible for retaining a structurally consistent set of events. For
+    /// example, retaining a finish event while dropping its corresponding start event can produce
+    /// a log that downstream consumers cannot interpret correctly.
+    /// </remarks>
+    public delegate bool BinaryLogEventFilter(BinaryLogEventMetadata metadata);
+
+    internal sealed class BinaryLogEventFilterException : Exception
+    {
+        public BinaryLogEventFilterException(Exception innerException)
+            : base("The binary log event filter threw an exception.", innerException)
+        {
+        }
+    }
+}

--- a/src/StructuredLogger/BinaryLogger/BinaryLogEventFilter.cs
+++ b/src/StructuredLogger/BinaryLogger/BinaryLogEventFilter.cs
@@ -49,7 +49,15 @@ namespace Microsoft.Build.Logging.StructuredLogger
     /// </remarks>
     public delegate bool BinaryLogEventFilter(BinaryLogEventMetadata metadata);
 
-    internal sealed class BinaryLogEventFilterException : Exception
+    /// <summary>
+    /// Wraps an exception thrown by a <see cref="BinaryLogEventFilter"/> callback.
+    /// </summary>
+    /// <remarks>
+    /// The wrapper distinguishes caller bugs in the filter from errors encountered while reading the
+    /// log, so filter failures abort the replay instead of being reported as recoverable read errors.
+    /// The exception thrown by the filter is available as <see cref="Exception.InnerException"/>.
+    /// </remarks>
+    public sealed class BinaryLogEventFilterException : Exception
     {
         public BinaryLogEventFilterException(Exception innerException)
             : base("The binary log event filter threw an exception.", innerException)

--- a/src/StructuredLogger/BinaryLogger/BuildEventArgsReader.Viewer.cs
+++ b/src/StructuredLogger/BinaryLogger/BuildEventArgsReader.Viewer.cs
@@ -101,14 +101,17 @@ namespace Microsoft.Build.Logging.StructuredLogger
         private bool sawCulture;
 
         private void OnMessageRead(BuildMessageEventArgs args)
+            => ProcessCultureMessage(args.SenderName, args.Message);
+
+        private bool ProcessCultureMessage(string senderName, string message)
         {
             if (sawCulture)
             {
-                return;
+                return false;
             }
 
-            if (args.SenderName == "BinaryLogger" &&
-                args.Message is string message &&
+            if (senderName == "BinaryLogger" &&
+                message is string &&
                 message.StartsWith("CurrentUICulture", StringComparison.Ordinal))
             {
                 sawCulture = true;
@@ -118,7 +121,11 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 {
                     Strings.Initialize(culture);
                 }
+
+                return true;
             }
+
+            return false;
         }
 
         private string GetTargetStartedMessage(string projectFile, string targetFile, string parentTarget, string targetName)

--- a/src/StructuredLogger/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/StructuredLogger/BinaryLogger/BuildEventArgsReader.cs
@@ -281,12 +281,25 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 bool filteredOut = false;
                 try
                 {
-                    bool filterAfterDeserialization =
-                        eventFilter != null &&
-                        (_fileFormatVersion < BinaryLogger.ForwardCompatibilityMinimalVersion ||
-                         recordKind == BinaryLogRecordKind.TargetSkipped);
+                    // Events that cannot be judged from the common fields alone (legacy binlogs that
+                    // are not length-framed, and TargetSkipped whose original context lives in the
+                    // type-specific payload) have to be deserialized before the filter can run.
+                    BinaryLogEventFilter? filterBeforeDeserialization = null;
+                    BinaryLogEventFilter? filterAfterDeserialization = null;
+                    if (eventFilter != null)
+                    {
+                        if (_fileFormatVersion < BinaryLogger.ForwardCompatibilityMinimalVersion ||
+                            recordKind == BinaryLogRecordKind.TargetSkipped)
+                        {
+                            filterAfterDeserialization = eventFilter;
+                        }
+                        else
+                        {
+                            filterBeforeDeserialization = eventFilter;
+                        }
+                    }
 
-                    if (eventFilter != null && !filterAfterDeserialization)
+                    if (filterBeforeDeserialization != null)
                     {
                         var commonFields = ReadBuildEventArgsFields();
                         var metadata = new BinaryLogEventMetadata(
@@ -296,7 +309,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
                             recordKind == BinaryLogRecordKind.Message &&
                             ProcessCultureMessage(commonFields.SenderName, commonFields.Message);
 
-                        if (!isRequiredPreamble && !ApplyEventFilter(eventFilter, metadata))
+                        if (!isRequiredPreamble && !ApplyEventFilter(filterBeforeDeserialization, metadata))
                         {
                             SkipBytes(_readStream.BytesCountAllowedToReadRemaining);
                             filteredOut = true;
@@ -319,7 +332,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
                             _commonFieldsPrefetched = false;
                         }
 
-                        if (result != null && filterAfterDeserialization)
+                        if (result != null && filterAfterDeserialization != null)
                         {
                             var metadata = new BinaryLogEventMetadata(
                                 recordKind,
@@ -328,7 +341,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
                             bool isRequiredPreamble =
                                 !sawCultureBeforeDeserialization && sawCulture;
 
-                            if (!isRequiredPreamble && !ApplyEventFilter(eventFilter!, metadata))
+                            if (!isRequiredPreamble && !ApplyEventFilter(filterAfterDeserialization, metadata))
                             {
                                 result = null;
                                 filteredOut = true;
@@ -462,16 +475,19 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
         private void SkipBytes(int count)
         {
-            var buffer = _skipBuffer ??= new byte[8192];
-            while (count > 0)
+            if (count <= 0)
             {
-                int read = _binaryReader.Read(buffer, 0, Math.Min(count, buffer.Length));
-                if (read == 0)
-                {
-                    throw new EndOfStreamException();
-                }
+                return;
+            }
 
-                count -= read;
+            // Note: Stream.Seek() on the underlying TransparentReadStream funnels into
+            // StreamExtensions.SkipBytes(throwOnEndOfStream: true), which reports a truncated stream
+            // as InvalidDataException. Read() cannot tell that apart from a corrupt record, so a
+            // truncated log would surface as a hard read error instead of being recovered. Detect the
+            // short read here and report it as EndOfStreamException instead.
+            if (_readStream.SkipBytes(count, throwOnEndOfStream: false, _skipBuffer ??= new byte[8192]) != count)
+            {
+                throw new EndOfStreamException();
             }
         }
 

--- a/src/StructuredLogger/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/StructuredLogger/BinaryLogger/BuildEventArgsReader.cs
@@ -309,6 +309,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
                     if (!filteredOut)
                     {
+                        bool sawCultureBeforeDeserialization = sawCulture;
                         try
                         {
                             result = ReadBuildEventArgs(recordKind);
@@ -324,8 +325,10 @@ namespace Microsoft.Build.Logging.StructuredLogger
                                 recordKind,
                                 result.BuildEventContext,
                                 (result as TargetSkippedEventArgs)?.OriginalBuildEventContext);
+                            bool isRequiredPreamble =
+                                !sawCultureBeforeDeserialization && sawCulture;
 
-                            if (!ApplyEventFilter(eventFilter!, metadata))
+                            if (!isRequiredPreamble && !ApplyEventFilter(eventFilter!, metadata))
                             {
                                 result = null;
                                 filteredOut = true;

--- a/src/StructuredLogger/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/StructuredLogger/BinaryLogger/BuildEventArgsReader.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
         private long _recordNumber = 0;
         private bool _skipUnknownEvents;
         private bool _skipUnknownEventParts;
+        private byte[] _skipBuffer;
 
         /// <summary>
         /// A list of string records we've encountered so far. If it's a small string, it will be the string directly.
@@ -240,7 +241,9 @@ namespace Microsoft.Build.Logging.StructuredLogger
         /// The next <see cref="BuildEventArgs"/>.
         /// If there are no more records, returns <see langword="null"/>.
         /// </returns>
-        public BuildEventArgs? Read()
+        public BuildEventArgs? Read() => Read(eventFilter: null);
+
+        internal BuildEventArgs? Read(BinaryLogEventFilter? eventFilter)
         {
             CheckErrorsSubscribed();
             BuildEventArgs? result = null;
@@ -275,9 +278,60 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 }
 
                 bool hasError = false;
+                bool filteredOut = false;
                 try
                 {
-                    result = ReadBuildEventArgs(recordKind);
+                    bool filterAfterDeserialization =
+                        eventFilter != null &&
+                        (_fileFormatVersion < BinaryLogger.ForwardCompatibilityMinimalVersion ||
+                         recordKind == BinaryLogRecordKind.TargetSkipped);
+
+                    if (eventFilter != null && !filterAfterDeserialization)
+                    {
+                        var commonFields = ReadBuildEventArgsFields();
+                        var metadata = new BinaryLogEventMetadata(
+                            recordKind,
+                            commonFields.BuildEventContext);
+                        bool isRequiredPreamble =
+                            recordKind == BinaryLogRecordKind.Message &&
+                            ProcessCultureMessage(commonFields.SenderName, commonFields.Message);
+
+                        if (!isRequiredPreamble && !ApplyEventFilter(eventFilter, metadata))
+                        {
+                            SkipBytes(_readStream.BytesCountAllowedToReadRemaining);
+                            filteredOut = true;
+                        }
+                        else
+                        {
+                            _commonFieldsPrefetched = true;
+                        }
+                    }
+
+                    if (!filteredOut)
+                    {
+                        try
+                        {
+                            result = ReadBuildEventArgs(recordKind);
+                        }
+                        finally
+                        {
+                            _commonFieldsPrefetched = false;
+                        }
+
+                        if (result != null && filterAfterDeserialization)
+                        {
+                            var metadata = new BinaryLogEventMetadata(
+                                recordKind,
+                                result.BuildEventContext,
+                                (result as TargetSkippedEventArgs)?.OriginalBuildEventContext);
+
+                            if (!ApplyEventFilter(eventFilter!, metadata))
+                            {
+                                result = null;
+                                filteredOut = true;
+                            }
+                        }
+                    }
                 }
                 catch (Exception e) when (
                     // We throw this on mismatches in metadata (name-value list, strings index).
@@ -307,7 +361,7 @@ namespace Microsoft.Build.Logging.StructuredLogger
                     return null;
                 }
 
-                if (result == null && !hasError)
+                if (result == null && !hasError && !filteredOut)
                 {
                     int localSerializedEventLength = serializedEventLength;
                     BinaryLogRecordKind localRecordKind = recordKind;
@@ -346,6 +400,20 @@ namespace Microsoft.Build.Logging.StructuredLogger
                 {
                     throw new InvalidDataException(msgFactory(), innerException);
                 }
+            }
+        }
+
+        private static bool ApplyEventFilter(
+            BinaryLogEventFilter eventFilter,
+            BinaryLogEventMetadata metadata)
+        {
+            try
+            {
+                return eventFilter(metadata);
+            }
+            catch (Exception ex)
+            {
+                throw new BinaryLogEventFilterException(ex);
             }
         }
 
@@ -391,7 +459,17 @@ namespace Microsoft.Build.Logging.StructuredLogger
 
         private void SkipBytes(int count)
         {
-            _binaryReader.BaseStream.Seek(count, SeekOrigin.Current);
+            var buffer = _skipBuffer ??= new byte[8192];
+            while (count > 0)
+            {
+                int read = _binaryReader.Read(buffer, 0, Math.Min(count, buffer.Length));
+                if (read == 0)
+                {
+                    throw new EndOfStreamException();
+                }
+
+                count -= read;
+            }
         }
 
         private BinaryLogRecordKind PreprocessRecordsTillNextEvent(Func<BinaryLogRecordKind, bool> isPreprocessRecord)
@@ -1611,9 +1689,16 @@ namespace Microsoft.Build.Logging.StructuredLogger
         }
 
         private readonly BuildEventArgsFields fields = new BuildEventArgsFields();
+        private bool _commonFieldsPrefetched;
 
         private BuildEventArgsFields ReadBuildEventArgsFields(bool readImportance = false)
         {
+            if (_commonFieldsPrefetched)
+            {
+                _commonFieldsPrefetched = false;
+                return fields;
+            }
+
             BuildEventArgsFieldFlags flags = (BuildEventArgsFieldFlags)ReadInt32();
             var result = fields;
             result.Flags = flags;


### PR DESCRIPTION
## Summary

- add an opt-in `BinLogReader.EventFilter` callback with record kind and build event context metadata
- skip rejected event-specific payloads in version 18+ length-framed binlogs while continuing to process auxiliary records
- preserve required culture initialization for modern and legacy binlogs, and fall back to full deserialization for older formats and `TargetSkipped` records
- propagate filter callback exceptions while always completing the threaded replay worker
- cover compact reserialization, metadata, truncation, culture preambles, worker cleanup, and exception behavior with tests

## Motivation

Consumers that need only a subset of a large binary log currently deserialize every event. This API lets them reject records after reading lightweight common metadata, then connect accepted replay events to `BinaryLogger` to produce a compact, standalone filtered binlog.

## Validation

- 6 filtered-replay tests pass
- 98 remaining tests pass when excluding three environment-dependent baseline failures reproduced on unmodified `main`